### PR TITLE
(Feature) change salary fields to strings

### DIFF
--- a/app/form_models/vacancy_form.rb
+++ b/app/form_models/vacancy_form.rb
@@ -3,7 +3,7 @@ class VacancyForm
 
   attr_accessor :vacancy
 
-  delegate *Vacancy.attribute_names.map { |attr| [attr, "#{attr}="] }.flatten, to: :vacancy
+  delegate *Vacancy.attribute_names.map { |attr| [attr, "#{attr}=", "#{attr}?"] }.flatten, to: :vacancy
   delegate :save, to: :vacancy
 
   def initialize(params = {})

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -37,8 +37,8 @@ class Vacancy < ApplicationRecord
     indexes :publish_on, type: :date
     indexes :status, type: :keyword
     indexes :working_pattern, type: :keyword
-    indexes :minimum_salary, type: :integer
-    indexes :maximum_salary, type: :integer
+    indexes :minimum_salary, type: :string
+    indexes :maximum_salary, type: :string
   end
 
   extend FriendlyId

--- a/app/validators/salary_validator.rb
+++ b/app/validators/salary_validator.rb
@@ -1,0 +1,59 @@
+class SalaryValidator < ActiveModel::EachValidator
+  include ApplicationHelper
+  include ActiveSupport::Rescuable
+
+  rescue_from ArgumentError, with: :invalid_format_message
+
+  SALARY_FORMAT = /^\d+\.{0,1}\d{2}{0,1}$/
+  MIN_SALARY_ALLOWED = PayScale.minimum_payscale_salary.freeze
+  MAX_SALARY_ALLOWED = 2147483647
+
+  def validate_each(record, attribute, value)
+    return error_message(record, attribute, cant_be_blank_message) if value.blank? && check_presence?
+    return error_message(record, attribute, invalid_format_message) if value[SALARY_FORMAT].nil?
+
+    salary = converted_salary(value)
+    return error_message(record, attribute, must_be_higher_than_min_allowed_message) if less_than_min_allowed?(salary)
+    return error_message(record, attribute, must_be_less_than_max_salary_message) if salary > MAX_SALARY_ALLOWED
+  end
+
+  private
+
+  def error_message(record, attribute, message)
+    record.errors[attribute] << message
+  end
+
+  def check_presence?
+    options.key?(:presence) && options[:presence]
+  end
+
+  def check_minimum?
+    options.key?(:minimum_value) && options[:minimum_value]
+  end
+
+  def less_than_min_allowed?(value)
+    value < BigDecimal(MIN_SALARY_ALLOWED) if check_minimum?
+  end
+
+  def converted_salary(value)
+    BigDecimal(value)
+  end
+
+  def cant_be_blank_message
+    I18n.t('errors.messages.blank')
+  end
+
+  def invalid_format_message
+    I18n.t('errors.messages.salary.invalid_format')
+  end
+
+  def must_be_less_than_max_salary_message
+    I18n.t('errors.messages.less_than_or_equal_to',
+           count: ActionController::Base.helpers.number_to_currency(MAX_SALARY_ALLOWED))
+  end
+
+  def must_be_higher_than_min_allowed_message
+    I18n.t('errors.messages.salary.lower_than_minimum_payscale',
+           minimum_salary: number_to_currency(MIN_SALARY_ALLOWED))
+  end
+end

--- a/app/views/hiring_staff/vacancies/job_specification/edit.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/edit.html.haml
@@ -37,7 +37,6 @@
         %span.form-hint= t('vacancies.form_hints.salary_range')
 
         = f.input :minimum_salary,
-                  as: :integer,
                   required: true,
                   wrapper: false,
                   label: false,
@@ -46,7 +45,6 @@
         to
 
         = f.input :maximum_salary,
-                  as: :integer,
                   wrapper: false,
                   required: true,
                   label: false,

--- a/app/views/hiring_staff/vacancies/job_specification/new.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/new.html.haml
@@ -39,7 +39,6 @@
         %span.form-hint= t('vacancies.form_hints.salary_range')
 
         = f.input :minimum_salary,
-                  as: :integer,
                   required: true,
                   wrapper: false,
                   label: false,
@@ -48,7 +47,6 @@
         to
 
         = f.input :maximum_salary,
