### PR TITLE
Chore/docker disk usage

### DIFF
--- a/bin/drebuild
+++ b/bin/drebuild
@@ -3,13 +3,13 @@
 echo "Remove all unused images before we build new ones…"
 docker image prune -f
 
-echo "Rebuiling the test server…"
+echo "Rebuilding the test server…"
 docker-compose --file=docker-compose.test.yml down -v --remove-orphans
 docker-compose --file=docker-compose.test.yml build
 bin/dtest-server
 echo "Rebuilt and started the testing server for TVS."
 
-echo "Rebuiling the web server…"
+echo "Rebuilding the web server…"
 docker-compose down -v --remove-orphans
 docker-compose build
 docker-compose run --rm web rake db:seed

--- a/bin/drebuild
+++ b/bin/drebuild
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+echo "Remove all unused images before we build new ones…"
+docker image prune -f
+
 echo "Rebuiling the test server…"
 docker-compose --file=docker-compose.test.yml down -v --remove-orphans
 docker-compose --file=docker-compose.test.yml build


### PR DESCRIPTION
* This should combat the incremental disk usage seen whenever we run this script it will leave old and untagged images in its wake. Some of these are gigabytes or more each.
* This change does remove any image on the host machine not just this project.. that said all images can be rebuilt so there is no inherent value in keeping them which is handy because I cannot selectively remove images because by their nature, they’re unsued and untagged! https://docs.docker.com/engine/reference/commandline/image_prune/