### PR TITLE
[178] Log the request IP that's not our CloudFront IP

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -52,7 +52,7 @@ class ApplicationController < ActionController::Base
 
   private def append_info_to_payload(payload)
     super
-    payload[:ip] = request_ip
+    payload[:remote_ip] = request_ip
     payload[:session_id] = "#{session.id[0..7]}…" if session.id
   end
 

--- a/app/controllers/concerns/ip.rb
+++ b/app/controllers/concerns/ip.rb
@@ -4,7 +4,7 @@ module Ip
   extend ActiveSupport::Concern
 
   def request_ip
-    anonymize_ip(request.ip)
+    anonymize_ip(request.remote_ip)
   end
 
   def anonymize_ip(ip_string)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -94,7 +94,7 @@ Rails.application.configure do
   config.lograge.custom_options = lambda do |event|
     exceptions = ['controller', 'action', 'format', 'id']
     {
-      ip: event.payload[:ip],
+      ip: event.payload[:remote_ip],
       session_id: event.payload[:session_id],
       params: event.payload[:params].except(*exceptions)
     }

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -87,7 +87,7 @@ Rails.application.configure do
   config.lograge.custom_options = lambda do |event|
     exceptions = ['controller', 'action', 'format', 'id']
     {
-      ip: event.payload[:ip],
+      ip: event.payload[:remote_ip],
       session_id: event.payload[:session_id],
       params: event.payload[:params].except(*exceptions)
     }

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe ApplicationController, type: :controller do
     context 'when the IP is at the max range' do
       it 'returns the anonymized IP with the last octet zero padded' do
         allow_any_instance_of(ActionController::TestRequest)
-          .to receive(:ip)
+          .to receive(:remote_ip)
           .and_return('255.255.255.255')
         expect(controller.request_ip).to eql('255.255.255.0')
       end


### PR DESCRIPTION
* We noticed a lot of interesting traffic coming from IP addresses other than the one the pen testers had given us. This prompted us to review who was sending hundreds of malicious search attempts.
* It turns out that using just `request.ip` will give you the last IP in a chain of forwards. It looks like Cloudfront was adding an IP onto the end and made the pen test traffic look like it was originating from wherewhere else. We know this because every IP we do see is from AWS and that in the raw headers from Rollbar we can see the trusted IP at the beginning of the value.
* `request.remote_ip` will assist us with this as per: https://stackoverflow.com/a/10997117/3976093
* ALB load balancers do not seem to add an IP another forwarded address as Cloudfront does. Talked this through with Ops to confirm.
* We don't care about the CloudFront IP so we can remove it.
* Here’s the raw headers with the `X-Forwarded-For` including the 2 IP. And we want to log the first IP using request.remote_ip. 
```
curl --request GET 'https://teachingjobs.education.gov.uk/jobs?utf8=%E2%9C%93&location=&keyword=&minimum_salary=40000&maximum_salary=20000&working_pattern=full_time%0ATest:%208xeqzrzc&phase=not_applicable&sort_column=&sort_order=&commit=Apply%20filters' \
--header 'Via:1.1 699f29706ac19519e0b631e243565331.cloudfront.net (CloudFront)' \
--header 'Accept-Language:en-US,en;q=0.5' \
--header 'Cloudfront-Is-Desktop-Viewer:true' \
--header 'Cloudfront-Is-Smarttv-Viewer:false' \
--header 'X-Forwarded-Proto:https' \
--header 'X-Forwarded-Port:443' \
--header 'X-Forwarded-For:46.101.86.134, 54.240.147.6' \
--header 'Cloudfront-Viewer-Country:GB' \
--header 'Cloudfront-Forwarded-Proto:https' \
```