### PR TITLE
Feature/79 add temporary support link to footer of front page

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -39,4 +39,10 @@
         %span= msg
     = yield
 
+- content_for :footer_top do
+  %p
+    Problems using this service? Email
+    =mail_to 'isobel.croot@digital.education.gov.uk'
+    for support.
+
 = render file: 'layouts/govuk_template'

--- a/app/views/shared/_beta_banner.html.haml
+++ b/app/views/shared/_beta_banner.html.haml
@@ -1,0 +1,6 @@
+.flash.notice
+  .small This service is still in development, so for now only lists jobs in select schools in Cambridgeshire and the North East. When it launches, the full service will list jobs in schools throughout England.
+  .small
+    Interested in listing jobs at your school? Email
+    =mail_to 'isobel.croot@digital.education.gov.uk'
+    for more information.

--- a/app/views/vacancies/index.html.haml
+++ b/app/views/vacancies/index.html.haml
@@ -1,3 +1,5 @@
+= render partial: 'shared/beta_banner'
+
 %h1.heading-large
   = pluralize_vacancy_count(@vacancy_count, 'vacancies.vacancy_count')
 .grid-row

--- a/app/views/vacancies/show.html.haml
+++ b/app/views/vacancies/show.html.haml
@@ -1,3 +1,4 @@
+=render partial: 'shared/beta_banner'
 =render partial: 'vacancies/show'
 
 %script.jobref{type: 'application/ld+json'}


### PR DESCRIPTION
<img width="1123" alt="screen shot 2018-04-17 at 17 31 58" src="https://user-images.githubusercontent.com/822507/38883574-45577d18-4265-11e8-957c-b1d0164ceb07.png">
