### PR TITLE
(Fix) Change cloudwatch alerts topic to be unique

### DIFF
--- a/terraform/modules/cloudwatch/cloudwatch.tf
+++ b/terraform/modules/cloudwatch/cloudwatch.tf
@@ -1,5 +1,5 @@
 resource "aws_sns_topic" "cloudwatch_alerts" {
-  name = "cloudwatch-alerts"
+  name = "${var.project_name}-${var.environment}-cloudwatch-alerts"
 }
 
 resource "aws_kms_key" "cloudwatch_lambda" {


### PR DESCRIPTION
* Name is now "${var.project_name}-${var.environment}-cloudwatch-alerts"
instead of cloudwatch-alerts. This was causing duplicate alerts, as
all lambda functions were listening to the same sns topic.