### PR TITLE
(fix) changes order of date fields

### DIFF
--- a/app/views/hiring_staff/vacancies/application_details.html.haml
+++ b/app/views/hiring_staff/vacancies/application_details.html.haml
@@ -17,9 +17,9 @@
                 required: true
 
       %div.form-group
-        = f.gov_uk_date_field :expires_on, legend_text: t('vacancies.deadline_date'), legend_class: 'form-label-bold', form_hint_text: t('vacancies.form_hints.deadline_date')
+        = f.gov_uk_date_field :publish_on, legend_text: t('vacancies.publication_date'), legend_class: 'form-label-bold', form_hint_text: t('vacancies.form_hints.publication_date')
 
       %div.form-group
-        = f.gov_uk_date_field :publish_on, legend_text: t('vacancies.publication_date'), legend_class: 'form-label-bold', form_hint_text: t('vacancies.form_hints.publication_date')
+        = f.gov_uk_date_field :expires_on, legend_text: t('vacancies.deadline_date'), legend_class: 'form-label-bold', form_hint_text: t('vacancies.form_hints.deadline_date')
 
       = f.button :submit, t('buttons.save_and_continue')


### PR DESCRIPTION
https://trello.com/c/Yvl9AUWk/199-change-the-order-of-the-date-fields-in-the-application-details-page

- change the order of the dates so that they are chronological e.g. vacancy listing date shown above application deadline date

before: 
<img width="929" alt="screen shot 2018-03-21 at 15 34 26" src="https://user-images.githubusercontent.com/822507/37719824-d87997b4-2d1d-11e8-8a9f-fa1014fd0222.png">

after: 
<img width="999" alt="screen shot 2018-03-21 at 15 35 25" src="https://user-images.githubusercontent.com/822507/37719831-dece0618-2d1d-11e8-8eb9-61936a417f68.png">
