### PR TITLE
(feature): 503 and 502 will be served with a static offline page

### DIFF
--- a/terraform.tf
+++ b/terraform.tf
@@ -47,24 +47,24 @@ module "core" {
 module "ecs" {
   source = "./terraform/modules/ecs"
 
-  environment                                    = "${terraform.workspace}"
-  project_name                                   = "${var.project_name}"
-  region                                         = "${var.region}"
-  ecs_cluster_name                               = "${var.ecs_cluster_name}"
-  ecs_service_name                               = "${var.project_name}_${terraform.workspace}_${var.ecs_service_name}"
-  ecs_service_task_name                          = "${var.project_name}_${terraform.workspace}_${var.ecs_service_task_name}"
-  ecs_service_task_count                         = "${var.ecs_service_task_count}"
-  ecs_service_task_port                          = "${var.ecs_service_task_port}"
-  ecs_service_task_definition_file_path          = "${var.ecs_service_task_definition_file_path}"
-  ecs_service_rake_task_definition_file_path     = "${var.ecs_service_rake_task_definition_file_path}"
+  environment                                = "${terraform.workspace}"
+  project_name                               = "${var.project_name}"
+  region                                     = "${var.region}"
+  ecs_cluster_name                           = "${var.ecs_cluster_name}"
+  ecs_service_name                           = "${var.project_name}_${terraform.workspace}_${var.ecs_service_name}"
+  ecs_service_task_name                      = "${var.project_name}_${terraform.workspace}_${var.ecs_service_task_name}"
+  ecs_service_task_count                     = "${var.ecs_service_task_count}"
+  ecs_service_task_port                      = "${var.ecs_service_task_port}"
+  ecs_service_task_definition_file_path      = "${var.ecs_service_task_definition_file_path}"
+  ecs_service_rake_task_definition_file_path = "${var.ecs_service_rake_task_definition_file_path}"
 
-  import_schools_task_command                    = "${var.import_schools_task_command}"
+  import_schools_task_command = "${var.import_schools_task_command}"
 
-  vacancies_scrape_task_command                  = "${var.vacancies_scrape_task_command}"
-  vacancies_scrape_task_schedule                 = "${var.vacancies_scrape_task_schedule}"
+  vacancies_scrape_task_command  = "${var.vacancies_scrape_task_command}"
+  vacancies_scrape_task_schedule = "${var.vacancies_scrape_task_schedule}"
 
-  sessions_trim_task_command                     = "${var.sessions_trim_task_command}"
-  sessions_trim_task_schedule                    = "${var.sessions_trim_task_schedule}"
+  sessions_trim_task_command  = "${var.sessions_trim_task_command}"
+  sessions_trim_task_schedule = "${var.sessions_trim_task_schedule}"
 
   aws_alb_target_group_arn      = "${module.core.alb_target_group_arn}"
   aws_cloudwatch_log_group_name = "${module.logs.aws_cloudwatch_log_group_name}"
@@ -161,4 +161,6 @@ module "cloudfront" {
   cloudfront_origin_domain_name = "${module.core.alb_dns_name}"
   cloudfront_aliases            = "${var.cloudfront_aliases}"
   cloudfront_certificate_arn    = "${var.cloudfront_certificate_arn}"
+  offline_bucket_domain_name    = "${var.offline_bucket_domain_name}"
+  offline_bucket_origin_path    = "${var.offline_bucket_origin_path}"
 }

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -123,3 +123,21 @@ The `cloudwatch_slack_hook_url` and `cloudwatch_ops_genie_api_key` variables nee
 6. Click 'Save'
 7. Reload the page, and copy both of the (now encrypted) values, and replace `cloudwatch_slack_hook_url` and `cloudwatch_ops_genie_api_key` in your variables file.
 8. Run a terraform plan to ensure everything has been done correctly (You should not have any changes required for the lambda resource)
+
+## Being offline
+
+We are using a combination of AWS CloudFront and S3 to serve users a self-contained static page that can be found here https://github.com/dxw/school-jobs-offline. CloudFront has been configured through Terraform to detect 503 'Service Unavailable' or 502 'Bad Gateway' responses that occur downstream in our stack and will handle those requests by responding with content from the bucket.
+
+This allows for our servers or containers to be turned off intentionally or fail unintentionally whilst ensuring a our service fails gracefully, with expectations set with the user.
+
+If we wished to turn force the service into this offline mode we can set the desired container count to 0 through Terraform.
+
+The way this can fail is that either AWS CloudFront, AWS S3 or our configuration of the 2 becomes non functional. Should AWS experience such a fundamental failure we might consider recovering from that situation by moving the static content to a new provider and updating the DNS.
+
+### Setup
+
+Without this setup, CloudFront will continue to provide generic 503 and 502 pages.
+
+1. Create a new S3 bucket and set the access permissions to public, this value will correspond to: `offline_bucket_domain_name`
+2. Add your static content to a new directory that corresponds to, making sure they are all set to public too: `offline_bucket_origin_path`
+3. The file that will be rendered is currently `index.html`

--- a/terraform/modules/cloudfront/cloudfront.tf
+++ b/terraform/modules/cloudfront/cloudfront.tf
@@ -11,6 +11,25 @@ resource "aws_cloudfront_distribution" "default" {
     }
   }
 
+  origin {
+    domain_name = "${var.offline_bucket_domain_name}"
+    origin_id   = "${var.project_name}-${var.environment}-offline"
+  }
+
+  custom_error_response {
+    error_code            = "503"
+    error_caching_min_ttl = "60"
+    response_code         = "503"
+    response_page_path    = "${var.offline_bucket_origin_path}/index.html"
+  }
+
+  custom_error_response {
+    error_code            = "502"
+    error_caching_min_ttl = "60"
+    response_code         = "502"
+    response_page_path    = "${var.offline_bucket_origin_path}/index.html"
+  }
+
   enabled = true
   aliases = "${var.cloudfront_aliases}"
 
@@ -30,6 +49,28 @@ resource "aws_cloudfront_distribution" "default" {
 
     min_ttl     = 0
     default_ttl = 5
+    max_ttl     = 86400
+
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  cache_behavior {
+    allowed_methods  = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "${var.project_name}-${var.environment}-offline"
+
+    path_pattern = "${var.offline_bucket_origin_path}/*"
+
+    forwarded_values = {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl     = 0
+    default_ttl = 60
     max_ttl     = 86400
 
     viewer_protocol_policy = "redirect-to-https"

--- a/terraform/modules/cloudfront/input.tf
+++ b/terraform/modules/cloudfront/input.tf
@@ -7,3 +7,5 @@ variable "cloudfront_aliases" {
 }
 
 variable "cloudfront_certificate_arn" {}
+variable "offline_bucket_domain_name" {}
+variable "offline_bucket_origin_path" {}

--- a/variables.tf
+++ b/variables.tf
@@ -189,6 +189,9 @@ variable "cloudfront_aliases" {
   type        = "list"
 }
 
+variable "offline_bucket_domain_name" {}
+variable "offline_bucket_origin_path" {}
+
 # Cloudwatch
 variable "cloudwatch_slack_hook_url" {
   description = "The slack hook that cloudwatch alarms are sent to"
@@ -204,6 +207,7 @@ variable "cloudwatch_ops_genie_api_key" {
 
 # Application
 variable "rails_env" {}
+
 variable "override_school_urn" {}
 variable "http_user" {}
 variable "http_pass" {}

--- a/workspace-variables/workspace.tfvars.example
+++ b/workspace-variables/workspace.tfvars.example
@@ -39,6 +39,8 @@ es_version = "6.0"
 # CloudFront
 cloudfront_certificate_arn =
 cloudfront_aliases =
+offline_bucket_domain_name = # "<offline-bucket>.s3.amazonaws.com"
+offline_bucket_origin_path = "/school-jobs-offline"
 
 # CloudWatch
 cloudwatch_slack_hook_url =


### PR DESCRIPTION
* Whenever CloudFront receives a 503 service unavailable or 502 bad gateway from our application or load balancer, it will respond with a different behaviour. Instead of passing up a basic 503 error page it will look to a specified bucket to supply the web page instead. This will enable us to selectively put the site offline by scaling the number of instances or containers down to 0 or go offline automatically if our whole service becomes unavailable.
* https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/custom-error-pages.html

![screen shot 2018-04-16 at 17 25 03](https://user-images.githubusercontent.com/912473/38822364-22d5ff28-419b-11e8-899e-5339ea07f33e.png)
