### PR TITLE
Feature/23 only return vacancies with a status of published and a publish_on date greater than today for vacancy listing

### DIFF
--- a/app/services/vacancy_search_builder.rb
+++ b/app/services/vacancy_search_builder.rb
@@ -19,6 +19,7 @@ class VacancySearchBuilder
     minimum_salary_query = minimum_salary_build
     maximum_salary_query = maximum_salary_build
     expired_query = expired_build
+    published_on_query = published_on_build
     status_query = status_build
     sort_query = sort_build
 
@@ -31,6 +32,7 @@ class VacancySearchBuilder
       maximum_salary_query,
       expired_query,
       status_query,
+      published_on_query
     ].compact
 
     query = {
@@ -73,6 +75,17 @@ class VacancySearchBuilder
       range: {
         'expires_on': {
           'gte': 'now/d',
+        },
+      },
+    }
+  end
+
+  def published_on_build
+    return if @published_on
+    {
+      range: {
+        'publish_on': {
+          'lte': 'now/d',
         },
       },
     }

--- a/spec/features/hiring_staff_can_navigate_via_breadcrumbs.rb
+++ b/spec/features/hiring_staff_can_navigate_via_breadcrumbs.rb
@@ -4,7 +4,7 @@ RSpec.feature 'School viewing vacancies' do
   include_context 'when authenticated as a member of hiring staff',
                   stub_basic_auth_env: true
 
-  scenario 'Navigate from viewing a vacancy to all vacancies for that school', elasticsearch: true do
+  scenario 'Navigate from viewing a vacancy to all vacancies for that school' do
     school = FactoryGirl.create(:school)
     vacancy = FactoryGirl.create(:vacancy, school: school)
 
@@ -20,7 +20,7 @@ RSpec.feature 'School viewing vacancies' do
     expect(page).to have_content("Vacancies at #{school.name}")
   end
 
-  scenario 'Navigate from editing an active vacancy to all vacancies for that school', elasticsearch: true do
+  scenario 'Navigate from editing an active vacancy to all vacancies for that school' do
     school = FactoryGirl.create(:school)
     vacancy = FactoryGirl.create(:vacancy, school: school)
 
@@ -36,7 +36,7 @@ RSpec.feature 'School viewing vacancies' do
     expect(page).to have_content("Vacancies at #{school.name}")
   end
 
-  scenario 'Navigate from reviewing a draft vacancy to all vacancies for that school', elasticsearch: true do
+  scenario 'Navigate from reviewing a draft vacancy to all vacancies for that school' do
     school = FactoryGirl.create(:school)
     vacancy = FactoryGirl.create(:vacancy, school: school)
 

--- a/spec/features/hiring_staff_can_view_vacancies_spec.rb
+++ b/spec/features/hiring_staff_can_view_vacancies_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature 'School viewing vacancies' do
     stub_hiring_staff_auth(urn: school.urn)
   end
 
-  scenario 'A school should see advisory text when there are no vacancies', elasticsearch: true do
+  scenario 'A school should see advisory text when there are no vacancies' do
     visit school_path(school)
 
     expect(page).to have_content(I18n.t('schools.vacancies.index', school: school.name))
@@ -14,7 +14,7 @@ RSpec.feature 'School viewing vacancies' do
     expect(page).to have_content('You have no current vacancies.')
   end
 
-  scenario 'A school can see a list of vacancies', elasticsearch: true do
+  scenario 'A school can see a list of vacancies' do
     vacancy1 = create(:vacancy, school: school)
     vacancy2 = create(:vacancy, school: school)
 
@@ -35,10 +35,9 @@ RSpec.feature 'School viewing vacancies' do
     expect(page).to have_content(I18n.t('messages.vacancies.view.only_published'))
   end
 
-  scenario 'A published vacancy show page should not show a flash message with the status', elasticsearch: true do
+  scenario 'A published vacancy show page should not show a flash message with the status' do
     vacancy = create(:vacancy, school: school, status: 'published')
-
-    visit school_vacancy_path(school_id: school.id, id: vacancy.id)
+    visit school_vacancy_path(school, vacancy.id)
 
     expect(page).to have_content(school.name)
     expect(page).to have_content(vacancy.job_title)

--- a/spec/features/job_seekers_can_view_a_vacancy_spec.rb
+++ b/spec/features/job_seekers_can_view_a_vacancy_spec.rb
@@ -35,10 +35,9 @@ RSpec.feature 'Viewing a single published vacancy' do
     expect(page).to have_content('This vacancy has expired')
   end
 
-  scenario 'A single vacancy must contain JobPosting schema.org mark up', elasticsearch: true do
+  scenario 'A single vacancy must contain JobPosting schema.org mark up' do
     vacancy = create(:vacancy, :job_schema)
 
-    Vacancy.__elasticsearch__.client.indices.flush
     visit vacancy_path(vacancy)
 
     expect(script_tag_content(wrapper_class: '.jobref')).to eq(vacancy_json_ld(vacancy).to_json)

--- a/spec/services/vacancy_search_builder_spec.rb
+++ b/spec/services/vacancy_search_builder_spec.rb
@@ -1,3 +1,4 @@
+require 'rails_helper'
 RSpec.describe VacancySearchBuilder do
   describe '#call' do
     it 'returns the default keyword query with no parameters' do
@@ -131,6 +132,23 @@ RSpec.describe VacancySearchBuilder do
             terms: {
               status: ['published'],
             },
+          },
+        },
+      }
+
+      expect(builder).to be_a(Hash)
+      expect(builder[:search_query][:bool][:must]).to include(expected_hash)
+    end
+
+    it 'builds a published_on query by default' do
+      sort = OpenStruct.new(column: :expires_on, order: :desc)
+      filters = OpenStruct.new
+      builder = VacancySearchBuilder.new(filters: filters, sort: sort).call
+
+      expected_hash = {
+        range: {
+          publish_on: {
+            lte: 'now/d',
           },
         },
       }


### PR DESCRIPTION
- remove elasticsearch tag from specs that dont require it