### PR TITLE
[69] Sanitise job seeker search inputs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'turbolinks', '~> 5'
 gem 'jquery-rails'
 gem 'jbuilder', '~> 2.5'
 gem 'addressable'
+gem 'sanitize', '~> 4.6'
 
 gem 'omniauth'
 gem 'omniauth-azure-activedirectory'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,6 +205,8 @@ GEM
     nio4r (2.1.0)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
+    nokogumbo (1.5.0)
+      nokogiri
     omniauth (1.8.1)
       hashie (>= 3.4.6, < 3.6.0)
       rack (>= 1.6.2, < 3)
@@ -308,6 +310,10 @@ GEM
     ruby_parser (3.10.1)
       sexp_processor (~> 4.9)
     safe_yaml (1.0.4)
+    sanitize (4.6.4)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.4.4)
+      nokogumbo (~> 1.4)
     sass (3.5.1)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -412,6 +418,7 @@ DEPENDENCIES
   rspec-collection_matchers
   rspec-rails
   rubocop
+  sanitize (~> 4.6)
   sass-rails (~> 5.0)
   shoulda-matchers!
   simple_form

--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -22,11 +22,44 @@ class VacanciesController < ApplicationController
     params[:page]
   end
 
+  helper_method :location
+  private def location
+    params[:location]
+  end
+
+  helper_method :keyword
+  private def keyword
+    params[:keyword]
+  end
+
+  helper_method :minimum_salary
+  private def minimum_salary
+    params[:minimum_salary]
+  end
+
+  helper_method :maximum_salary
+  private def maximum_salary
+    params[:maximum_salary]
+  end
+
+  helper_method :working_pattern
+  private def working_pattern
+    params[:working_pattern]
+  end
+
+  helper_method :phase
+  private def phase
+    params[:phase]
+  end
+
+  helper_method :sort_column
   private def sort_column
     params[:sort_column]
   end
 
+  helper_method :sort_order
   private def sort_order
     params[:sort_order]
   end
+
 end

--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -2,7 +2,7 @@ class VacanciesController < ApplicationController
   helper_method :sort_order, :sort_column
 
   def index
-    @filters = VacancyFilters.new(params)
+    @filters = VacancyFilters.new(sanitised_params)
     @sort = VacancySort.new(default_column: 'expires_on', default_order: 'asc')
                        .update(column: sort_column, order: sort_order)
     records = Vacancy.public_search(filters: @filters, sort: @sort).records
@@ -10,15 +10,23 @@ class VacanciesController < ApplicationController
   end
 
   def show
-    vacancy = Vacancy.published.friendly.find(params[:id])
+    vacancy = Vacancy.published.friendly.find(id)
     @vacancy = VacancyPresenter.new(vacancy)
   end
 
-  def sort_column
+  private def id
+    params[:id]
+  end
+
+  private def page
+    params[:page]
+  end
+
+  private def sort_column
     params[:sort_column]
   end
 
-  def sort_order
+  private def sort_order
     params[:sort_order]
   end
 end

--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -1,8 +1,15 @@
 class VacanciesController < ApplicationController
-  helper_method :sort_order, :sort_column
+  helper_method :location,
+                :keyword,
+                :minimum_salary,
+                :maximum_salary,
+                :working_pattern,
+                :phase,
+                :sort_column,
+                :sort_order
 
   def index
-    @filters = VacancyFilters.new(sanitised_params)
+    @filters = VacancyFilters.new(search_params)
     @sort = VacancySort.new(default_column: 'expires_on', default_order: 'asc')
                        .update(column: sort_column, order: sort_order)
     records = Vacancy.public_search(filters: @filters, sort: @sort).records
@@ -14,52 +21,56 @@ class VacanciesController < ApplicationController
     @vacancy = VacancyPresenter.new(vacancy)
   end
 
-  private def id
+  def params
+    sanitised_params = super.each_pair do |key, value|
+      super[key] = Sanitize.fragment(value)
+    end
+    ActionController::Parameters.new(sanitised_params)
+  end
+
+  private
+
+  def search_params
+    params.permit(:keyword, :location, :minimum_salary, :maximum_salary, :phase, :phase, :working_pattern).to_hash
+  end
+
+  def id
     params[:id]
   end
 
-  private def page
+  def page
     params[:page]
   end
 
-  helper_method :location
-  private def location
+  def location
     params[:location]
   end
 
-  helper_method :keyword
-  private def keyword
+  def keyword
     params[:keyword]
   end
 
