### PR TITLE
Feature/28 add checkbox for flexible working arrangements available next to working pattern

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -29,11 +29,12 @@
 @import 'design-patterns/buttons';
 @import 'design-patterns/breadcrumbs';
 
-// From GDS's alphagov/govuk_elements
+// From GDS's alphagov/govuk_elements https://github.com/alphagov/govuk_elements/blob/master/assets/sass/_elements.scss
 @import 'elements/layout';
 @import 'elements/helpers';
 @import 'elements/reset';
 @import 'elements/elements-typography';
+@import "elements/forms/form-multiple-choice";
 @import 'elements/buttons';
 @import 'elements/lists';
 @import 'elements/tables';

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -74,3 +74,7 @@ input[type="search"] {
 @import 'base/layout';
 @import 'base/forms';
 @import 'base/utilities';
+
+.form-group .form-hint {
+  clear: both;
+}

--- a/app/controllers/hiring_staff/vacancies/job_specification_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/job_specification_controller.rb
@@ -51,7 +51,8 @@ class HiringStaff::Vacancies::JobSpecificationController < HiringStaff::Vacancie
                                                    :minimum_salary, :maximum_salary, :working_pattern,
                                                    :benefits, :weekly_hours, :subject_id, :pay_scale_id,
                                                    :starts_on_dd, :starts_on_mm, :starts_on_yyyy,
-                                                   :ends_on_dd, :ends_on_mm, :ends_on_yyyy)
+                                                   :ends_on_dd, :ends_on_mm, :ends_on_yyyy,
+                                                   :flexible_working)
   end
 
   def save_vacancy_without_validation

--- a/app/presenters/vacancy_presenter.rb
+++ b/app/presenters/vacancy_presenter.rb
@@ -52,6 +52,10 @@ class VacancyPresenter < BasePresenter
     model.publish_on == Time.zone.today
   end
 
+  def flexible_working
+    @flexible_working = model.flexible_working ? 'Yes' : 'No'
+  end
+
   def working_pattern
     model.working_pattern.sub('_', ' ').humanize
   end

--- a/app/views/hiring_staff/vacancies/edit.html.haml
+++ b/app/views/hiring_staff/vacancies/edit.html.haml
@@ -44,6 +44,13 @@
           = link_to t('buttons.change'), edit_school_vacancy_job_specification_path(@school, @vacancy.id, anchor: 'working_pattern')
       %div
         %dt.cya-question
+          = t('vacancies.flexible_working')
+        %dd.cya-answer
+          = @vacancy.flexible_working
+        %dd.cya-change
+          = link_to t('buttons.change'), job_specification_school_vacancy_path(schoold_id: @school.id)
+      %div
+        %dt.cya-question
           = t('vacancies.benefits')
         %dd.cya-answer
           = @vacancy.benefits

--- a/app/views/hiring_staff/vacancies/edit.html.haml
+++ b/app/views/hiring_staff/vacancies/edit.html.haml
@@ -48,7 +48,7 @@
         %dd.cya-answer
           = @vacancy.flexible_working
         %dd.cya-change
-          = link_to t('buttons.change'), job_specification_school_vacancy_path(schoold_id: @school.id)
+          = link_to t('buttons.change'), edit_school_vacancy_job_specification_path(@school, @vacancy.id, anchor: 'flexible_working')
       %div
         %dt.cya-question
           = t('vacancies.benefits')

--- a/app/views/hiring_staff/vacancies/job_specification/edit.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/edit.html.haml
@@ -69,6 +69,7 @@
                 wrapper_html: {id: 'working_pattern'},
                 required: true
       = f.input :flexible_working, as: :boolean,
+                hint: t('vacancies.form_hints.flexible_working'),
                 wrapper: :inline_checkbox,
                 wrapper_html: { id: 'flexible_working' }
       = f.input :weekly_hours,

--- a/app/views/hiring_staff/vacancies/job_specification/edit.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/edit.html.haml
@@ -68,6 +68,10 @@
                 collection: working_pattern_options,
                 wrapper_html: {id: 'working_pattern'},
                 required: true
+      %fieldset.form-group#flexible-working
+        .multiple-choice
+          = f.check_box :flexible_working
+          = f.label :flexible_working
       = f.input :weekly_hours,
                 label: t('vacancies.weekly_hours'),
                 as: :decimal,

--- a/app/views/hiring_staff/vacancies/job_specification/edit.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/edit.html.haml
@@ -68,10 +68,9 @@
                 collection: working_pattern_options,
                 wrapper_html: {id: 'working_pattern'},
                 required: true
-      %fieldset.form-group#flexible-working
-        .multiple-choice
-          = f.check_box :flexible_working
-          = f.label :flexible_working
+      = f.input :flexible_working, as: :boolean,
+                wrapper: :inline_checkbox,
+                wrapper_html: { id: 'flexible_working' }
       = f.input :weekly_hours,
                 label: t('vacancies.weekly_hours'),
                 as: :decimal,

