### PR TITLE
(fix) restructure school search form

### DIFF
--- a/app/views/schools/_search_form.html.haml
+++ b/app/views/schools/_search_form.html.haml
@@ -1,6 +1,6 @@
 = form_tag search_schools_path, method: :get do
 
-  %div
-    = label_tag :name, t('schools.search_label')
+  .form-group
+    = label_tag :name, t('schools.search_label'), class: 'form-label'
     = search_field_tag :name, name, class: 'form-control'
-    = button_tag t('buttons.find'), class: 'button', type: 'submit'
+  = button_tag t('buttons.find'), class: 'button', type: 'submit'


### PR DESCRIPTION
https://trello.com/c/5TUhSJdN/19-schools-search-form-elements-need-to-be-realigned

Before: 
<img width="758" alt="screen_shot_2018-02-22_at_14 30 04" src="https://user-images.githubusercontent.com/822507/37397430-7a796842-2773-11e8-831c-44a46a176f6f.png">

After: 
<img width="608" alt="screen shot 2018-03-14 at 10 32 26" src="https://user-images.githubusercontent.com/822507/37397459-90aea0e6-2773-11e8-830f-bd9d71593ee3.png">

