### PR TITLE
(refactor): Test server rebuilds with one less image

### DIFF
--- a/bin/dclean-slate
+++ b/bin/dclean-slate
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Sometimes you need to remove all state including in persistent database volumes and all connected images.
+# This process takes much more time to rebuild from but aims to guarantee a fresh state.
+
+echo "Removing all traces of the test server…"
+docker-compose --file=docker-compose.test.yml down --rmi=all -v --remove-orphans
+
+echo "Removing all traces of the web server…"
+docker-compose down -v --rmi=all --remove-orphans

--- a/bin/drebuild
+++ b/bin/drebuild
@@ -11,5 +11,6 @@ echo "Rebuilt and started the testing server for TVS."
 echo "Rebuiling the web server…"
 docker-compose down -v --rmi=all --remove-orphans
 docker-compose build
+docker-compose run --rm web rake db:seed
 echo "Rebuilt and starting the web server for TVS."
 bin/dstart

--- a/bin/drebuild
+++ b/bin/drebuild
@@ -1,15 +1,13 @@
 #!/bin/sh
 
-# Test server
 echo "Rebuiling the test server…"
-docker-compose --file=docker-compose.test.yml down --rmi=all -v --remove-orphans
+docker-compose --file=docker-compose.test.yml down -v --remove-orphans
 docker-compose --file=docker-compose.test.yml build
 bin/dtest-server
 echo "Rebuilt and started the testing server for TVS."
 
-# Web server
 echo "Rebuiling the web server…"
-docker-compose down -v --rmi=all --remove-orphans
+docker-compose down --remove-orphans
 docker-compose build
 docker-compose run --rm web rake db:seed
 echo "Rebuilt and starting the web server for TVS."

--- a/bin/dspec
+++ b/bin/dspec
@@ -4,8 +4,8 @@ set -e
 if [ $# -eq 0 ]
 then
   echo "No arguments supplied. Defaults to 'rake default'"
-  docker exec teachervacancyservicestatic_spring_1 rake default $@
+  docker exec teachervacancyservice_test_1 rake default $@
 else
   echo "Testing: $@"
-  docker exec teachervacancyservicestatic_spring_1 rspec $@
+  docker exec teachervacancyservice_test_1 rspec $@
 fi

--- a/bin/dteaspoon
+++ b/bin/dteaspoon
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
 
-docker-compose exec spring rake teaspoon $@
+docker-compose exec test rake teaspoon $@

--- a/bin/dtest-server
+++ b/bin/dtest-server
@@ -3,25 +3,25 @@ set -e
 
 start_test_server()
 {
-  docker-compose --project-name 'teachervacancyservice_static' --file docker-compose.test.yml up -d db-test
-  docker-compose --project-name 'teachervacancyservice_static' --file docker-compose.test.yml up -d elasticsearch-test
-  docker-compose --project-name 'teachervacancyservice_static' --file docker-compose.test.yml up -d spring
+  docker-compose --file docker-compose.test.yml up -d db-test
+  docker-compose --file docker-compose.test.yml up -d elasticsearch-test
+  docker-compose --file docker-compose.test.yml up -d test
 }
 
 
 if [[ $# -eq 0 ]]
 then
-  docker-compose --project-name 'teachervacancyservice_static' --file docker-compose.test.yml down
+  docker-compose --file docker-compose.test.yml down
   start_test_server
 fi
 
 if [[ $1 == "up" ]]
 then
-  docker-compose --project-name 'teachervacancyservice_static' --file docker-compose.test.yml down
+  docker-compose --file docker-compose.test.yml down
   start_test_server
 fi
 
 if [[ $1 == "down" ]]
 then
-  docker-compose --project-name 'teachervacancyservice_static' --file docker-compose.test.yml down
+  docker-compose --file docker-compose.test.yml down
 fi

--- a/bin/dtests
+++ b/bin/dtests
@@ -4,5 +4,5 @@ set -e
 docker-compose --file docker-compose.test.yml build
 docker-compose --file docker-compose.test.yml up -d db-test
 docker-compose --file docker-compose.test.yml up -d elasticsearch-test
-docker-compose --file docker-compose.test.yml run test
+docker-compose --file docker-compose.test.yml run test rake
 docker-compose --file docker-compose.test.yml down

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -16,7 +16,7 @@ services:
     depends_on:
       - db-test
       - elasticsearch-test
-    command: ["bundle", "exec", "./bin/dsetup && rake"]
+    command: ["bundle", "exec", "./bin/dsetup && spring server"]
     networks:
       - tests
 
@@ -43,10 +43,6 @@ services:
       #- ./config/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml
     networks:
       - tests
-
-  spring:
-    <<: *test
-    command: ["bundle", "exec", "./bin/dsetup && spring server"]
 
 networks:
   tests:


### PR DESCRIPTION
* Having Spring as a separate docker-compose service was creating a third docker image at rebuild time. One for web, test and spring. Given Web and Spring are the main things we want to run we can cut our build time by a third by instead calling the test service with a non-spring command as and when we need it, which is just bin/dtests I believe.
* I was finding repeated issues in dev with a spring image not being reliably cleaned up on bin/drebuild. This caused gems still not to be present after a lengthy rebuild.