### PR TITLE
(chore): Ignore any environment config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,4 @@ terraform.tfstate
 ./*.tfstate
 .terraform/
 .terraform.tfstate.lock.info
-workspace-variables/staging.tfvars
+workspace-variables/*.tfvars


### PR DESCRIPTION
* We've just added a new edge environment and needed a new set of variables so we need to make sure these are never committed.
* Making it flexible enough to allow for other new environments without having this problem again in future.