### PR TITLE
(feature): Development uses HTTPS

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,8 @@
 .env
 .dockerignore
 config/application.yml
+
+# Terraform
 *.tfstate
 *.tfstate.backup
 .terraform/environment
@@ -10,3 +12,7 @@ terraform.tfstate
 ./*.tfstate
 .terraform/
 .terraform.tfstate.lock.info
+
+# Certificates
+config/localhost/https/*.key
+config/localhost/https/*.crt

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ terraform.tfstate
 .terraform/
 .terraform.tfstate.lock.info
 workspace-variables/*.tfvars
+
+# Certificates
+config/localhost/https/*.key
+config/localhost/https/*.crt

--- a/README.md
+++ b/README.md
@@ -6,20 +6,25 @@
 
 ### Setting up the project
 
-Copy the docker environment variables and fill in any missing secrets:
+1. Copy the docker environment variables and fill in any missing secrets:
 
 ```
 $ cp docker-compose.env.example docker-compose.env
 ```
 
-Build the docker container and set up the database
+2. Build the docker container and set up the database
 
-`bin/drebuild`
+```
+bin/drebuild
+```
 
+3. [Follow these instructions to configure HTTPS](config/localhost/https/README.md)
 
-Start the application
+4. Start the application
 
-`bin/dstart`
+```
+bin/dstart
+```
 
 ## Running the tests
 

--- a/config/localhost/https/README.md
+++ b/config/localhost/https/README.md
@@ -1,0 +1,33 @@
+# HTTPS in development
+
+## Understanding why
+In order to integrate with DfE Sign-in's Open ID Connect service we are required to communicate over https instead of http in all environments, including dev as of 01/05/2018.
+
+https://github.com/DFE-Digital/login.dfe.oidc
+
+## Getting set up for development
+
+You will need 4 files for this task. Ask the dev team for a copy of them or access the TeachingJobs vault:
+
+- RootCA.pem
+- RootCA.key
+- local.key
+- local.crt
+
+1. Open Keychain Access on your Mac and go to the Certificates category in your System keychain. Once there, import the `rootCA.pem`  `File > Import Items`. Double click the imported certificate and change the “When using this certificate:” dropdown to Always Trust in the Trust section.
+
+2. Copy both `local.key` and `local.crt` into this application here: `config/localhost/https/`
+
+
+Docker Compose will start the server up correctly via the `bin/dstart` or `docker-compose up`.
+
+To do it without Docker you could run:
+
+```
+rails s -b 'ssl://localhost:3000?key=config/localhost/https/local.key&cert=config/localhost/https/local.crt'
+```
+
+## Repeating the process
+This guide was used to create the required components and configure a development machine properly of which only the local.crt and local.key have been committed to source control: https://medium.freecodecamp.org/how-to-get-https-working-on-your-local-development-environment-in-5-minutes-7af615770eec
+
+Should the Root CA pem and key files be lost or need replacing, follow this guide and replace the local.crt and local.key in this repository and redistribute to all developers.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     restart: on-failure
     volumes:
       - .:/srv/dfe-tvs:cached
-    command: bash -c "rm -f tmp/pids/server.pid && rails s"
+    command: bash -c "rm -f tmp/pids/server.pid && rails s -b 'ssl://web:3000?key=config/localhost/https/local.key&cert=config/localhost/https/local.crt'"
 
   db:
     image: postgres


### PR DESCRIPTION
![screen shot 2018-05-09 at 15 12 34](https://user-images.githubusercontent.com/912473/39819479-7614f48e-539b-11e8-9f7a-27bf003b1d32.png)

* Required for DfE Sign in
* This resource was very useful in creating this: https://medium.freecodecamp.org/how-to-get-https-working-on-your-local-development-environment-in-5-minutes-7af615770eec
* All developers will need to follow the instructions to trust a CA pem file that will need to be distributed separately
* We’ve decided not to include the above file in source control because even though it’s password protected it still presents a risk of a hostile actor brute forcing the password to create a certificate and targeting a developer via a phishing attack
* To mitigate the inconvenience of not having this close to the code there are instructions on how to replicate the process and create new files
* This change will require SSO and other integrations to communicate in dev with HTTPS too
* There is no auto redirect from http://localhost to https://localhost - this might be irritating for developers. Appreciate any ideas to help with this.