### PR TITLE
[134] Keyword will search by subject name too

### DIFF
--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -21,6 +21,10 @@ class Vacancy < ApplicationRecord
       indexes :address, type: :string
     end
 
+    indexes :subject do
+      indexes :name, type: :string
+    end
+
     indexes :expires_on, type: :date
     indexes :starts_on, type: :date
     indexes :updated_at, type: :date
@@ -73,7 +77,12 @@ class Vacancy < ApplicationRecord
   end
 
   def as_indexed_json(_ = {})
-    as_json(include: { school: { only: %i[phase postcode name town county address] } })
+    as_json(
+      include: {
+        school: { only: %i[phase postcode name town county address] },
+        subject: { only: %i[name] }
+      }
+    )
   end
 
   private

--- a/app/services/vacancy_search_builder.rb
+++ b/app/services/vacancy_search_builder.rb
@@ -153,7 +153,7 @@ class VacancySearchBuilder
     {
       multi_match: {
         query: keyword,
-        fields: %w[job_title^5 headline^2 job_description],
+        fields: %w[job_title^5 subject.name^3 headline^2 job_description],
         operator: 'and',
         fuzziness: 1,
       },

--- a/spec/features/users_can_search_vacancies_spec.rb
+++ b/spec/features/users_can_search_vacancies_spec.rb
@@ -51,4 +51,21 @@ RSpec.feature 'Searching vacancies by keyword' do
 
     expect(page.find('.vacancy:eq(1)')).to have_content(vacancy.job_title)
   end
+
+  scenario 'searching for the subject', elasticsearch: true do
+    vacancy = create(:vacancy, job_title: 'Teacher Foo', subject: create(:subject, name: 'English'))
+
+    Vacancy.__elasticsearch__.client.indices.flush
+
+    visit vacancies_path
+
+    expect(page.find('.vacancy:eq(1)')).to have_content(vacancy.job_title)
+
+    within '.filters-form' do
+      fill_in 'keyword', with: 'English'
+      page.find('.button[type=submit]').click
+    end
+
+    expect(page.find('.vacancy:eq(1)')).to have_content(vacancy.job_title)
+  end
 end

--- a/spec/services/vacancy_search_builder_spec.rb
+++ b/spec/services/vacancy_search_builder_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe VacancySearchBuilder do
       expected_hash = {
         multi_match: {
           query: 'german',
-          fields: %w[job_title^5 headline^2 job_description],
+          fields: %w[job_title^5 subject.name^3 headline^2 job_description],
           operator: 'and',
           fuzziness: 1
         },


### PR DESCRIPTION
* Weighted this as more important than content from the headline as we aren’t sure what content will be included there but can trust that subject will always be useful if not included in the initial job title.