### PR TITLE
(feature) prevent access to hiring_staff/vacancies#show if

### DIFF
--- a/app/controllers/hiring_staff/vacancies_controller.rb
+++ b/app/controllers/hiring_staff/vacancies_controller.rb
@@ -1,18 +1,21 @@
 class HiringStaff::VacanciesController < HiringStaff::Vacancies::ApplicationController
   def show
     vacancy = school.vacancies.active.find(id)
+    unless vacancy.published?
+      return redirect_to school_vacancy_review_path(school, vacancy.id),
+                         notice: I18n.t('vacancies.view.only_published')
+    end
     @vacancy = VacancyPresenter.new(vacancy)
-    flash.now[:alert] = t('vacancies.draft') if vacancy.draft?
   end
 
   def new
     reset_session_vacancy!
-    redirect_to job_specification_school_vacancy_path(school_id: school.id)
+    redirect_to job_specification_school_vacancy_path(school)
   end
 
   def edit
     vacancy = school.vacancies.find(id)
-    redirect_to school_vacancy_review_path(school_id: school.id, vacancy_id: vacancy.id) unless vacancy.published?
+    redirect_to school_vacancy_review_path(school, vacancy.id) unless vacancy.published?
 
     @vacancy = VacancyPresenter.new(vacancy)
   end

--- a/app/controllers/hiring_staff/vacancies_controller.rb
+++ b/app/controllers/hiring_staff/vacancies_controller.rb
@@ -3,7 +3,7 @@ class HiringStaff::VacanciesController < HiringStaff::Vacancies::ApplicationCont
     vacancy = school.vacancies.active.find(id)
     unless vacancy.published?
       return redirect_to school_vacancy_review_path(school, vacancy.id),
-                         notice: I18n.t('vacancies.view.only_published')
+                         alert: I18n.t('messages.vacancies.view.only_published')
     end
     @vacancy = VacancyPresenter.new(vacancy)
   end
@@ -24,7 +24,7 @@ class HiringStaff::VacanciesController < HiringStaff::Vacancies::ApplicationCont
     vacancy = school.vacancies.active.find(vacancy_id)
     if vacancy.published?
       redirect_to school_vacancy_path(school_id: school.id, id: vacancy.id),
-                  notice: t('vacancies.already_published')
+                  notice: t('messages.vacancies.already_published')
     end
 
     session[:current_step] = :review

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -133,6 +133,8 @@ en:
     vacancies:
       delete: The vacancy has been deleted
       updated: 'The vacancy has been updated'
+      view:
+        only_published: You can only view published vacancies
 
   errors:
     vacancies:

--- a/spec/features/hiring_staff_can_view_vacancies_spec.rb
+++ b/spec/features/hiring_staff_can_view_vacancies_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature 'School viewing vacancies' do
     visit school_vacancy_path(school_id: school.id, id: vacancy.id)
 
     expect(page.current_path).to eq(school_vacancy_review_path(school, vacancy.id))
-    expect(page).to have_content(I18n.t('vacancies.view.only_published'))
+    expect(page).to have_content(I18n.t('messages.vacancies.view.only_published'))
   end
 
   scenario 'A published vacancy show page should not show a flash message with the status', elasticsearch: true do

--- a/spec/features/hiring_staff_can_view_vacancies_spec.rb
+++ b/spec/features/hiring_staff_can_view_vacancies_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature 'School viewing vacancies' do
 
   scenario 'A school should see advisory text when there are no vacancies', elasticsearch: true do
     school = FactoryGirl.create(:school)
-    visit school_path(school.id)
+    visit school_path(school)
 
     expect(page).to have_content(I18n.t('schools.vacancies.index', school: school.name))
     expect(page).not_to have_css('table.vacancies')
@@ -17,28 +17,27 @@ RSpec.feature 'School viewing vacancies' do
     school = FactoryGirl.create(:school)
     vacancy1 = FactoryGirl.create(:vacancy, school: school)
     vacancy2 = FactoryGirl.create(:vacancy, school: school)
-    visit school_path(school.id)
+    visit school_path(school)
 
     expect(page).to have_content(I18n.t('schools.vacancies.index', school: school.name))
     expect(page).to have_content(vacancy1.job_title)
     expect(page).to have_content(vacancy2.job_title)
   end
 
-  scenario 'A draft vacancy show page should show a flash message with the status', elasticsearch: true do
+  scenario 'A draft vacancy redirects to the vacancy review page' do
     school = FactoryGirl.create(:school)
-    vacancy = FactoryGirl.create(:vacancy, school: school, status: 'draft')
+    vacancy = FactoryGirl.create(:vacancy, :draft, school: school)
     visit school_vacancy_path(school_id: school.id, id: vacancy.id)
-    expect(page).to have_content(school.name)
-    expect(page).to have_content(vacancy.job_title)
-    expect(page).to have_content(I18n.t('vacancies.draft'))
+
+    expect(page.current_path).to eq(school_vacancy_review_path(school, vacancy.id))
+    expect(page).to have_content(I18n.t('vacancies.view.only_published'))
   end
 
   scenario 'A published vacancy show page should not show a flash message with the status', elasticsearch: true do
     school = FactoryGirl.create(:school)
-    vacancy = FactoryGirl.create(:vacancy, school: school, status: 'published')
-    visit school_vacancy_path(school_id: school.id, id: vacancy.id)
+    vacancy = FactoryGirl.create(:vacancy, :published, school: school)
+    visit school_vacancy_path(school, vacancy.id)
     expect(page).to have_content(school.name)
     expect(page).to have_content(vacancy.job_title)
-    expect(page).not_to have_content(I18n.t('vacancies.draft'))
   end
 end


### PR DESCRIPTION
a vacancy has not been published and redirect to review page

- utilise factories to create draft and published vacancies
- simplify path helper parameters, no need to specify school_id and vacancy_id

(the current vacancy#show page assumes a vacancy's fields have been succesfuly validated and does not check for empty values, which currently causes some draft vacancies to break the page)