### PR TITLE
Fix/publishing error validation message

### DIFF
--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -110,6 +110,7 @@ class Vacancy < ApplicationRecord
   end
 
   def validity_of_publish_on
-    errors.add(:publish_on, /can''t be before today/) if publish_on && publish_on < Time.zone.today
+    error_message = I18n.t('activerecord.errors.models.vacancy.attributes.publish_on.before_today')
+    errors.add(:publish_on, error_message) if publish_on && publish_on < Time.zone.today
   end
 end

--- a/app/views/vacancies/job_specification.html.haml
+++ b/app/views/vacancies/job_specification.html.haml
@@ -35,9 +35,8 @@
                       collection: Subject.order(:name),
                       required: false
       %fieldset.form-group
-        %legend
-          %div Salary range
-          %span.form-hint= t('vacancies.form_hints.salary_range')
+        %label= t('vacancies.salary_range')
+        %span.form-hint= t('vacancies.form_hints.salary_range')
 
         = f.input :minimum_salary,
                   as: :integer,

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -14,3 +14,5 @@ en:
               blank: can't be blank
             working_pattern:
               blank: can't be blank
+            essential_requirements:
+              blank: can't be blank

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -16,3 +16,10 @@ en:
               blank: can't be blank
             essential_requirements:
               blank: can't be blank
+            contact_email:
+              blank: can't be blank
+            expires_on:
+              blank: can't be blank
+            publish_on:
+              blank: can't be blank
+              before_today: can't be before today

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -1,0 +1,16 @@
+en:
+  activerecord:
+    errors:
+      models:
+        vacancy:
+          attributes:
+            job_title:
+              blank: can't be blank
+            headline:
+              blank: can't be blank
+            job_description:
+              blank: can't be blank
+            minimum_salary:
+              blank: can't be blank
+            working_pattern:
+              blank: can't be blank

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,34 +1,3 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t 'hello'
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t('hello') %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# The following keys must be escaped otherwise they will not be retrieved by
-# the default I18n backend:
-#
-# true, false, on, off, yes, no
-#
-# Instead, surround them with single quotes.
-#
-# en:
-#   'true': 'foo'
-#
-# To learn more, please read the Rails Internationalization guide
-# available at http://guides.rubyonrails.org/i18n.html.
-
 en:
   number:
     currency:

--- a/spec/features/schools_can_publish_a_vacancy_spec.rb
+++ b/spec/features/schools_can_publish_a_vacancy_spec.rb
@@ -34,15 +34,39 @@ RSpec.feature 'Creating a vacancy' do
     expect(page).to have_content('Publish a vacancy for Salisbury School')
   end
 
-  scenario 'Users can see validation errors when they don\'t fill in all required fields' do
-    school = create(:school)
-    vacancy = build(:vacancy, job_title: '')
+  context 'Users can see validation errors when they don\'t fill in all required fields' do
+    scenario 'on the first page' do
+      school = create(:school)
 
-    visit new_vacancy_path(school_id: school.id)
-    fill_in_job_spec_fields(vacancy)
+      visit new_vacancy_path(school_id: school.id)
 
-    expect(page).to have_content('error')
-    expect(page).to have_content('Job title can\'t be blank')
+      # Don't fill in any information to force all errors to show
+      click_button 'Save and continue'
+
+      within('.error-summary') do
+        expect(page).to have_content('5 errors prevented this vacancy from being saved:')
+      end
+
+      within_row_for(text: I18n.t('vacancies.job_title')) do
+        expect(page).to have_content(I18n.t('activerecord.errors.models.vacancy.attributes.job_title.blank'))
+      end
+
+      within_row_for(text: I18n.t('vacancies.headline')) do
+        expect(page).to have_content(I18n.t('activerecord.errors.models.vacancy.attributes.headline.blank'))
+      end
+
+      within_row_for(text: I18n.t('vacancies.description')) do
+        expect(page).to have_content(I18n.t('activerecord.errors.models.vacancy.attributes.job_description.blank'))
+      end
+
+      within_row_for(text: I18n.t('vacancies.salary_range')) do
+        expect(page).to have_content(I18n.t('activerecord.errors.models.vacancy.attributes.minimum_salary.blank'))
+      end
+
+      within_row_for(text: I18n.t('vacancies.working_pattern')) do
+        expect(page).to have_content(I18n.t('activerecord.errors.models.vacancy.attributes.working_pattern.blank'))
+      end
+    end
   end
 
   context 'Reviewing a vacancy' do
@@ -99,5 +123,10 @@ RSpec.feature 'Creating a vacancy' do
       expect(page).to have_content("The system reference number is #{vacancy.reference}")
       expect(page).to have_content("The vacancy will be posted on #{vacancy.publish_on}, you can preview it here:")
     end
+  end
+
+  def within_row_for(text:, &block)
+    element = page.find('label', text: text).find(:xpath, '..')
+    within(element, &block)
   end
 end

--- a/spec/features/schools_can_publish_a_vacancy_spec.rb
+++ b/spec/features/schools_can_publish_a_vacancy_spec.rb
@@ -67,6 +67,33 @@ RSpec.feature 'Creating a vacancy' do
         expect(page).to have_content(I18n.t('activerecord.errors.models.vacancy.attributes.working_pattern.blank'))
       end
     end
+
+    scenario 'on the second page' do
+      school = create(:school)
+
+      visit new_vacancy_path(school_id: school.id)
+
+      fill_in 'vacancy[job_title]', with: 'title'
+      fill_in 'vacancy[headline]', with: 'headline'
+      fill_in 'vacancy[job_description]', with: 'description'
+      select 'Full time', from: 'vacancy[working_pattern]'
+      fill_in 'vacancy[minimum_salary]', with: 0
+      fill_in 'vacancy[maximum_salary]', with: 1
+      click_button 'Save and continue'
+
+      expect(page).to have_content('Step 2 of 3')
+
+      # Don't fill in any information to force all errors to show
+      click_button 'Save and continue'
+
+      within('.error-summary') do
+        expect(page).to have_content('1 error prevented this vacancy from being saved:')
+      end
+
+      within_row_for(text: I18n.t('vacancies.essential_requirements')) do
+        expect(page).to have_content(I18n.t('activerecord.errors.models.vacancy.attributes.working_pattern.blank'))
+      end
+    end
   end
 
   context 'Reviewing a vacancy' do


### PR DESCRIPTION
* the test coverage for the form errors was very very limited, testing only 1 field and only for presence. This PR firstly goes and adds in test coverage before adding a new one for our poorly formatted error message
* added error messages to localisation

Before:
![screen shot 2018-03-16 at 15 27 03](https://user-images.githubusercontent.com/912473/37536578-e5de186e-2942-11e8-99cd-cfcef24047c4.png)

After:
![screen shot 2018-03-16 at 15 35 50](https://user-images.githubusercontent.com/912473/37536575-e4399c54-2942-11e8-8e56-aa6ec19db0b9.png)

