### PR TITLE
(feature) a school can delete a vacancy

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -21,6 +21,8 @@
 @import 'typography';
 @import 'shims';
 
+@import 'base/mixins';
+
 @import 'govuk_date_fields';
 
 @import 'design-patterns/alpha-beta';
@@ -53,6 +55,7 @@
 @import 'components/banners';
 @import 'components/school';
 @import 'components/sortable_links';
+@import 'components/flashes';
 
 main#content {
   @extend %site-width-container;

--- a/app/assets/stylesheets/base/_mixins.scss
+++ b/app/assets/stylesheets/base/_mixins.scss
@@ -1,0 +1,17 @@
+/// Slightly lighten a color
+/// @access public
+/// @param {Color} $color - color to tint
+/// @param {Number} $percentage - percentage of `$color` in returned color
+/// @return {Color}
+@function tint($color, $percentage) {
+  @return mix(white, $color, $percentage);
+}
+
+/// Slightly darken a color
+/// @access public
+/// @param {Color} $color - color to shade
+/// @param {Number} $percentage - percentage of `$color` in returned color
+/// @return {Color}
+@function shade($color, $percentage) {
+  @return mix(black, $color, $percentage);
+}

--- a/app/assets/stylesheets/components/flashes.scss
+++ b/app/assets/stylesheets/components/flashes.scss
@@ -1,0 +1,27 @@
+$notice: $light-blue;
+$success: $green;
+$error: $error-colour;
+$alert: $yellow;
+
+@mixin flash($name) {
+  background-color: tint($name, 80%);
+  color: shade($name, 50%);
+  border: 1px solid shade($name, 50%);
+}
+
+.flash {
+  margin-top: $gutter/2;
+  padding: 14px 15px 10px 15px;
+  &.notice {
+    @include flash($notice);
+  }
+  &.success {
+    @include flash($success);
+  }
+  &.error {
+    @include flash($error);
+  }
+  &.alert {
+    @include flash($alert);
+  }
+}

--- a/app/controllers/hiring_staff/vacancies_controller.rb
+++ b/app/controllers/hiring_staff/vacancies_controller.rb
@@ -1,4 +1,9 @@
 class HiringStaff::VacanciesController < HiringStaff::BaseController
+  def index
+    @school = find_school_from_params
+    @vacancies = @school.vacancies.all
+  end
+
   def show
     @school = find_school_from_params
     vacancy = find_vacancy_from_params
@@ -79,6 +84,14 @@ class HiringStaff::VacanciesController < HiringStaff::BaseController
     end
 
     @vacancy = VacancyPresenter.new(vacancy)
+  end
+
+  def destroy
+    @school = find_school_from_params
+    @vacancy = find_vacancy_from_params
+    @vacancy.destroy
+
+    redirect_to school_vacancies_path, notice: 'Your vacancy was deleted.'
   end
 
   private

--- a/app/views/hiring_staff/vacancies/_vacancy.html.haml
+++ b/app/views/hiring_staff/vacancies/_vacancy.html.haml
@@ -1,0 +1,7 @@
+%tr.vacancy[vacancy]
+  %td= link_to vacancy.job_title, school_vacancy_path(school.id, vacancy), class: 'view-vacancy-link'
+  %td= format_date(vacancy.publish_on)
+  %td= format_date(vacancy.expires_on)
+  %td= vacancy.status.titleize
+  %td= link_to 'Delete', school_vacancy_path(school.id, vacancy), method: :delete, data: { confirm: "Are you sure you want to delete the '#{vacancy.job_title}' vacancy?" }
+

--- a/app/views/hiring_staff/vacancies/index.html.haml
+++ b/app/views/hiring_staff/vacancies/index.html.haml
@@ -1,0 +1,13 @@
+%h1.heading-large
+  = t('schools.vacancies.index', school: @school.name)
+
+.grid-row
+  .column-full
+    %table.vacancies
+      %th= t('vacancies.job_title')
+      %th= t('vacancies.publish_on')
+      %th= t('vacancies.expires_on')
+      %th= t('vacancies.status')
+      %th= t('vacancies.actions')
+      - @vacancies.each do |vacancy|
+        = render partial: 'vacancy', locals: { vacancy: vacancy, school: @school }

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -30,6 +30,9 @@
         %span
           This is a new service - your feedback will help us to improve it.
 
+    - flash.each do |name, msg|
+      %div{class: "flash #{name}"}
+        %span= msg
     = yield
 
 = render file: 'layouts/govuk_template'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -50,6 +50,8 @@ en:
     view_posted_vacancy: 'The vacancy has been posted, you can view it here:'
     preview_posted_vacancy: 'The vacancy will be posted on %{date}, you can preview it here:'
     application_link: 'Apply for this job'
+    actions: 'Actions'
+    status: 'Status'
     form_hints:
       job_title: "For secondary school roles include subject to be taught and, if applicable, level of seniority ('Subject leader for Science', for example)."
       headline: 'Sum up the job in a single sentence, which will appear at the top of the listing.'
