### PR TITLE
[151] Remove html tags from scraped content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@
 # Ignore application configuration
 /config/application.yml
 
+/spec/fixtures/temp_schools_data.csv
+
 # Docker
 docker-compose.env
 

--- a/lib/vacancy_scraper/north_east_schools/scraper.rb
+++ b/lib/vacancy_scraper/north_east_schools/scraper.rb
@@ -25,7 +25,7 @@ module VacancyScraper::NorthEastSchools
       vacancy.headline = job_title
       vacancy.subject = Subject.find_by(name: subject)
       vacancy.school = school
-      vacancy.job_description = Nokogiri::HTML(body.to_html).text
+      vacancy.job_description = job_description
       vacancy.working_pattern = working_pattern
       vacancy.weekly_hours = work_hours
       vacancy.minimum_salary = min_salary
@@ -50,6 +50,10 @@ module VacancyScraper::NorthEastSchools
 
     def job_title
       vacancy.css('.page-title').text
+    end
+
+    def job_description
+      Nokogiri::HTML(body.to_html).text
     end
 
     def subject

--- a/spec/lib/vacancy_scraper_spec.rb
+++ b/spec/lib/vacancy_scraper_spec.rb
@@ -59,6 +59,15 @@ RSpec.describe VacancyScraper::NorthEastSchools do
           expect(scraper.job_title).to eq('Teacher of Psychology')
         end
 
+        it '#job_description' do
+          expect(scraper.job_description).to include(
+            'Kings Priory School'
+          )
+          expect(scraper.job_description).not_to include(
+            '<p>Kings Priory School'
+          )
+        end
+
         it '#url' do
           expect(scraper.url).to eq('http://www.kingsprioryschool.co.uk')
         end
@@ -116,6 +125,15 @@ RSpec.describe VacancyScraper::NorthEastSchools do
           expect(scraper.job_title).to eq('Assistant Curriculum Leader: Mathematics')
         end
 
+        it '#job_description' do
+          expect(scraper.job_description).to include(
+            'ASSISTANT CURRICULUM LEADER: MATHEMATICS PermanentTMPS/UPS + TLR2B (£4,443)'
+          )
+          expect(scraper.job_description).not_to include(
+            '<p><strong>ASSISTANT CURRICULUM LEADER: MATHEMATICS </strong></p>'
+          )
+        end
+
         it '#subject' do
           expect(scraper.subject).to eq('Math')
         end
@@ -170,6 +188,15 @@ RSpec.describe VacancyScraper::NorthEastSchools do
           expect(scraper.job_title).to eq('Permanent Main Scale Teacher')
         end
 
+        it '#job_description' do
+          expect(scraper.job_description).to include(
+            'Permanent Main Scale Teacher plus TLR2B (KS2 and maths)'
+          )
+          expect(scraper.job_description).not_to include(
+            '<p><strong>Permanent Main Scale Teacher plus TLR2B (KS2 and maths)</strong></p>'
+          )
+        end
+
         it '#subject' do
           expect(scraper.subject).to eq(nil)
         end
@@ -222,6 +249,15 @@ RSpec.describe VacancyScraper::NorthEastSchools do
 
         it '#job_title' do
           expect(scraper.job_title).to eq('Teacher of English')
+        end
+
+        it '#job_description' do
+          expect(scraper.job_description).to include(
+            'NQT /Main/Upper Pay Ranges: £22,917 – £38,633 per annum'
+          )
+          expect(scraper.job_description).not_to include(
+            '<p>NQT /Main/Upper Pay Ranges: £22,917 – £38,633 per annum</p>'
+          )
         end
 
         it '#subject' do


### PR DESCRIPTION
* Based on https://github.com/dxw/teacher-vacancy-service/pull/59 for the test suite
* Nokogiri was doing a good job of removing tags from what I could see after running the scraper so I have just added some tests to support this behaviour