### PR TITLE
(Feature) minimum salary is not less than lowest pay scale salary

### DIFF
--- a/app/models/concerns/vacancy_job_specification_validations.rb
+++ b/app/models/concerns/vacancy_job_specification_validations.rb
@@ -1,15 +1,21 @@
 module VacancyJobSpecificationValidations
   extend ActiveSupport::Concern
+  include ApplicationHelper
 
   included do
     validates :job_title, :job_description, :headline,
               :minimum_salary, :working_pattern, presence: true
 
     validate :minimum_salary_lower_than_maximum, :working_hours
+    validate :minimum_salary_greater_than_minimum_payscale, if: proc { |a| a.minimum_salary.present? }
   end
 
   def minimum_salary_lower_than_maximum
     errors.add(:minimum_salary, min_salary_must_be_greater_than_max_error) if minimum_higher_than_maximum_salary?
+  end
+
+  def minimum_salary_greater_than_minimum_payscale
+    errors.add(:minimum_salary, min_salary_lower_than_minimum_payscale_error) unless minimum_at_least_minimum_payscale?
   end
 
   def working_hours
@@ -25,6 +31,14 @@ module VacancyJobSpecificationValidations
 
   private
 
+  def minimum_at_least_minimum_payscale?
+    minimum_salary >= minimum_payscale_salary
+  end
+
+  def minimum_payscale_salary
+    @minimum_payscale_salar ||= PayScale.minimum_payscale_salary
+  end
+
   def minimum_higher_than_maximum_salary?
     maximum_salary && minimum_salary > maximum_salary
   end
@@ -39,5 +53,10 @@ module VacancyJobSpecificationValidations
 
   def invalid_weekly_hours_error
     I18n.t('activerecord.errors.models.vacancy.attributes.weekly_hours.invalid')
+  end
+
+  def min_salary_lower_than_minimum_payscale_error
+    I18n.t('activerecord.errors.models.vacancy.attributes.minimum_salary.lower_than_minimum_payscale',
+           minimum_salary: number_to_currency(minimum_payscale_salary))
   end
 end

--- a/app/models/pay_scale.rb
+++ b/app/models/pay_scale.rb
@@ -1,3 +1,7 @@
 class PayScale < ApplicationRecord
   has_many :vacancies
+
+  def self.minimum_payscale_salary
+    PayScale.minimum(:salary).to_i
+  end
 end

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -13,6 +13,7 @@ en:
             minimum_salary:
               blank: can't be blank
               greater_than_maximum_salary: must be lower than the maximum salary
+              lower_than_minimum_payscale: must be at least equal to the minimum pay range of %{minimum_salary}
             working_pattern:
               blank: can't be blank
             experience:

--- a/spec/factories/pay_scales.rb
+++ b/spec/factories/pay_scales.rb
@@ -2,6 +2,6 @@ FactoryGirl.define do
   factory :pay_scale do
     label { Faker::Lorem.unique.words(2).join(' ') }
     code { Faker::Code.asin }
-    salary { Faker::Number.number(5) }
+    salary { Faker::Number.number(4) }
   end
 end

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -15,8 +15,8 @@ FactoryGirl.define do
     status { :published }
     expires_on { Faker::Time.forward(14) }
     publish_on { Time.zone.today }
-    minimum_salary { Faker::Number.number(4) }
-    maximum_salary { Faker::Number.number(5) }
+    minimum_salary { Faker::Number.number(5) }
+    maximum_salary { Faker::Number.number(6) }
     contact_email { Faker::Internet.email }
     application_link { Faker::Internet.url }
 

--- a/spec/form_models/job_specification_form_spec.rb
+++ b/spec/form_models/job_specification_form_spec.rb
@@ -23,6 +23,21 @@ RSpec.describe JobSpecificationForm, type: :model do
             .to eq('must be lower than the maximum salary')
         end
       end
+
+      describe '#minimum_salary_at_least_minimum_payscale' do
+        let(:job_specification) do
+          JobSpecificationForm.new(headline: 'headline', job_title: 'job title',
+                                   job_description: 'description', working_pattern: :full_time,
+                                   minimum_salary: 20, maximum_salary: 200)
+        end
+
+        it 'the minimum salary should be at least equal to the minimum payscale value' do
+          create(:pay_scale, salary: 3000)
+          expect(job_specification.valid?). to be false
+          expect(job_specification.errors.messages[:minimum_salary][0])
+            . to eq('must be at least equal to the minimum pay range of £3,000')
+        end
+      end
     end
   end
 
@@ -33,18 +48,19 @@ RSpec.describe JobSpecificationForm, type: :model do
 
     it 'a JobSpecificationForm can be converted to a vacancy' do
       job_specification_form = JobSpecificationForm.new(headline: 'headline', job_title: 'job title',
-                                                        job_description: 'description', working_pattern: :full_time,
-                                                        minimum_salary: 20, maximum_salary: 40, benefits: 'benefits',
-                                                        subject_id: main_subject.id, pay_scale_id: payscale.id,
-                                                        leadership_id: leadership.id)
+                                                        job_description: 'description',
+                                                        working_pattern: :full_time,
+                                                        minimum_salary: 20000, maximum_salary: 40000,
+                                                        benefits: 'benefits', subject_id: main_subject.id,
+                                                        pay_scale_id: payscale.id, leadership_id: leadership.id)
 
       expect(job_specification_form.valid?).to be true
       expect(job_specification_form.vacancy.job_title).to eq('job title')
       expect(job_specification_form.vacancy.job_description).to eq('description')
       expect(job_specification_form.vacancy.headline).to eq('headline')
       expect(job_specification_form.vacancy.working_pattern).to eq('full_time')
-      expect(job_specification_form.vacancy.minimum_salary).to eq(20)
-      expect(job_specification_form.vacancy.maximum_salary).to eq(40)
+      expect(job_specification_form.vacancy.minimum_salary).to eq(20000)
+      expect(job_specification_form.vacancy.maximum_salary).to eq(40000)
       expect(job_specification_form.vacancy.benefits).to eq('benefits')
       expect(job_specification_form.vacancy.pay_scale.label).to eq(payscale.label)
       expect(job_specification_form.vacancy.subject.name).to eq(main_subject.name)


### PR DESCRIPTION
- update factories to so that by generated pay scale values are always less than minimum salary
- fix broken specs by updating specified salary values in Factory