### PR TITLE
[83]  Error pages are shown when errors are caused by SSO

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,4 +1,7 @@
 class ErrorsController < ApplicationController
+  skip_before_action :verify_authenticity_token,
+                     only: %i[not_found unprocessable_entity internal_server_error]
+
   def not_found
     respond_to do |format|
       format.html { render status: 404 }


### PR DESCRIPTION
* When a request comes in from another source that raises an error, eg. SSO, then currently the application does not provide a 500 page and the request results in an unstyled browser 500.
* Replicate by signing in and then visiting https://tvs.edge.dxw.net/auth/azureactivedirectory/callback directly

Before:
![screen shot 2018-04-18 at 11 33 10](https://user-images.githubusercontent.com/912473/38927842-e3ffa67c-42fe-11e8-846d-649759912c6f.png)

After:
![screen shot 2018-04-18 at 11 44 12](https://user-images.githubusercontent.com/912473/38927851-e7ee1ae8-42fe-11e8-9122-2059e836f0ce.png)
