### PR TITLE
(fix) better spacing for job list sort links

### DIFF
--- a/app/assets/stylesheets/components/filter_vacancies.scss
+++ b/app/assets/stylesheets/components/filter_vacancies.scss
@@ -1,4 +1,5 @@
 .filter-vacancies {
+  margin-bottom: 0;
   padding: $gutter-half;
   background-color: $panel-colour;
   h2 {
@@ -12,5 +13,9 @@
   }
   .button {
     margin-top: $gutter-half;
+  }
+
+  @media screen and (max-width: $small-screen) {
+    margin-bottom: $gutter;
   }
 }


### PR DESCRIPTION
#### before:
<img width="373" alt="before" src="https://user-images.githubusercontent.com/822507/40181827-f14a4b26-59e1-11e8-8d20-4c76520cb354.png">

#### after:
<img width="391" alt="after" src="https://user-images.githubusercontent.com/822507/40181830-f2e16406-59e1-11e8-859e-52822c9126b7.png">
