### PR TITLE
(fix) 63 cross browser testing

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,8 +10,8 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
-//= require rails-ujs
 //= require jquery
 //= require jquery_ujs
+//= require rails-ujs
 //= require turbolinks
 //= require_tree .

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -58,6 +58,8 @@
 @import 'components/sortable_links';
 @import 'components/flashes';
 
+@import 'ie';
+
 main#content {
   @extend %site-width-container;
   &:focus {

--- a/app/assets/stylesheets/ie.scss
+++ b/app/assets/stylesheets/ie.scss
@@ -1,0 +1,32 @@
+html.lte-ie8 {
+
+  #content {
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .column-one-third {
+    width: 30%;
+    float: left;
+  }
+
+  .column-one-half {
+    width: 48%;
+    float: left;
+  }
+
+  .column-two-thirds {
+    width: 60%;
+    float: left;
+  }
+
+  .multiple-choice {
+    input.boolean {
+      -ms-filter:"progid:DXImageTransform.Microsoft.Alpha(Opacity=50)";
+      border: 1px solid #000;
+      width: 25px;
+      height: 25px;
+    }
+  }
+
+}


### PR DESCRIPTION
This PR fixes some CSS issues (screenshots here), and a couple of interaction behaviours that were caused by jQuery not being picked up in IE8 (videos on the [Trello card](https://trello.com/c/5k9FhSCK/63-cross-browser-testing)).

list before:
<img width="1263" alt="listing before" src="https://user-images.githubusercontent.com/822507/40129508-592d40c4-592c-11e8-95ef-e0d27b359e59.png">
list after:
<img width="1005" alt="listing after" src="https://user-images.githubusercontent.com/822507/40129509-5946f370-592c-11e8-9284-8e37f1a65001.png">
post before:
<img width="1258" alt="post before" src="https://user-images.githubusercontent.com/822507/40129511-597970c0-592c-11e8-921b-3d9ada42d680.png">
post after:
<img width="998" alt="post after" src="https://user-images.githubusercontent.com/822507/40129510-595fbc48-592c-11e8-80fc-8d0da34f2769.png">
dashboard before:
<img width="1245" alt="hiring dashboard before" src="https://user-images.githubusercontent.com/822507/40129512-5994b5ec-592c-11e8-9afb-feebe0ba61fd.png">
dashboard after:
<img width="1040" alt="hiring dashboard after" src="https://user-images.githubusercontent.com/822507/40129513-59afd534-592c-11e8-8641-17aee0f32ccf.png">
flexible working checkbox now visible:
<img width="554" alt="flex working checkbox" src="https://user-images.githubusercontent.com/822507/40129982-a2623c62-592d-11e8-9679-204cf98d743c.png">
