### PR TITLE
(chore): Allow new containers 30 seconds to become healthy

### DIFF
--- a/terraform/modules/ecs/ecs.tf
+++ b/terraform/modules/ecs/ecs.tf
@@ -23,6 +23,7 @@ resource "aws_ecs_service" "web" {
   desired_count   = "${var.ecs_service_task_count}"
 
   deployment_minimum_healthy_percent = 50
+  health_check_grace_period_seconds = 30
 
   load_balancer {
     target_group_arn = "${var.aws_alb_target_group_arn}"


### PR DESCRIPTION
* ALB is marking new containers as unhealthy before ECS has finished starting them up. So that they have enough time to get settled before being wrongly removed, they have 30 seconds to get ready.
* We hope this will address an issue we've seen where resources start getting consumed as ECS continuously restarts unhealthy containers but because they are restarting, the resource usage goes up and trips the auto scaling!
