### PR TITLE
(feature) display vacancy contact email

### DIFF
--- a/app/assets/stylesheets/base/_utilities.scss
+++ b/app/assets/stylesheets/base/_utilities.scss
@@ -1,3 +1,7 @@
 .mt1 {
   margin-top: $gutter;
 }
+
+.wordwrap {
+  word-wrap:break-word;
+}

--- a/app/views/hiring_staff/vacancies/application_details/edit.html.haml
+++ b/app/views/hiring_staff/vacancies/application_details/edit.html.haml
@@ -9,6 +9,7 @@
     .column-one-half
       = f.input :contact_email,
                 label: t('vacancies.contact_email'),
+                hint: t('vacancies.form_hints.contact_email'),
                 as: :email,
                 wrapper_html: {id: 'contact_email'},
                 required: true

--- a/app/views/hiring_staff/vacancies/application_details/new.html.haml
+++ b/app/views/hiring_staff/vacancies/application_details/new.html.haml
@@ -11,6 +11,7 @@
     .column-one-half
       = f.input :contact_email,
                 label: t('vacancies.contact_email'),
+                hint: t('vacancies.form_hints.contact_email'),
                 as: :email,
                 wrapper_html: {id: 'contact_email'},
                 required: true

--- a/app/views/vacancies/_show.html.haml
+++ b/app/views/vacancies/_show.html.haml
@@ -113,6 +113,10 @@
           %dt= t('vacancies.leadership_level')
           %dd= @vacancy.leadership.title
 
+        - if @vacancy.contact_email.present?
+          %dt= t('vacancies.contact_email')
+          %dd.wordwrap= mail_to @vacancy.contact_email, @vacancy.contact_email, subject: t('vacancies.contact_email_subject', vacancy: @vacancy.job_title), body: t('vacancies.contact_email_body', url: url_for(only_path: false))
+
     - if @vacancy.application_link.present?
       %br
       = link_to t('vacancies.apply'), @vacancy.application_link, target: '_blank', class: 'button'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,6 +40,8 @@ en:
     candidate_specification: 'Candidate specification'
     application_details: 'Application details'
     contact_email: 'Vacancy contact email'
+    contact_email_subject: '%{vacancy} vacancy enquiry'
+    contact_email_body: 'Regarding the vacancy at %{url}'
     deadline_date: 'Application deadline'
     publication_date: 'Date role will be listed'
     review: 'Review the vacancy details and make any necessary changes before submitting it for publication below.'

--- a/spec/features/job_seekers_can_view_a_vacancy_spec.rb
+++ b/spec/features/job_seekers_can_view_a_vacancy_spec.rb
@@ -10,6 +10,7 @@ RSpec.feature 'Viewing a single published vacancy' do
     expect(page).to have_content(published_vacancy.headline)
     expect(page).to have_content(published_vacancy.job_description)
     expect(page).to have_content(published_vacancy.salary_range)
+    expect(page).to have_content(published_vacancy.contact_email)
   end
 
   scenario 'Unpublished vacancies are not viewable' do


### PR DESCRIPTION
show the given contact email on the vacancy show page

- adds a spec to check presence of email address
- adds the email address to the vacancy show page sidebar
- adds a sass utility class to wrap long email addresses so they don’t break the layout
- adds hint text to the form views

<img width="545" alt="hint" src="https://user-images.githubusercontent.com/822507/38422070-578b6c32-39a1-11e8-9ab1-df7c3934e01e.png">

<img width="432" alt="email" src="https://user-images.githubusercontent.com/822507/38422086-5e68f786-39a1-11e8-8eb8-ee7c386ac736.png">

