### PR TITLE
(chore) hint text for educational requirements

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -77,7 +77,7 @@ en:
       weekly_hours: 'Number of hours to be worked each week'
       start_date: 'For example, %{date}'
       end_date: 'For example, %{date}'
-      education: 'Degree or certificate needed for the role'
+      education: 'Educational background needed for the position'
       qualifications: 'Specific qualifications required for this role'
       experience: 'Expected teaching or other experience'
       deadline_date: 'For example, %{date}'


### PR DESCRIPTION
to be closer to the job posting schema definition re: 'background'

**'Educational background needed for the position.'**

Hypothesis: this will help users distinguish between the qualification and educational requirements fields

before:
<img width="539" alt="before" src="https://user-images.githubusercontent.com/822507/39516993-79ffbf7a-4df6-11e8-8125-e5c8e8ef55cd.png">

after:
<img width="523" alt="after" src="https://user-images.githubusercontent.com/822507/39517003-7daaa7d4-4df6-11e8-9fc9-f8c900f77655.png">