-  helper_method :minimum_salary
-  private def minimum_salary
+  def minimum_salary
     params[:minimum_salary]
   end
 
-  helper_method :maximum_salary
-  private def maximum_salary
+  def maximum_salary
     params[:maximum_salary]
   end
 
-  helper_method :working_pattern
-  private def working_pattern
+  def working_pattern
     params[:working_pattern]
   end
 
-  helper_method :phase
-  private def phase
+  def phase
     params[:phase]
   end
 
-  helper_method :sort_column
-  private def sort_column
+  def sort_column
     params[:sort_column]
   end
 
-  helper_method :sort_order
-  private def sort_order
+  def sort_order
     params[:sort_order]
   end
-
 end

--- a/app/models/vacancy_filters.rb
+++ b/app/models/vacancy_filters.rb
@@ -1,13 +1,15 @@
 class VacancyFilters
   attr_reader :location, :keyword, :minimum_salary, :maximum_salary, :working_pattern, :phase
 
-  def initialize(params)
-    @location = params[:location]
-    @keyword = params[:keyword]
-    @minimum_salary = params[:minimum_salary]
-    @maximum_salary = params[:maximum_salary]
-    @working_pattern = extract_working_pattern(params)
-    @phase = School.phases.include?(params[:phase]) ? params[:phase] : nil
+  def initialize(args)
+    args = ActiveSupport::HashWithIndifferentAccess.new(args)
+
+    @location = args[:location]
+    @keyword = args[:keyword]
+    @minimum_salary = args[:minimum_salary]
+    @maximum_salary = args[:maximum_salary]
+    @working_pattern = extract_working_pattern(args)
+    @phase = School.phases.include?(args[:phase]) ? args[:phase] : nil
   end
 
   private

--- a/app/views/vacancies/_filters.html.haml
+++ b/app/views/vacancies/_filters.html.haml
@@ -5,22 +5,22 @@
   = form_tag vacancies_path, class: 'filters-form', method: :get do
     .form-group
       = label_tag 'location', t('vacancies.filters.location'), class: 'form-label'
-      = search_field_tag :location, params[:location], class: 'form-control form-control-block', placeholder: t('vacancies.filters.location_hint')
+      = search_field_tag :location, location, class: 'form-control form-control-block', placeholder: t('vacancies.filters.location_hint')
     .form-group
       = label_tag 'keyword', t('vacancies.filters.keyword'), class: 'form-label'
-      = search_field_tag :keyword, params[:keyword], class: 'form-control form-control-block', placeholder: t('vacancies.filters.keyword_hint')
+      = search_field_tag :keyword, keyword, class: 'form-control form-control-block', placeholder: t('vacancies.filters.keyword_hint')
     .form-group
       = label_tag 'minimum_salary', t('vacancies.filters.minimum_salary'), class: 'form-label'
-      = select_tag 'minimum_salary', options_for_select(salary_options, params[:minimum_salary]), class: 'form-control form-control-block', include_blank: 'None'
+      = select_tag 'minimum_salary', options_for_select(salary_options, minimum_salary), class: 'form-control form-control-block', include_blank: 'None'
     .form-group
       = label_tag 'maximum_salary', t('vacancies.filters.maximum_salary'), class: 'form-label'
-      = select_tag 'maximum_salary', options_for_select(salary_options, params[:maximum_salary]), class: 'form-control form-control-block', include_blank: 'None'
+      = select_tag 'maximum_salary', options_for_select(salary_options, maximum_salary), class: 'form-control form-control-block', include_blank: 'None'
     .form-group
       = label_tag 'working_pattern', t('vacancies.filters.working_pattern'), class: 'form-label'
-      = select_tag 'working_pattern', options_for_select(working_pattern_options, params[:working_pattern]), class: 'form-control form-control-block', include_blank: 'Any'
+      = select_tag 'working_pattern', options_for_select(working_pattern_options, working_pattern), class: 'form-control form-control-block', include_blank: 'Any'
     .form-group
       = label_tag 'phase', t('vacancies.filters.education_phase'), class: 'form-label'
-      = select_tag 'phase', options_for_select(school_phase_options, params[:phase]), class: 'form-control form-control-block', include_blank: 'Any'
+      = select_tag 'phase', options_for_select(school_phase_options, phase), class: 'form-control form-control-block', include_blank: 'Any'
 
     = hidden_field_tag :sort_column, sort_column
     = hidden_field_tag :sort_order, sort_order


### PR DESCRIPTION
* stop accessing `params` directly from the views