### PR TITLE
(fix): Signing out shows the user a message

### DIFF
--- a/app/controllers/hiring_staff/sessions_controller.rb
+++ b/app/controllers/hiring_staff/sessions_controller.rb
@@ -24,7 +24,7 @@ class HiringStaff::SessionsController < HiringStaff::BaseController
 
   def destroy
     session.destroy
-    redirect_to root_path, notice: I18n.t('access.signed_out')
+    redirect_to root_path, notice: I18n.t('messages.access.signed_out')
   end
 
   private def redirect_to_azure

--- a/spec/features/hiring_staff_can_sign_in.rb
+++ b/spec/features/hiring_staff_can_sign_in.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
-RSpec.feature 'Hiring staff can log in' do
+RSpec.feature 'Hiring staff can sign in' do
   before do
     OmniAuth.config.test_mode = true
   end

--- a/spec/features/hiring_staff_can_sign_out.rb
+++ b/spec/features/hiring_staff_can_sign_out.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+RSpec.feature 'Hiring staff can sign out' do
+  let(:school) { create(:school) }
+
+  scenario 'as an authenticated user' do
+    stub_hiring_staff_auth(urn: school.urn)
+
+    visit root_path
+
+    click_on('School sign out')
+
+    expect(page).to have_content(I18n.t('messages.access.signed_out'))
+  end
+end


### PR DESCRIPTION
* rename tests from 'log in' to 'sign in' to be consistent with the rest of the app and with 'DfE Sign In'