### PR TITLE
(fix): Application links are always external

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem 'uglifier', '>= 1.3.0'
 gem 'turbolinks', '~> 5'
 gem 'jquery-rails'
 gem 'jbuilder', '~> 2.5'
+gem 'addressable'
 
 gem 'omniauth'
 gem 'omniauth-azure-activedirectory'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -372,6 +372,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-session_store
+  addressable
   breasal (~> 0.0.1)
   byebug
   capybara (~> 2.13)

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -88,6 +88,13 @@ class Vacancy < ApplicationRecord
     save(validate: false)
   end
 
+  def application_link=(value)
+    # Data may not include a scheme/protocol so we must be careful when creating
+    # links that Rails doesn't make them incorrectly relative.
+    value = Addressable::URI.heuristic_parse(value).to_s
+    super(value)
+  end
+
   private
 
   def slug_candidates

--- a/spec/features/job_seekers_can_apply_for_a_vacancy_spec.rb
+++ b/spec/features/job_seekers_can_apply_for_a_vacancy_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.feature 'Job seekers can apply for a vacancy' do
+  scenario 'the application link is without protocol' do
+    vacancy = create(:vacancy, :published, application_link: 'www.google.com')
+
+    visit vacancy_path(vacancy.id)
+
+    expect(page).to have_link(I18n.t('vacancies.apply', href: 'http://www.google.com'))
+  end
+end

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -229,4 +229,25 @@ RSpec.describe Vacancy, type: :model do
       expect(vacancy.school_name).to eq('St James School')
     end
   end
+
+  describe '#application_link' do
+    it 'returns the url' do
+      vacancy = create(:vacancy, application_link: 'https://example.com')
+      expect(vacancy.application_link).to eql('https://example.com')
+    end
+
+    context 'when a protocol was not provided' do
+      it 'returns an absolute url with `http` as the protocol' do
+        vacancy = create(:vacancy, application_link: 'example.com')
+        expect(vacancy.application_link).to eql('http://example.com')
+      end
+    end
+
+    context 'when only the `www` sub domain was provided' do
+      it 'returns an absolute url with `http` as the protocol' do
+        vacancy = create(:vacancy, application_link: 'www.example.com')
+        expect(vacancy.application_link).to eql('http://www.example.com')
+      end
+    end
+  end
 end


### PR DESCRIPTION
* Before this change you had to input link text with a protocol eg ‘https://’ for them to be clickable. Without this they are internal links eg tvs.testing.dxw.net/www.foo.bar.