-                  as: :integer,
                   wrapper: false,
                   required: true,
                   label: false,

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -6,6 +6,10 @@ en:
       too_long:
         other: is too long (maximum is %{count} characters)
       less_than_or_equal_to: must be less than or equal to %{count}
+      blank: can't be blank
+      salary:
+        invalid_format: please enter a valid salary
+        lower_than_minimum_payscale: must be at least equal to the minimum pay range of %{minimum_salary}
   activerecord:
     errors:
       models:
@@ -18,7 +22,6 @@ en:
             minimum_salary:
               blank: can't be blank
               greater_than_maximum_salary: must be lower than the maximum salary
-              lower_than_minimum_payscale: must be at least equal to the minimum pay range of %{minimum_salary}
             working_pattern:
               blank: can't be blank
             experience:

--- a/db/migrate/20180416124318_change_minimum_and_maximum_salary_to_strings.rb
+++ b/db/migrate/20180416124318_change_minimum_and_maximum_salary_to_strings.rb
@@ -1,0 +1,6 @@
+class ChangeMinimumAndMaximumSalaryToStrings < ActiveRecord::Migration[5.1]
+  def change
+    change_column :vacancies, :minimum_salary, :string
+    change_column :vacancies, :maximum_salary, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180413100631) do
+ActiveRecord::Schema.define(version: 20180416124318) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -113,8 +113,8 @@ ActiveRecord::Schema.define(version: 20180413100631) do
     t.string "job_title", null: false
     t.string "slug", null: false
     t.text "job_description", null: false
-    t.integer "minimum_salary", null: false
-    t.integer "maximum_salary"
+    t.string "minimum_salary", null: false
+    t.string "maximum_salary"
     t.text "benefits"
     t.integer "working_pattern"
     t.float "full_time_equivalent"

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -14,8 +14,8 @@ FactoryGirl.define do
     status { :published }
     expires_on { Faker::Time.forward(14) }
     publish_on { Time.zone.today }
-    minimum_salary { Faker::Number.number(5) }
-    maximum_salary { Faker::Number.number(6) }
+    minimum_salary { SalaryValidator::MIN_SALARY_ALLOWED }
+    maximum_salary { SalaryValidator::MAX_SALARY_ALLOWED }
     contact_email { Faker::Internet.email }
     application_link { Faker::Internet.url }
     weekly_hours '8.5'
@@ -35,8 +35,8 @@ FactoryGirl.define do
       experience { Faker::Lorem.characters(1010) }
       education { Faker::Lorem.characters(1005) }
       qualifications { Faker::Lorem.characters(1002) }
-      minimum_salary { Vacancy::MAX_INTEGER + 10 }
-      maximum_salary { Vacancy::MAX_INTEGER + 10 }
+      minimum_salary { (SalaryValidator::MAX_SALARY_ALLOWED + 100) }
+      maximum_salary { SalaryValidator::MAX_SALARY_ALLOWED + 100 }
     end
 
     trait :complete do

--- a/spec/form_models/job_specification_form_spec.rb
+++ b/spec/form_models/job_specification_form_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe JobSpecificationForm, type: :model do
         end
 
         it 'the minimum salary should be at least equal to the minimum payscale value' do
-          create(:pay_scale, salary: 3000)
+          stub_const('SalaryValidator::MIN_SALARY_ALLOWED', '3000')
           expect(job_specification.valid?). to be false
           expect(job_specification.errors.messages[:minimum_salary][0])
             . to eq('must be at least equal to the minimum pay range of £3,000')
@@ -57,8 +57,8 @@ RSpec.describe JobSpecificationForm, type: :model do
       expect(job_specification_form.vacancy.job_title).to eq('English Teacher')
       expect(job_specification_form.vacancy.job_description).to eq('description')
       expect(job_specification_form.vacancy.working_pattern).to eq('full_time')
-      expect(job_specification_form.vacancy.minimum_salary).to eq(20000)
-      expect(job_specification_form.vacancy.maximum_salary).to eq(40000)
+      expect(job_specification_form.vacancy.minimum_salary).to eq('20000')
+      expect(job_specification_form.vacancy.maximum_salary).to eq('40000')
       expect(job_specification_form.vacancy.benefits).to eq('benefits')
       expect(job_specification_form.vacancy.pay_scale.label).to eq(payscale.label)
       expect(job_specification_form.vacancy.subject.name).to eq(main_subject.name)

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -114,6 +114,48 @@ RSpec.describe Vacancy, type: :model do
       end
     end
 
