### PR TITLE
(fix) reword salary range hint to not include (£)

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -62,7 +62,7 @@ en:
       headline: 'Sum up the job in a single sentence, which will appear at the top of the listing.'
       description: 'Describe the job, the duties involved and the competencies required by the jobholder.'
       main_subject: 'What subject will the teacher focus on?'
-      salary_range: 'Annual pay before tax (£)'
+      salary_range: 'Annual pay before tax (do not include £ sign)'
       pay_scale: 'What pay scale does the job’s salary fall in?'
       weekly_hours: 'Number of hours to be worked each week'
       start_date: 'For example, 31 9 2018'


### PR DESCRIPTION
Partially addresses this trello card [34-using-in-salary-range-does-not-work](https://trello.com/c/Wza31XO5/)

The purpose for rewording the salary range hint is to help the user avoid errors.
There is a long discussion on the card and asking the user not to put the '£' is a first small step in improving the form.