### PR TITLE
(fix): Logs on staging and production include params

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -90,6 +90,12 @@ Rails.application.configure do
   config.lograge.ignore_actions = ['ApplicationController#check']
   config.lograge.logger = ActiveSupport::Logger.new(STDOUT)
 
+  # Include params in logs: https://github.com/roidrage/lograge#what-it-doesnt-do
+  config.lograge.custom_options = lambda do |event|
+    exceptions = ['controller', 'action', 'format', 'id']
+    { params: event.payload[:params].except(*exceptions) }
+  end
+
   # Don't log SQL in production
   config.active_record.logger = nil
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -83,6 +83,12 @@ Rails.application.configure do
   config.lograge.ignore_actions = ['ApplicationController#check']
   config.lograge.logger = ActiveSupport::Logger.new(STDOUT)
 
+  # Include params in logs: https://github.com/roidrage/lograge#what-it-doesnt-do
+  config.lograge.custom_options = lambda do |event|
+    exceptions = ['controller', 'action', 'format', 'id']
+    { params: event.payload[:params].except(*exceptions) }
+  end
+
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 end


### PR DESCRIPTION
* Oddly this is not enabled by default and Lograge explains that you need to do this to enable it: https://github.com/roidrage/lograge#what-it-doesnt-do
* “Lograge doesn't yet log the request parameters. This is something I'm actively contemplating, mainly because I want to find a good way to include them, a way that fits in with the general spirit of the log output generated by Lograge. However, the payload does already contain the params hash, so you can easily add it in manually using custom_options:”

Before:
![screen shot 2018-05-03 at 16 16 04](https://user-images.githubusercontent.com/912473/39585722-54646836-4eed-11e8-8ea4-f54901ef0a21.png)

After:
![screen shot 2018-05-03 at 16 14 58](https://user-images.githubusercontent.com/912473/39585726-57e681f6-4eed-11e8-9929-92067e16e0b6.png)
