### PR TITLE
(chore): Patch security vulnerability in loofah

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ gem 'haml-rails'
 gem 'kaminari'
 gem 'roadie-rails'
 gem 'simple_form'
+gem 'rails-html-sanitizer', '~> 1.0.4', '>= 1.0.4' # Must be above this version due to CVE-2018-3741
 
 gem 'gov_uk_date_fields', '~> 2.0', '>= 2.0.3'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,7 +80,7 @@ GEM
     concurrent-ruby (1.0.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
-    crass (1.0.2)
+    crass (1.0.3)
     css_parser (1.5.0)
       addressable
     database_cleaner (1.6.1)
@@ -180,7 +180,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
-    loofah (2.1.1)
+    loofah (2.2.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.6.6)
@@ -196,7 +196,7 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.0.0)
     nio4r (2.1.0)
-    nokogiri (1.8.1)
+    nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     parser (2.4.0.0)
       ast (~> 2.2)
@@ -237,8 +237,8 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.0.3)
-      loofah (~> 2.0)
+    rails-html-sanitizer (1.0.4)
+      loofah (~> 2.2, >= 2.2.2)
     railties (5.1.4)
       actionpack (= 5.1.4)
       activesupport (= 5.1.4)
@@ -383,6 +383,7 @@ DEPENDENCIES
   rack_session_access
   rails (~> 5.1.4)
   rails-controller-testing (~> 1.0, >= 1.0.2)
+  rails-html-sanitizer (~> 1.0.4, >= 1.0.4)
   roadie-rails
   rollbar
   rspec-collection_matchers


### PR DESCRIPTION
* Loofah is a dependency on rails-html-sanitizer which is a dependency of actionpack (rails). There is no patch for Rails at this time so we have to define it explicitly.
* CVE-2018-3741