### PR TITLE
(chore) job spec number field JS consistency

### DIFF
--- a/app/assets/javascripts/removeCommaFromNumber.js
+++ b/app/assets/javascripts/removeCommaFromNumber.js
@@ -1,0 +1,3 @@
+function removeCommaFromNumber(number) {
+  return number.replace(/,/g, '');
+}

--- a/app/views/hiring_staff/vacancies/job_specification/edit.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/edit.html.haml
@@ -43,7 +43,7 @@
                     required: true,
                     wrapper: false,
                     label: false,
-                    input_html: { class: 'form-control-1-8', step: '1', min: '1000', max: '1000000', onchange: "this.value = this.value.replace(/,/g, '')" }
+                    input_html: { class: 'form-control-1-8', step: '1', min: '1000', max: '1000000', onchange: "this.value = removeCommaFromNumber(this.value)" }
 
         to
 
@@ -54,7 +54,7 @@
                     wrapper: false,
                     required: true,
                     label: false,
-                    input_html: { class: 'form-control-1-8', step: '1', min: '1000', max: '1000000', onchange: "this.value = this.value.replace(/,/g, '')" }
+                    input_html: { class: 'form-control-1-8', step: '1', min: '1000', max: '1000000', onchange: "this.value = removeCommaFromNumber(this.value)" }
 
       = f.input :pay_scale_id,
                   label: t('vacancies.pay_scale'),

--- a/app/views/hiring_staff/vacancies/job_specification/new.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/new.html.haml
@@ -45,7 +45,7 @@
                     wrapper: false,
                     required: true,
                     label: false,
-                    input_html: { class: 'form-control-1-8', step: '1', min: '1000', max: '1000000' }
+                    input_html: { class: 'form-control-1-8', step: '1', min: '1000', max: '1000000', onchange: "this.value = removeCommaFromNumber(this.value)" }
 
         to
 
@@ -56,7 +56,7 @@
                     wrapper: false,
                     required: true,
                     label: false,
-                    input_html: { class: 'form-control-1-8', step: '1', min: '1000', max: '1000000' }
+                    input_html: { class: 'form-control-1-8', step: '1', min: '1000', max: '1000000', onchange: "this.value = removeCommaFromNumber(this.value)" }
 
       = f.input :pay_scale_id,
                   label: t('vacancies.pay_scale'),

--- a/spec/javascripts/removeCommaFromNumber_spec.js
+++ b/spec/javascripts/removeCommaFromNumber_spec.js
@@ -1,0 +1,9 @@
+describe("Remove comma from number", function () {
+
+  it("should remove commas from numbers", function () {
+    var salary = '30,000'
+    var cleanedSalary = removeCommaFromNumber(salary)
+    expect(cleanedSalary).to.equal('30000');
+  })
+
+});


### PR DESCRIPTION
The inline JS for removing commas in IE8 number fields wasn’t being applied consistently.

- abstracted inline JS into a function
- added a teaspoon spec
- added consistently across new and edit views