### PR TITLE
(fix) makes published highlight box full width

### DIFF
--- a/app/views/vacancies/published.html.haml
+++ b/app/views/vacancies/published.html.haml
@@ -1,5 +1,5 @@
 .vacancy.grid-row
-  .column-two-thirds
+  .column-full
     .govuk-box-highlight.margin-bottom-large
       %h1.heading-large.margin-top
         = t('vacancies.submitted')
@@ -8,6 +8,7 @@
         %br
         %strong.heading-medium=@vacancy.reference
 
+  .column-two-thirds
     - if @vacancy.publish_today?
       %p
         = t('vacancies.view_posted_vacancy')


### PR DESCRIPTION
https://trello.com/c/3zub6dzS/24-vacancy-published-confirmation-page

Before:
<img width="986" alt="screen_shot_2018-02-22_at_15 01 20" src="https://user-images.githubusercontent.com/822507/37399056-666f3778-2778-11e8-8210-734f015c1287.png">

After: 
<img width="1009" alt="screen shot 2018-03-14 at 11 07 09" src="https://user-images.githubusercontent.com/822507/37399061-6f3f0892-2778-11e8-9583-53950e7f82e2.png">
