### PR TITLE
(Fix) Scaling down policy requires upper bound

### DIFF
--- a/terraform/modules/core/core.tf
+++ b/terraform/modules/core/core.tf
@@ -361,7 +361,7 @@ resource "aws_appautoscaling_policy" "down" {
     metric_aggregation_type = "Maximum"
 
     step_adjustment {
-      metric_interval_lower_bound = 0
+      metric_interval_upper_bound = 0
       scaling_adjustment = -1
     }
   }


### PR DESCRIPTION
* This error was observed in the CloudWatch Alarm history: "error": "No step adjustment found for metric value [0.14282611394791225, 0.14367561052112202] and breach threshold 85.0"
* The metric value is calculated as such: 'CloudWatch metric' - 'Alarm threshold'. Our threshold is 85, so when the CloudWatch metric goes below 85, the metric value goes below 0. Setting the down policy to have an upper_bound of 0 sets the step adjustement to trigger when the CloudWatch metric goes below 85.