### PR TITLE
[34] Salary input works in FireFox

### DIFF
--- a/app/assets/stylesheets/base/_mixins.scss
+++ b/app/assets/stylesheets/base/_mixins.scss
@@ -15,3 +15,11 @@
 @function shade($color, $percentage) {
   @return mix(black, $color, $percentage);
 }
+
+@mixin clearfix {
+  &::after {
+    clear: both;
+    content: "";
+    display: block;
+  }
+}

--- a/app/assets/stylesheets/components/vacancy-form.scss
+++ b/app/assets/stylesheets/components/vacancy-form.scss
@@ -1,10 +1,25 @@
 .vacancy-form {
-  
+
   .form-control {
     width: 100%;
     &.text {
       max-width: 100%;
     }
   }
+
+  .salary_field {
+    @include clearfix;
+    position: relative;
+    .pound_sign {
+      position: absolute;
+        bottom: 6px;
+        left: 8px;
+    }
+    #job_specification_form_minimum_salary,
+    #job_specification_form_maximum_salary {
+      padding-left: 18px;
+    }
+  }
+
 
 }

--- a/app/models/concerns/vacancy_job_specification_validations.rb
+++ b/app/models/concerns/vacancy_job_specification_validations.rb
@@ -12,7 +12,9 @@ module VacancyJobSpecificationValidations
               numericality: {
                 less_than_or_equal_to: MAX_INTEGER,
                 message: I18n.t('errors.messages.less_than_or_equal_to',
-                                count: ActionController::Base.helpers.number_to_currency(MAX_INTEGER))
+                                count: ActionController::Base.helpers.number_to_currency(MAX_INTEGER,
+                                                                                         separator: '.',
+                                                                                         delimiter: ''))
               },
               if: proc { |model| model.minimum_salary.present? }
 
@@ -20,7 +22,9 @@ module VacancyJobSpecificationValidations
               numericality: {
                 less_than_or_equal_to: MAX_INTEGER,
                 message: I18n.t('errors.messages.less_than_or_equal_to',
-                                count: ActionController::Base.helpers.number_to_currency(MAX_INTEGER))
+                                count: ActionController::Base.helpers.number_to_currency(MAX_INTEGER,
+                                                                                         separator: '.',
+                                                                                         delimiter: ''))
               },
               if: proc { |model| model.maximum_salary.present? }
 

--- a/app/views/hiring_staff/vacancies/job_specification/edit.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/edit.html.haml
@@ -43,7 +43,7 @@
                     required: true,
                     wrapper: false,
                     label: false,
-                    input_html: {class: 'form-control-1-8'}
+                    input_html: { class: 'form-control-1-8', step: '100', min: '1000', max: '1000000', onchange: "this.value = this.value.replace(/,/g, '')" }
 
         to
 
@@ -54,7 +54,7 @@
                     wrapper: false,
                     required: true,
                     label: false,
-                    input_html: {class: 'form-control-1-8'}
+                    input_html: { class: 'form-control-1-8', step: '100', min: '1000', max: '1000000', onchange: "this.value = this.value.replace(/,/g, '')" }
 
       = f.input :pay_scale_id,
                   label: t('vacancies.pay_scale'),

--- a/app/views/hiring_staff/vacancies/job_specification/edit.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/edit.html.haml
@@ -36,21 +36,25 @@
         %label.form-label.form-label-bold= t('vacancies.salary_range')
         %span.form-hint= t('vacancies.form_hints.salary_range')
 
-        = f.input :minimum_salary,
-                  as: :integer,
-                  required: true,
-                  wrapper: false,
-                  label: false,
-                  input_html: {class: 'form-control-1-8'}
+        .salary_field
+          %span.pound_sign £
+          = f.input :minimum_salary,
+                    as: :integer,
+                    required: true,
+                    wrapper: false,
+                    label: false,
+                    input_html: {class: 'form-control-1-8'}
 
         to
 
-        = f.input :maximum_salary,
-                  as: :integer,
-                  wrapper: false,
-                  required: true,
-                  label: false,
-                  input_html: {class: 'form-control-1-8'}
+        .salary_field
+          %span.pound_sign £
+          = f.input :maximum_salary,
+                    as: :integer,
+                    wrapper: false,
+                    required: true,
+                    label: false,
+                    input_html: {class: 'form-control-1-8'}
 
       = f.input :pay_scale_id,
                   label: t('vacancies.pay_scale'),

--- a/app/views/hiring_staff/vacancies/job_specification/new.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/new.html.haml
@@ -40,10 +40,10 @@
 
         = f.input :minimum_salary,
                   as: :integer,
-                  required: true,
                   wrapper: false,
+                  required: true,
                   label: false,
-                  input_html: {class: 'form-control-1-8'}
+                  input_html: { class: 'form-control-1-8', step: '100', min: '1000', max: '1000000' }
 
         to
 
