### PR TITLE
[183] Search results display when paginated

### DIFF
--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -4,9 +4,10 @@ class VacanciesController < ApplicationController
     @sort = VacancySort.new(default_column: 'expires_on', default_order: 'asc')
                        .update(column: sort_column, order: sort_order)
     @query = Vacancy.public_search(filters: @filters, sort: @sort)
-    vacancies = @query.page(params[:page]).records
+    records = @query.records
 
-    @vacancies = VacanciesPresenter.new(vacancies)
+    @vacancy_count = records.count
+    @vacancies = VacanciesPresenter.new(records.page(params[:page]))
   end
 
   def show

--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -22,6 +22,14 @@ module VacanciesHelper
             class: "sortby--#{order}#{active_class || ''}"
   end
 
+  def pluralize_vacancy_count(count, i18n_id, plural_i18n_id = nil)
+    if count == 1
+      I18n.t(i18n_id, count: count)
+    else
+      I18n.t(plural_i18n_id || (i18n_id + '_plural'), count: count)
+    end
+  end
+
   private
 
   def vacancy_params_whitelist

--- a/app/presenters/vacancies_presenter.rb
+++ b/app/presenters/vacancies_presenter.rb
@@ -9,12 +9,4 @@ class VacanciesPresenter < BasePresenter
   def each(&block)
     decorated_collection.each(&block)
   end
-
-  def pluralize_vacancy_count(count, i18n_id, plural_i18n_id = nil)
-    if count == 1
-      I18n.t(i18n_id, count: count)
-    else
-      I18n.t(plural_i18n_id || (i18n_id + '_plural'), count: count)
-    end
-  end
 end

--- a/app/views/vacancies/index.html.haml
+++ b/app/views/vacancies/index.html.haml
@@ -1,5 +1,5 @@
 %h1.heading-large
-  = pluralize_vacancy_count(@vacancies.count, 'vacancies.vacancy_count')
+  = pluralize_vacancy_count(@vacancy_count, 'vacancies.vacancy_count')
 .grid-row
   .column-one-third
     = render 'filters'

--- a/app/views/vacancies/index.html.haml
+++ b/app/views/vacancies/index.html.haml
@@ -1,5 +1,5 @@
 %h1.heading-large
-  = @vacancies.pluralize_vacancy_count(@vacancies.count, 'vacancies.vacancy_count')
+  = pluralize_vacancy_count(@vacancies.count, 'vacancies.vacancy_count')
 .grid-row
   .column-one-third
     = render 'filters'

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -17,6 +17,7 @@ services:
       - db-test
       - elasticsearch-test
     command: ["bundle", "exec", "./bin/dsetup && spring server"]
+    restart: on-failure
     networks:
       - tests
 
@@ -26,6 +27,7 @@ services:
       - pg_test_data:/var/lib/postgresql/data/:cached
     networks:
       - tests
+    restart: on-failure
 
   elasticsearch-test:
     image: elasticsearch
@@ -43,6 +45,7 @@ services:
       #- ./config/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml
     networks:
       - tests
+    restart: on-failure
 
 networks:
   tests:

--- a/spec/features/users_can_view_vacancies_spec.rb
+++ b/spec/features/users_can_view_vacancies_spec.rb
@@ -1,5 +1,16 @@
 require 'rails_helper'
 RSpec.feature 'Viewing vacancies' do
+  scenario 'There are enough vacancies to invoke pagination', elasticsearch: true do
+    vacancy_count = Vacancy.default_per_page + 1 # must be larger than the default page limit
+    vacancy_count.times { FactoryGirl.create(:vacancy) }
+
+    Vacancy.__elasticsearch__.client.indices.flush
+    visit vacancies_path
+
+    expect(page).to have_content("There are #{vacancy_count} vacancies that match your search.")
+    expect(page).to have_selector('.vacancy', count: Vacancy.default_per_page)
+  end
+
   scenario 'Only published, non-expired vacancies are visible in the list', elasticsearch: true do
     valid_vacancy = create(:vacancy)
 

--- a/spec/helpers/vacancies_helper_spec.rb
+++ b/spec/helpers/vacancies_helper_spec.rb
@@ -51,4 +51,27 @@ RSpec.describe VacanciesHelper, type: :helper do
       end
     end
   end
+
+  describe '#pluralize_vacancy_count' do
+    context 'when the count is 1' do
+      it 'returns a singular count message' do
+        result = helper.pluralize_vacancy_count(1, 'vacancies.vacancy_count')
+        expect(result).to eql('There is 1 vacancy that matches your search.')
+      end
+    end
+
+    context 'when the count is 0' do
+      it 'returns an empty count message' do
+        result = helper.pluralize_vacancy_count(0, 'vacancies.vacancy_count')
+        expect(result).to eql('There are 0 vacancies that match your search.')
+      end
+    end
+
+    context 'when the count is larger than 1' do
+      it 'returns a plural count message' do
+        result = helper.pluralize_vacancy_count(2, 'vacancies.vacancy_count')
+        expect(result).to eql('There are 2 vacancies that match your search.')
+      end
+    end
+  end
 end


### PR DESCRIPTION
* Kaminari `total_count` returns the full list of records without filtering.
* Moved helper method and found it was missing tests so added them.
* I deleted vacancies at random to try and break the pagination, it held up okay.

Before:
![screen shot 2018-03-19 at 13 32 28](https://user-images.githubusercontent.com/912473/37598440-1d93a1c8-2b7a-11e8-91d0-4f076110a0c6.png)

After: 
![screen shot 2018-03-19 at 13 33 05](https://user-images.githubusercontent.com/912473/37598462-2b94a3da-2b7a-11e8-8a10-255f26630049.png)