+    context '#minimum_salary' do
+      it 'does not allow the pound sign' do
+        vacancy = build(:vacancy, minimum_salary: '£123.33')
+        vacancy.valid?
+
+        expect(vacancy.errors.messages[:minimum_salary].first).to eq(I18n.t('errors.messages.salary.invalid_format'))
+      end
+
+      it 'does not allow commas' do
+        vacancy = build(:vacancy, minimum_salary: '300,33')
+        vacancy.valid?
+
+        expect(vacancy.errors.messages[:minimum_salary].first).to eq(I18n.t('errors.messages.salary.invalid_format'))
+      end
+
+      it 'does not allow fullstops if the decimal separation point is wrong' do
+        vacancy = build(:vacancy, minimum_salary: '300.330')
+        vacancy.valid?
+
+        expect(vacancy.errors.messages[:minimum_salary].first).to eq(I18n.t('errors.messages.salary.invalid_format'))
+      end
+
+      it 'does not allow any non numeric characters' do
+        vacancy = build(:vacancy, minimum_salary: 'A300330')
+        vacancy.valid?
+
+        expect(vacancy.errors.messages[:minimum_salary].first).to eq(I18n.t('errors.messages.salary.invalid_format'))
+      end
+
+      it 'allows fullstops if the decimal separation point is correct' do
+        vacancy = build(:vacancy, minimum_salary: '30000.50')
+
+        expect(vacancy).to be_valid
+      end
+
+      it 'accepts integer numbers' do
+        vacancy = build(:vacancy, minimum_salary: '45000')
+
+        expect(vacancy).to be_valid
+      end
+    end
+
     context 'a record saved with job spec and candidate spec details, ' \
       'and empty contact_email' do
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -27,6 +27,10 @@ RSpec.configure do |config|
     DatabaseCleaner.clean_with(:truncation)
   end
 
+  config.before do
+    stub_const('SalaryValidator::MIN_SALARY_ALLOWED', '1')
+  end
+
   config.before(:each) do
     DatabaseCleaner.strategy = :transaction
   end

--- a/spec/validators/salary_validator_spec.rb
+++ b/spec/validators/salary_validator_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe SalaryValidator do
+  describe '#validates_each(record, attribute, value)' do
+    let(:model)  do
+      class TestModel
+        include ActiveModel::Validations
+
+        attr_accessor :amount
+        validates :amount, salary: { presence: true, minimum_value: true }
+      end
+      TestModel.new
+    end
+
+    it 'validates the salary format' do
+      model.amount = '$12.23'
+      model.valid?
+
+      expect(model.errors[:amount].first).to eq(I18n.t('errors.messages.salary.invalid_format'))
+    end
+
+    it 'validates the salary format' do
+      model.amount = '$12.23'
+      model.valid?
+
+      expect(model.errors[:amount].first).to eq(I18n.t('errors.messages.salary.invalid_format'))
+    end
+
+    context 'optional checks' do
+      context 'if presence: true' do
+        it 'validates that the value is not blank' do
+          model.amount = nil
+          model.valid?
+
+          expect(model.errors[:amount].first).to eq(I18n.t('errors.messages.blank'))
+        end
+      end
+
+      context 'if minimum_value: true' do
+        it 'validates that the value is not less than the minimum allowed' do
+          stub_const('SalaryValidator::MIN_SALARY_ALLOWED', '400')
+
+          model.amount = '12.23'
+          model.valid?
+
+          expect(model.errors[:amount].first).to eq(I18n.t('errors.messages.salary.lower_than_minimum_payscale',
+                                                           minimum_salary: '£400'))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- implemented `SalaryValidator` - checks for
  - blank?
  - format `/^\d+\.{0,1}\d{2}{0,1}$/` should match XX or X*.XX
  - minimum_allowed
  - maximum_allowed

- extended `VacancyForm` to delegate `=` attributes so validation conditions can be simplified
- extract min and max allowed salaries to constants