### PR TITLE
[150] Rake tasks can log in production

### DIFF
--- a/lib/tasks/logging.rake
+++ b/lib/tasks/logging.rake
@@ -1,0 +1,9 @@
+desc 'switch rails logger to stdout'
+task verbose: [:environment] do
+  Rails.logger = Logger.new(STDOUT)
+end
+
+desc 'switch rails logger log level to debug'
+task debug: %i[environment verbose] do
+  Rails.logger.level = Logger::DEBUG
+end

--- a/variables.tf
+++ b/variables.tf
@@ -124,12 +124,12 @@ variable "ecs_service_logspout_container_definition_file_path" {
 
 variable "import_schools_task_command" {
   description = "The Entrypoint for the import_schools task"
-  default     = ["rake", "data:schools:import"]
+  default     = ["rake", "verbose", "data:schools:import"]
 }
 
 variable "vacancies_scrape_task_command" {
   description = "The Entrypoint for the vacancies_scrape task"
-  default     = ["rake", "vacancies:data:scrape"]
+  default     = ["rake", "verbose", "vacancies:data:scrape"]
 }
 
 variable "sessions_trim_task_command" {


### PR DESCRIPTION
* Followed this guide to get rake tasks to log http://macbury.ninja/2014/8/better-loging-in-rake-tasks
* When `RAILS_ENV` is production or staging rake tasks will not log to STDOUT and therefore don't get collected by logspout and piped to Papertrail.
* This will allow the Papertrail alerts to ping when we scrape a vacancy

<img width="1397" alt="screen shot 2018-05-10 at 15 08 46" src="https://user-images.githubusercontent.com/912473/39873892-1316d3ba-5464-11e8-89b4-18a47b4f2900.png">
