### PR TITLE
[148] Log request ip

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -53,6 +53,7 @@ class ApplicationController < ActionController::Base
   private def append_info_to_payload(payload)
     super
     payload[:ip] = request_ip
+    payload[:session_id] = "#{session.id[0..7]}…" if session.id
   end
 
   private def set_headers

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,7 @@ class ApplicationController < ActionController::Base
   before_action :set_headers
 
   include AuthenticationConcerns
+  include Ip
 
   def check
     render json: { status: 'OK' }, status: 200
@@ -47,6 +48,11 @@ class ApplicationController < ActionController::Base
       Rails.logger.warn('Basic auth failed: ENV["HTTP_PASS"] expected but not found.')
       nil
     end
+  end
+
+  private def append_info_to_payload(payload)
+    super
+    payload[:ip] = request_ip
   end
 
   private def set_headers

--- a/app/controllers/concerns/ip.rb
+++ b/app/controllers/concerns/ip.rb
@@ -1,0 +1,12 @@
+module Ip
+  extend ActiveSupport::Concern
+
+  def request_ip
+    remove_the_last_octet(request.ip)
+  end
+
+  def remove_the_last_octet(ip)
+    # Strip everything after and including the third decimal
+    "#{ip.gsub(/[^.]*.[^.]*.[^.]*\K.*$/, '')}…"
+  end
+end

--- a/lib/logging/colour_log_formatter.rb
+++ b/lib/logging/colour_log_formatter.rb
@@ -11,9 +11,8 @@ class ColourLogFormatter < Lograge::Formatters::KeyValue
     duration: :magenta,
     view: :magenta,
     db: :magenta,
-    time: :cyan,
+    session_id: :cyan,
     ip: :cyan,
-    host: :red,
     params: :green
   }.freeze
 

--- a/lib/logging/colour_log_formatter.rb
+++ b/lib/logging/colour_log_formatter.rb
@@ -12,7 +12,7 @@ class ColourLogFormatter < Lograge::Formatters::KeyValue
     view: :magenta,
     db: :magenta,
     time: :cyan,
-    ip: :red,
+    ip: :cyan,
     host: :red,
     params: :green
   }.freeze

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -7,6 +7,21 @@ RSpec.describe ApplicationController, type: :controller do
     end
   end
 
+  describe '#request_ip' do
+    it 'returns the partial IP with the last octet removed' do
+      expect(controller.request_ip).to eql('0.0.0…')
+    end
+
+    context 'when the IP is at the max range' do
+      it 'returns the partial IP with the last octet removed' do
+        allow_any_instance_of(ActionController::TestRequest)
+          .to receive(:ip)
+          .and_return('255.255.255.255')
+        expect(controller.request_ip).to eql('255.255.255…')
+      end
+    end
+  end
+
   describe '#check_staging_auth' do
     context 'when we want to authenticate' do
       before(:each) do


### PR DESCRIPTION
* Include the first 3/4 parts of the IP in our logs to identify good and hostile traffic as well as to help us connect together user events for insight gathering, debugging or reacting to a hostile event. To this end I've included the start of our session_id incase the user changes IP or the IP becomes unreliable on it's own. Eg. if 2 users share the same first 3 parts of the IP but the last part is all that differs.

Before:
![screen shot 2018-05-16 at 17 11 23](https://user-images.githubusercontent.com/912473/40129437-31367e78-592c-11e8-9d4f-95c8f300b665.png)

After:
![screen shot 2018-05-16 at 17 09 13](https://user-images.githubusercontent.com/912473/40129355-fa47c944-592b-11e8-8455-fe546faab329.png)
