### PR TITLE
(chore) add rake task to create ES indices

### DIFF
--- a/lib/tasks/elasticsearch.rake
+++ b/lib/tasks/elasticsearch.rake
@@ -1,0 +1,9 @@
+namespace :elasticsearch do
+  desc 'Index vacancies'
+  namespace :vacancies do
+    task index: :environment do
+      Rails.logger.debug("Indexing vacancies in #{Rails.env}")
+      Vacancy.__elasticsearch__.create_index! force: true
+    end
+  end
+end


### PR DESCRIPTION
`rake elastic search:vacancies:index` 