--- a/app/views/hiring_staff/vacancies/job_specification/new.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/new.html.haml
@@ -70,10 +70,9 @@
                 collection: working_pattern_options,
                 wrapper_html: {id: 'working_pattern'},
                 required: true
-      %fieldset.form-group#flexible-working
-        .multiple-choice
-          = f.check_box :flexible_working
-          = f.label :flexible_working
+      = f.input :flexible_working, as: :boolean,
+                wrapper: :inline_checkbox,
+                wrapper_html: { id: 'flexible_working' }
       = f.input :weekly_hours,
                 label: t('vacancies.weekly_hours'),
                 as: :decimal,

--- a/app/views/hiring_staff/vacancies/job_specification/new.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/new.html.haml
@@ -70,6 +70,10 @@
                 collection: working_pattern_options,
                 wrapper_html: {id: 'working_pattern'},
                 required: true
+      %fieldset.form-group#flexible-working
+        .multiple-choice
+          = f.check_box :flexible_working
+          = f.label :flexible_working
       = f.input :weekly_hours,
                 label: t('vacancies.weekly_hours'),
                 as: :decimal,

--- a/app/views/hiring_staff/vacancies/job_specification/new.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/new.html.haml
@@ -71,6 +71,7 @@
                 wrapper_html: {id: 'working_pattern'},
                 required: true
       = f.input :flexible_working, as: :boolean,
+                hint: t('vacancies.form_hints.flexible_working'),
                 wrapper: :inline_checkbox,
                 wrapper_html: { id: 'flexible_working' }
       = f.input :weekly_hours,

--- a/app/views/hiring_staff/vacancies/review.html.haml
+++ b/app/views/hiring_staff/vacancies/review.html.haml
@@ -50,7 +50,7 @@
         %dt.cya-question
           = t('vacancies.flexible_working')
         %dd.cya-answer
-          = @vacancy.flexible_working ? 'Yes' : 'No'
+          = @vacancy.flexible_working
         %dd.cya-change
           = link_to t('buttons.change'), job_specification_school_vacancy_path(@school, acndhor: 'flexible_working')
 

--- a/app/views/hiring_staff/vacancies/review.html.haml
+++ b/app/views/hiring_staff/vacancies/review.html.haml
@@ -48,6 +48,14 @@
           = link_to t('buttons.change'), job_specification_school_vacancy_path(@school, anchor: 'working_pattern')
       %div
         %dt.cya-question
+          = t('vacancies.flexible_working')
+        %dd.cya-answer
+          = @vacancy.flexible_working ? 'Yes' : 'No'
+        %dd.cya-change
+          = link_to t('buttons.change'), job_specification_school_vacancy_path(@school, acndhor: 'flexible_working')
+
+      %div
+        %dt.cya-question
           = t('vacancies.benefits')
         %dd.cya-answer
           = @vacancy.benefits

--- a/app/views/vacancies/_show.html.haml
+++ b/app/views/vacancies/_show.html.haml
@@ -77,6 +77,9 @@
           %dt= t('vacancies.weekly_hours')
           %dd= @vacancy.weekly_hours
 
+        %dt= t('vacancies.flexible_working')
+        %dd= @vacancy.flexible_working
+
         %dt= t('vacancies.expires_on')
         %dd= format_date(@vacancy.expires_on)
 

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -62,7 +62,7 @@ SimpleForm.setup do |config|
   # Defaults to :nested for bootstrap config.
   #   inline: input + label
   #   nested: label > input
-  config.boolean_style = :nested
+  config.boolean_style = :inline
 
   # Default class for buttons
   config.button_class = 'button'
@@ -96,6 +96,15 @@ SimpleForm.setup do |config|
   # You can wrap each item in a collection of radio/check boxes with a tag,
   # defaulting to :span.
   # config.item_wrapper_tag = :span
+   config.wrappers :inline_checkbox, :tag => 'fieldset', :class => 'form-group', :error_class => 'error' do |b|
+     b.use :html5
+     b.wrapper :class => 'multiple-choice' do |ba|
+       ba.use :input
+       ba.use :label_text, wrap_with: { tag: 'label' }
+       ba.use :error, :wrap_with => { :tag => 'span', :class => 'help-inline' }
+       ba.use :hint,  :wrap_with => { :tag => 'p', :class => 'help-block' }
+     end
+   end
 
   # You can define a class to use in all item wrappers. Defaulting to none.
   # config.item_wrapper_class = nil

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -96,15 +96,18 @@ SimpleForm.setup do |config|
   # You can wrap each item in a collection of radio/check boxes with a tag,
   # defaulting to :span.
   # config.item_wrapper_tag = :span
