### PR TITLE
(fix): URL with either vacancy and jobs continue to work

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,10 @@ Rails.application.routes.draw do
   get 'check' => 'application#check'
 
   resources :jobs, only: %i[index show], controller: 'vacancies'
+
+  # Backward compatibility after changing routes to 'jobs'
+  resources :vacancies, only: [:show], controller: 'vacancies'
+
   resource :sessions, controller: 'hiring_staff/sessions'
 
   get '/auth/azureactivedirectory/callback', to: 'hiring_staff/sessions#create'

--- a/spec/features/job_seekers_can_view_a_vacancy_spec.rb
+++ b/spec/features/job_seekers_can_view_a_vacancy_spec.rb
@@ -63,4 +63,14 @@ RSpec.feature 'Viewing a single published vacancy' do
       expect(page).to_not have_content(I18n.t('jobs.benefits'))
     end
   end
+
+  context 'when the old vacancy URL is used' do
+    scenario 'vacancy is viewable' do
+      published_vacancy = VacancyPresenter.new(create(:vacancy, :published))
+
+      visit vacancy_path(published_vacancy)
+
+      expect(page).to have_content(published_vacancy.job_title)
+    end
+  end
 end


### PR DESCRIPTION
Ensures that past URLs presented to real users always work.

Both of these links should still work:
https://tvs.staging.dxw.net/jobs/teacher-of-pe-girls
https://tvs.staging.dxw.net/vacancies/teacher-of-pe-girls