### PR TITLE
(fix): bin/dspec can run after Docker update

### DIFF
--- a/bin/dspec
+++ b/bin/dspec
@@ -4,8 +4,8 @@ set -e
 if [ $# -eq 0 ]
 then
   echo "No arguments supplied. Defaults to 'rake default'"
-  docker exec -it teachervacancyservice_test_1 rake default $@
+  docker exec -it teacher-vacancy-service_test_1 rake default $@
 else
   echo "Testing: $@"
-  docker exec -it teachervacancyservice_test_1 rspec $@
+  docker exec -it teacher-vacancy-service_test_1 rspec $@
 fi


### PR DESCRIPTION
* Missed as part of https://github.com/dxw/teacher-vacancy-service/pull/166 which fixed this issue for bin/drebuild