-   config.wrappers :inline_checkbox, :tag => 'fieldset', :class => 'form-group', :error_class => 'error' do |b|
-     b.use :html5
-     b.wrapper :class => 'multiple-choice' do |ba|
-       ba.use :input
-       ba.use :label_text, wrap_with: { tag: 'label' }
-       ba.use :error, :wrap_with => { :tag => 'span', :class => 'help-inline' }
-       ba.use :hint,  :wrap_with => { :tag => 'p', :class => 'help-block' }
-     end
-   end
+  config.wrappers :inline_checkbox, :tag => 'div',
+                                    :class => 'form-group',
+                                    :error_class => 'error' do |checkbox|
+    checkbox.use :html5
+    checkbox.wrapper :class => 'multiple-choice' do |field|
+      field.use :input
+      field.use :label_text, wrap_with: { tag: 'label', class: 'form-label form-label-bold' }
+    end
+
+    checkbox.use :error, :wrap_with => { :tag => 'div', :class => 'help-inline' }
+    checkbox.use :hint,  :wrap_with => { :tag => 'div', :class => 'form-hint' }
+  end
 
   # You can define a class to use in all item wrappers. Defaulting to none.
   # config.item_wrapper_class = nil

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,6 +20,7 @@ en:
     publish_on: 'Date posted'
     expires_on: 'Closing date'
     working_pattern: 'Working pattern'
+    flexible_working: 'Flexible working'
     starts_on: 'Expected start date'
     ends_on: 'End date'
     expired: 'This vacancy has expired'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -71,6 +71,7 @@ en:
       main_subject: 'What subject will the teacher focus on?'
       salary_range: 'Annual pay before tax. No commas or decimal points, for example 30000'
       pay_scale: 'What pay scale does the job’s salary fall in?'
+      flexible_working: 'Tick this box if any flexible working arrangements are possible (job sharing or compressed hours, for example)'
       weekly_hours: 'Number of hours to be worked each week'
       start_date: 'For example, %{date}'
       end_date: 'For example, %{date}'

--- a/db/migrate/20180405150445_add_flexible_working_to_vacancies.rb
+++ b/db/migrate/20180405150445_add_flexible_working_to_vacancies.rb
@@ -1,0 +1,5 @@
+class AddFlexibleWorkingToVacancies < ActiveRecord::Migration[5.1]
+  def change
+    add_column :vacancies, :flexible_working, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -137,6 +137,7 @@ ActiveRecord::Schema.define(version: 20180419160314) do
     t.datetime "updated_at", null: false
     t.uuid "reference", default: -> { "gen_random_uuid()" }, null: false
     t.string "application_link"
+    t.boolean "flexible_working"
     t.index ["expires_on"], name: "index_vacancies_on_expires_on"
     t.index ["leadership_id"], name: "index_vacancies_on_leadership_id"
     t.index ["pay_scale_id"], name: "index_vacancies_on_pay_scale_id"

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -42,6 +42,7 @@ FactoryGirl.define do
     trait :complete do
       starts_on { Faker::Time.forward(30) }
       ends_on { Faker::Time.forward(60) }
+      flexible_working true
     end
 
     trait :draft do

--- a/spec/features/hiring_staff_can_edit_a_published_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_edit_a_published_vacancy_spec.rb
@@ -141,14 +141,17 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
 
       scenario 'can be succesfuly edited' do
         vacancy = create(:vacancy, :published, school: school)
+        vacancy = VacancyPresenter.new(vacancy)
         visit edit_school_vacancy_path(school, vacancy.id)
-        click_link_in_container_with_text(I18n.t('vacancies.application_link'))
 
-        fill_in 'application_details_form[application_link]', with: 'https://tvs.com'
+        click_link_in_container_with_text(I18n.t('vacancies.application_link'))
+        vacancy.application_link = 'https://tvs.com'
+
+        fill_in 'application_details_form[application_link]', with: vacancy.application_link
         click_on 'Update vacancy'
 
         expect(page).to have_content(I18n.t('messages.vacancies.updated'))
-        expect(page).to have_content('https://tvs.com')
+        verify_all_vacancy_details(vacancy)
       end
     end
 

--- a/spec/features/job_seekers_can_view_a_vacancy_spec.rb
+++ b/spec/features/job_seekers_can_view_a_vacancy_spec.rb
@@ -46,7 +46,10 @@ RSpec.feature 'Viewing a single published vacancy' do
   context 'A user viewing a vacancy' do
     scenario 'can click on the application link when there is one set' do
       vacancy = create(:vacancy, :job_schema)
+      vacancy = VacancyPresenter.new(vacancy)
       visit vacancy_path(vacancy)
+
+      verify_vacancy_show_page_details(vacancy)
       click_on 'Apply for this job'
 
       expect(page.current_url).to eq vacancy.application_link

