### PR TITLE
(fix) correct heading hierarchy for vacancy#show

### DIFF
--- a/app/views/vacancies/show.html.haml
+++ b/app/views/vacancies/show.html.haml
@@ -17,30 +17,30 @@
     %p.lede
       = @vacancy.headline
 
-    %h3.heading-medium= t('vacancies.description')
+    %h2.heading-medium= t('vacancies.description')
     %p= @vacancy.job_description
 
-    %h3.heading-medium= t('vacancies.requirements')
+    %h2.heading-medium= t('vacancies.requirements')
     %p= @vacancy.essential_requirements
 
     - if @vacancy.education
-      %h3.heading-medium= t('vacancies.education')
+      %h2.heading-medium= t('vacancies.education')
       %p= @vacancy.education
 
     - if @vacancy.qualifications
-      %h3.heading-medium= t('vacancies.qualifications')
+      %h2.heading-medium= t('vacancies.qualifications')
       %p= @vacancy.qualifications
 
     - if @vacancy.experience
-      %h3.heading-medium= t('vacancies.experience')
+      %h2.heading-medium= t('vacancies.experience')
       %p= @vacancy.experience
 
     - if @vacancy.benefits
-      %h3.heading-medium= t('vacancies.benefits')
+      %h2.heading-medium= t('vacancies.benefits')
       %p= @vacancy.benefits
 
     %hr
-    %h3.heading-medium
+    %h2.heading-medium
       = t('schools.about')
       = @vacancy.school.name
 


### PR DESCRIPTION
https://trello.com/c/HDDtqV3n/25-vacancies-show-page

Before: 
<img width="1192" alt="screen_shot_2018-02-22_at_15 07 38" src="https://user-images.githubusercontent.com/822507/37399493-b729eba8-2779-11e8-91e1-73ef34c54239.png">

After: 
<img width="1237" alt="screen shot 2018-03-14 at 11 17 06" src="https://user-images.githubusercontent.com/822507/37399502-bc7edece-2779-11e8-9b3b-1eeb3693bc8c.png">

