### PR TITLE
(chore) rename candidate spec ‘experience’ field

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -27,7 +27,7 @@ en:
     description: 'Job description'
     education: 'Essential educational requirements'
     qualifications: 'Essential qualifications'
-    experience: 'Essential experience'
+    experience: 'Essential skills and experience'
     benefits: 'Benefits'
     weekly_hours: 'Weekly hours'
     ref_no: 'Reference number'


### PR DESCRIPTION
rename to 'essential skills and experience' and revise hint text to be more descriptive and better aligned to the job posting schema definition: 'Description of skills and experience needed for the position.'

Hypothesis: this will help users identify what to bring across from existing job descriptions or listings

before:
<img width="516" alt="before" src="https://user-images.githubusercontent.com/822507/39517484-df19ed3a-4df7-11e8-90db-232f7f824ee9.png">

after (hiring staff):
<img width="505" alt="after hiring staff" src="https://user-images.githubusercontent.com/822507/39517488-e299e26c-4df7-11e8-8172-0c54d5e5ffa1.png">

after (job seekers):
<img width="1001" alt="after job seekers" src="https://user-images.githubusercontent.com/822507/39517506-e51f97a2-4df7-11e8-93e4-b9c60ba3338f.png">