--- a/spec/features/job_seekers_can_view_a_vacancy_spec.rb
+++ b/spec/features/job_seekers_can_view_a_vacancy_spec.rb
@@ -6,10 +6,7 @@ RSpec.feature 'Viewing a single published vacancy' do
 
     visit vacancy_path(published_vacancy)
 
-    expect(page).to have_content(published_vacancy.job_title)
-    expect(page.html).to include(published_vacancy.job_description)
-    expect(page).to have_content(published_vacancy.salary_range)
-    expect(page).to have_content(published_vacancy.contact_email)
+    verify_vacancy_show_page_details(published_vacancy)
   end
 
   scenario 'Unpublished vacancies are not viewable' do
@@ -46,10 +43,8 @@ RSpec.feature 'Viewing a single published vacancy' do
   context 'A user viewing a vacancy' do
     scenario 'can click on the application link when there is one set' do
       vacancy = create(:vacancy, :job_schema)
-      vacancy = VacancyPresenter.new(vacancy)
       visit vacancy_path(vacancy)
 
-      verify_vacancy_show_page_details(vacancy)
       click_on 'Apply for this job'
 
       expect(page.current_url).to eq vacancy.application_link

--- a/spec/presenters/vacancy_presenter_spec.rb
+++ b/spec/presenters/vacancy_presenter_spec.rb
@@ -78,4 +78,18 @@ RSpec.describe VacancyPresenter do
       expect(presenter.job_description).to eq('<p> call();Sanitized content</p>')
     end
   end
+
+  describe '#flexible_working' do
+    context 'it converts flexible working' do
+      it 'to Yes' do
+        vacancy = VacancyPresenter.new(build(:vacancy, :complete))
+        expect(vacancy.flexible_working).to eq('Yes')
+      end
+
+      it 'to No' do
+        vacancy = VacancyPresenter.new(build(:vacancy))
+        expect(vacancy.flexible_working).to eq('No')
+      end
+    end
+  end
 end

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -6,6 +6,7 @@ module VacancyHelpers
     select vacancy.pay_scale, from: 'job_specification_form[pay_scale_id]'
     select vacancy.subject.name, from: 'job_specification_form[subject_id]'
     select vacancy.leadership.title, from: 'job_specification_form[leadership_id]'
+    check 'job_specification_form[flexible_working]' if vacancy.flexible_working
     fill_in 'job_specification_form[minimum_salary]', with: vacancy.minimum_salary
     fill_in 'job_specification_form[maximum_salary]', with: vacancy.maximum_salary
     fill_in 'job_specification_form[starts_on_dd]', with: vacancy.starts_on.day
@@ -39,6 +40,7 @@ module VacancyHelpers
     expect(page).to have_content(vacancy.subject.name)
     expect(page).to have_content(vacancy.salary_range)
     expect(page).to have_content(vacancy.working_pattern)
+    expect(page).to have_content("Flexible working #{vacancy.flexible_working}")
     expect(page.html).to include(vacancy.benefits)
     expect(page).to have_content(vacancy.pay_scale)
     expect(page).to have_content(vacancy.weekly_hours)
@@ -52,6 +54,29 @@ module VacancyHelpers
 
     expect(page).to have_content(vacancy.contact_email)
     expect(page).to have_content(vacancy.application_link)
+    expect(page).to have_content(vacancy.expires_on)
+    expect(page).to have_content(vacancy.publish_on)
+  end
+
+  def verify_vacancy_show_page_details(vacancy)
+    expect(page).to have_content(vacancy.job_title)
+    expect(page.html).to include(vacancy.job_description)
+    expect(page).to have_content(vacancy.subject.name)
+    expect(page).to have_content(vacancy.salary_range)
+    expect(page).to have_content(vacancy.working_pattern)
+    expect(page).to have_content("Flexible working #{vacancy.flexible_working}")
+    expect(page.html).to include(vacancy.benefits)
+    expect(page).to have_content(vacancy.pay_scale)
+    expect(page).to have_content(vacancy.weekly_hours) if vacancy.part_time?
+    expect(page).to have_content(vacancy.starts_on)
+    expect(page).to have_content(vacancy.ends_on)
+
+    expect(page.html).to include(vacancy.education)
+    expect(page.html).to include(vacancy.qualifications)
+    expect(page.html).to include(vacancy.experience)
+    expect(page).to have_content(vacancy.leadership.title)
+
+    expect(page).to have_link(I18n.t('vacancies.apply'), href: vacancy.application_link)
     expect(page).to have_content(vacancy.expires_on)
     expect(page).to have_content(vacancy.publish_on)
   end


### PR DESCRIPTION
 this PR also introduces a simple_form wrapper that can be used across all checkbox components with
`wrapper: :inline_checkbox`