### PR TITLE
[104] Hide Vacancy reference from job seekers

### DIFF
--- a/app/views/vacancies/show.html.haml
+++ b/app/views/vacancies/show.html.haml
@@ -5,7 +5,7 @@
 .vacancy.grid-row
   - if @vacancy.expired?
     .column-full
-      .banner-warning 
+      .banner-warning
         = t('vacancies.expired')
 
   .column-two-thirds
@@ -93,9 +93,6 @@
         - if @vacancy.part_time?
           %dt= t('vacancies.weekly_hours')
           %dd= @vacancy.weekly_hours
-
-        %dt= t('vacancies.ref_no')
-        %dd= @vacancy.reference
 
         %dt= t('vacancies.expires_on')
         %dd= format_date(@vacancy.expires_on)

--- a/spec/features/users_can_view_a_vacancy_spec.rb
+++ b/spec/features/users_can_view_a_vacancy_spec.rb
@@ -9,7 +9,6 @@ RSpec.feature 'Viewing a single published vacancy' do
     expect(page).to have_content(published_vacancy.headline)
     expect(page).to have_content(published_vacancy.job_description)
     expect(page).to have_content(published_vacancy.salary_range)
-    expect(page).to have_content(published_vacancy.reference)
   end
 
   scenario 'Unpublished vacancies are not viewable' do


### PR DESCRIPTION
* As a raw UUID value that cannot be used to search, displaying this
number serves no user need we know about at the moment.