@@ -52,7 +52,7 @@
                   wrapper: false,
                   required: true,
                   label: false,
-                  input_html: {class: 'form-control-1-8'}
+                  input_html: { class: 'form-control-1-8', step: '100', min: '1000', max: '1000000' }
 
       = f.input :pay_scale_id,
                   label: t('vacancies.pay_scale'),

--- a/app/views/hiring_staff/vacancies/job_specification/new.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/new.html.haml
@@ -38,21 +38,25 @@
         %label.form-label.form-label-bold= t('vacancies.salary_range')
         %span.form-hint= t('vacancies.form_hints.salary_range')
 
-        = f.input :minimum_salary,
-                  as: :integer,
-                  wrapper: false,
-                  required: true,
-                  label: false,
-                  input_html: { class: 'form-control-1-8', step: '100', min: '1000', max: '1000000' }
+        .salary_field
+          %span.pound_sign £
+          = f.input :minimum_salary,
+                    as: :integer,
+                    wrapper: false,
+                    required: true,
+                    label: false,
+                    input_html: { class: 'form-control-1-8', step: '100', min: '1000', max: '1000000' }
 
         to
 
-        = f.input :maximum_salary,
-                  as: :integer,
-                  wrapper: false,
-                  required: true,
-                  label: false,
-                  input_html: { class: 'form-control-1-8', step: '100', min: '1000', max: '1000000' }
+        .salary_field
+          %span.pound_sign £
+          = f.input :maximum_salary,
+                    as: :integer,
+                    wrapper: false,
+                    required: true,
+                    label: false,
+                    input_html: { class: 'form-control-1-8', step: '100', min: '1000', max: '1000000' }
 
       = f.input :pay_scale_id,
                   label: t('vacancies.pay_scale'),

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -121,7 +121,7 @@ SimpleForm.setup do |config|
   # in this configuration, which is recommended due to some quirks from different browsers.
   # To stop SimpleForm from generating the novalidate option, enabling the HTML5 validations,
   # change this configuration to true.
-  config.browser_validations = false
+  config.browser_validations = true
 
   # Collection of methods to detect if a file type was given.
   # config.file_methods = [ :mounted_as, :file?, :public_filename ]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -67,7 +67,7 @@ en:
       job_title: "For secondary school roles include subject to be taught and, if applicable, level of seniority ('Subject leader for Science', for example)."
       description: 'Describe the job, the duties involved and the competencies required by the jobholder.'
       main_subject: 'What subject will the teacher focus on?'
-      salary_range: 'Annual pay before tax (do not include £ sign)'
+      salary_range: 'Annual pay before tax. No commas or decimal points, for example 30000'
       pay_scale: 'What pay scale does the job’s salary fall in?'
       weekly_hours: 'Number of hours to be worked each week'
       start_date: 'For example, %{date}'

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -105,12 +105,12 @@ RSpec.describe Vacancy, type: :model do
 
       it '#minimum_salary' do
         expect(subject.errors.messages[:minimum_salary].first)
-          .to eq('must be less than or equal to £2,147,483,647.00')
+          .to eq('must be less than or equal to £2147483647.00')
       end
 
       it '#maximum_salary' do
         expect(subject.errors.messages[:maximum_salary].first)
-          .to eq('must be less than or equal to £2,147,483,647.00')
+          .to eq('must be less than or equal to £2147483647.00')
       end
     end
 


### PR DESCRIPTION
I've added the markup and CSS (and updated hint text) to show a `£` in front of values for salary number inputs. 

<img width="530" alt="screen shot 2018-04-23 at 14 59 08" src="https://user-images.githubusercontent.com/822507/39132159-11b75ab6-4709-11e8-8ef8-552125123cfc.png">


There are some cross-browser issues to chew over.

Windows:

- IE8-11: strip anything that isn’t a number. Commas truncate the number, i.e. 50,000 is taken as 50
- FF (latest): any non-numerical input triggers native validation. Accepts and strips commas.
- Chrome (latest): prohibits non-numerical characters and triggers native validation. Doesn’t allow commas to be typed.

Mac:

- Safari (latest): any non-numerical input triggers native validation. Commas trigger native validations.
- FF (latest): any non-numerical input triggers native validation. Accepts and strips commas.
- Chrome (latest): prohibits non-numerical characters and triggers native validation. Doesn’t allow commas to be typed.

I'd say the biggest issue is IE8 truncating numbers with a comma. Though there's hint text to try and avoid the scenario, it's still far from ideal. Especially as the validation error figure has a comma in it:
<img width="523" alt="screen shot 2018-04-23 at 15 05 56" src="https://user-images.githubusercontent.com/822507/39132242-4d46300c-4709-11e8-90c5-4c85a89622ac.png">

All thoughts welcome!

