### PR TITLE
(feature) adds breadcrumbs for hiring staff views

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -42,7 +42,7 @@
 @import 'elements/forms';
 @import 'elements/forms/form-date';
 @import 'elements/forms/form-validation';
-//@import 'elements/breadcrumbs';
+@import 'elements/breadcrumbs';
 @import 'elements/phase-banner';
 @import 'elements/components';
 

--- a/app/views/hiring_staff/vacancies/_school_vacancy_breadcrumb.html.haml
+++ b/app/views/hiring_staff/vacancies/_school_vacancy_breadcrumb.html.haml
@@ -1,0 +1,8 @@
+.grid-row
+  .column-full
+    .breadcrumbs
+      %ol.no-style
+        %li
+          = link_to @school.name, school_path(@school)
+        %li{'aria-current' => 'page'}
+          = @vacancy.job_title

--- a/app/views/hiring_staff/vacancies/edit.html.haml
+++ b/app/views/hiring_staff/vacancies/edit.html.haml
@@ -1,4 +1,5 @@
-= link_to @school.name, school_path(@school)
+=render partial: 'school_vacancy_breadcrumb'
+
 %h1.heading-large
   = t('vacancies.edit_heading', school: @vacancy.school.name)
 

--- a/app/views/hiring_staff/vacancies/review.html.haml
+++ b/app/views/hiring_staff/vacancies/review.html.haml
@@ -1,3 +1,5 @@
+=render partial: 'school_vacancy_breadcrumb'
+
 %h1.heading-large
   = t('vacancies.review_heading', school: @vacancy.school.name)
 

--- a/app/views/hiring_staff/vacancies/show.html.haml
+++ b/app/views/hiring_staff/vacancies/show.html.haml
@@ -1,1 +1,3 @@
+=render partial: 'school_vacancy_breadcrumb'
+
 =render partial: 'vacancies/show'

--- a/spec/features/hiring_staff_can_navigate_via_breadcrumbs.rb
+++ b/spec/features/hiring_staff_can_navigate_via_breadcrumbs.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.feature 'School viewing vacancies' do
+  include_context 'when authenticated as a member of hiring staff',
+                  stub_basic_auth_env: true
+
+  scenario 'Navigate from viewing a vacancy to all vacancies for that school', elasticsearch: true do
+    school = FactoryGirl.create(:school)
+    vacancy = FactoryGirl.create(:vacancy, school: school)
+
+    visit school_vacancy_path(school_id: school.id, id: vacancy.id)
+
+    expect(page).to have_css('.breadcrumbs')
+    within('.breadcrumbs') do
+      expect(page).to have_content(school.name)
+      expect(page).to have_content(vacancy.job_title)
+    end
+
+    click_on school.name
+    expect(page).to have_content("Vacancies at #{school.name}")
+  end
+
+  scenario 'Navigate from editing an active vacancy to all vacancies for that school', elasticsearch: true do
+    school = FactoryGirl.create(:school)
+    vacancy = FactoryGirl.create(:vacancy, school: school)
+
+    visit edit_school_vacancy_path(school_id: school.id, id: vacancy.id)
+
+    expect(page).to have_css('.breadcrumbs')
+    within('.breadcrumbs') do
+      expect(page).to have_content(school.name)
+      expect(page).to have_content(vacancy.job_title)
+    end
+
+    click_on school.name
+    expect(page).to have_content("Vacancies at #{school.name}")
+  end
+
+  scenario 'Navigate from reviewing a draft vacancy to all vacancies for that school', elasticsearch: true do
+    school = FactoryGirl.create(:school)
+    vacancy = FactoryGirl.create(:vacancy, school: school)
+
+    visit school_vacancy_review_path(school_id: school.id, vacancy_id: vacancy.id)
+
+    expect(page).to have_css('.breadcrumbs')
+    within('.breadcrumbs') do
+      expect(page).to have_content(school.name)
+      expect(page).to have_content(vacancy.job_title)
+    end
+
+    click_on school.name
+    expect(page).to have_content("Vacancies at #{school.name}")
+  end
+end


### PR DESCRIPTION
displays breadcrumbs for hiring staff to return to their school page when they view/edit/review a vacancy

before:
<img width="993" alt="before" src="https://user-images.githubusercontent.com/822507/38256215-ac15b21a-3755-11e8-8b14-4efdbd73eadf.png">

after:
<img width="984" alt="after" src="https://user-images.githubusercontent.com/822507/38256223-b1d920ba-3755-11e8-92b3-e3fc8741d135.png">

