### PR TITLE
(chore): Include env examples logging in

### DIFF
--- a/docker-compose.env.sample
+++ b/docker-compose.env.sample
@@ -1,3 +1,6 @@
 GOOGLE_MAPS_API_KEY=
 ELASTICSEARCH_URL=http://elasticsearch:9200
 DATABASE_URL=postgres://postgres@db:5432/tvs_development?template=template0&pool=5&encoding=unicode
+HIRING_STAFF_HTTP_USER=user
+HIRING_STAFF_HTTP_PASS=a
+DEFAULT_SCHOOL_URN=


### PR DESCRIPTION
* The work was recently done to enable and enforce logins for all environments when attempting to publish. This forgot to include sample values for developers to cross over.
* If you don't set a default_school_urn then it will pick the first school in the database so it doesn't matter if it's blank 