### PR TITLE
(fix) remove text about previewing vacancy

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,10 +44,7 @@ en:
     deadline_date: 'Application deadline'
     publication_date: 'Date role will be listed'
     review: 'Review the vacancy details and make any necessary changes before submitting it for publication below.'
-    confirmation_summary:
-      >
-        You can preview your vacancy to see how it will look for potential applicants.
-        By submitting you are confirming that to the best of your knowledge, the details you are providing are correct.
+    confirmation_summary: 'By submitting you are confirming that to the best of your knowledge, the details you are providing are correct.'
     submit: 'Confirm and submit vacancy'
     submitted: 'Vacancy submitted'
     view_posted_vacancy: 'The vacancy has been posted, you can view it here:'


### PR DESCRIPTION
Remove "You can preview your vacancy to see how it will look for potential applicants." — not relevant until we build the [preview feature.](https://trello.com/c/6iWSgFJ0/185-in-situ-preview-of-job-posting)

before: 
![before](https://user-images.githubusercontent.com/822507/37723485-63ea6672-2d26-11e8-9cb1-d125582b463d.png)

after: 
![after](https://user-images.githubusercontent.com/822507/37723504-69c9fb52-2d26-11e8-90bf-b7382dec7f47.png)