@@ -89,7 +91,10 @@ en:
     school_age: 'School age'
     search_heading: 'Publish a vacancy'
     search_subheading: 'Which school is the job vacancy for?'
+    vacancies:
+      index: 'Vacancies at %{school}'
   buttons:
     apply_filters: 'Apply filters'
     save_and_continue: 'Save and continue'
     find: 'Find'
+    delete: 'Delete'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
 
   resources :schools, only: %i[index show edit update], controller: 'hiring_staff/schools' do
     get 'search', on: :collection
-    resources :vacancies, only: %i[new create update edit delete show], controller: 'hiring_staff/vacancies' do
+    resources :vacancies, only: %i[index new create update edit destroy show], controller: 'hiring_staff/vacancies' do
       # Legacy form routing copied over
       get 'review', on: :member
       put 'publish', on: :member
@@ -20,5 +20,5 @@ Rails.application.routes.draw do
     end
   end
 
-  match '*path', to: 'application#not_found', via: %i[get post patch put delete]
+  match '*path', to: 'application#not_found', via: %i[get post patch put destroy]
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -118,3 +118,24 @@ FactoryGirl.create(:vacancy,
                    maximum_salary: 35000,
                    pay_scale: payscale,
                    leadership: leadership)
+
+FactoryGirl.create(:vacancy,
+                   job_title: 'PE Teacher',
+                   subject: Subject.last,
+                   school: ealing_school,
+                   working_pattern: :part_time,
+                   minimum_salary: 30000,
+                   maximum_salary: 35000,
+                   pay_scale: payscale,
+                   leadership: leadership)
+
+FactoryGirl.create(:vacancy,
+                   job_title: 'Geography Teacher',
+                   subject: Subject.last,
+                   school: ealing_school,
+                   working_pattern: :part_time,
+                   minimum_salary: 30000,
+                   maximum_salary: 35000,
+                   pay_scale: payscale,
+                   status: 1,
+                   leadership: leadership)

--- a/spec/features/hiring_staff_can_delete_vacancies_spec.rb
+++ b/spec/features/hiring_staff_can_delete_vacancies_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+RSpec.feature 'School deleting vacancies' do
+  scenario 'Hiring staff should see a delete button for a vacancy', elasticsearch: true do
+    school = FactoryGirl.create(:school)
+    vacancy = FactoryGirl.create(:vacancy, school: school)
+    visit school_vacancies_path(school.id)
+
+    within("tr#vacancy_#{vacancy.id}") do
+      expect(page).to have_content(I18n.t('buttons.delete'))
+    end
+  end
+  scenario 'A school can delete a vacancy from a list', elasticsearch: true do
+    school = FactoryGirl.create(:school)
+    vacancy1 = FactoryGirl.create(:vacancy, school: school)
+    vacancy2 = FactoryGirl.create(:vacancy, school: school)
+    visit school_vacancies_path(school.id)
+    within("tr#vacancy_#{vacancy1.id}") do
+      click_on 'Delete'
+    end
+
+    expect(school.vacancies.count).to equal(1)
+    expect(page).not_to have_content(vacancy1.job_title)
+    expect(page).to have_content(vacancy2.job_title)
+    expect(page).to have_content('Your vacancy was deleted.')
+  end
+end

--- a/spec/features/hiring_staff_can_view_vacancies_spec.rb
+++ b/spec/features/hiring_staff_can_view_vacancies_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+RSpec.feature 'School viewing vacancies' do
+  scenario 'A school can see a list of vacancies', elasticsearch: true do
+    school = FactoryGirl.create(:school)
+    vacancy1 = FactoryGirl.create(:vacancy, school: school)
+    vacancy2 = FactoryGirl.create(:vacancy, school: school)
+    visit school_vacancies_path(school.id)
+
+    expect(page).to have_content(I18n.t('schools.vacancies.index', school: school.name))
+    expect(page).to have_content(vacancy1.job_title)
+    expect(page).to have_content(vacancy2.job_title)
+  end
+end


### PR DESCRIPTION
Just the most basic implementation of deleting a vacancy, for now.

- adds a view for a list of vacancies for a school
- items in that list have a ‘delete’ link with confirmation dialogue
- after deletion, a confirmation flash is displayed

![screen shot 2018-03-22 at 14 35 58](https://user-images.githubusercontent.com/822507/37776993-6ef7765a-2dde-11e8-977e-9ffe7505a5c4.png)
![screen shot 2018-03-22 at 14 36 08](https://user-images.githubusercontent.com/822507/37776998-72ff39ae-2dde-11e8-8989-4f49db992034.png)
![screen shot 2018-03-22 at 14 36 18](https://user-images.githubusercontent.com/822507/37777002-750f7498-2dde-11e8-8932-eeb869330265.png)
