### PR TITLE
(Fix) Provide correct log group to lambda policy

### DIFF
--- a/terraform/modules/cloudwatch/cloudwatch.tf
+++ b/terraform/modules/cloudwatch/cloudwatch.tf
@@ -13,7 +13,7 @@ resource "aws_kms_alias" "lambda" {
 }
 
 resource "aws_cloudwatch_log_group" "cloudwatch_lambda_log_group" {
-  name = "${var.project_name}-${var.environment}-cloudwatch_to_slack_opsgenie"
+  name = "/aws/lambda/${var.project_name}-${var.environment}-cloudwatch_to_slack_opsgenie"
 }
 
 resource "aws_iam_role" "slack_lambda_role" {


### PR DESCRIPTION
* The log group for lambda functions need to be prefixed with
`/aws/lambda/`