### PR TITLE
(fix) school address <dt> styles improved

### DIFF
--- a/app/assets/stylesheets/components/school.scss
+++ b/app/assets/stylesheets/components/school.scss
@@ -6,6 +6,7 @@
     dt {
       width: 30%;
       color: $secondary-text-colour;
+      float: left;
     }
     dd {
       width: 65%;


### PR DESCRIPTION
- the address `<dt>` is no longer aligned to the bottom of the `<dd>`

#### desktop before
<img width="818" alt="desktop before" src="https://user-images.githubusercontent.com/822507/40182720-ef8168e0-59e3-11e8-87c3-601a64f52bdb.png">

#### desktop after
<img width="707" alt="desktop after" src="https://user-images.githubusercontent.com/822507/40182734-f6ad460c-59e3-11e8-8673-891259a8b07b.png">

#### mobile before
<img width="372" alt="mobile before" src="https://user-images.githubusercontent.com/822507/40182764-05a4595c-59e4-11e8-8461-df060340ec1e.png">

#### mobile after
<img width="404" alt="mobile after" src="https://user-images.githubusercontent.com/822507/40182738-f83c1d72-59e3-11e8-8792-d7c409d86066.png">

