### PR TITLE
[179] Anonymise Rollbar IP collection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem 'addressable'
 gem 'sanitize', '~> 4.6'
 gem 'lograge'
 gem 'colorize'
+gem 'ipaddr'
 
 gem 'omniauth'
 gem 'omniauth-azure-activedirectory'

--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem 'rails-html-sanitizer', '~> 1.0.4', '>= 1.0.4' # Must be above this version 
 
 gem 'gov_uk_date_fields', '~> 2.0', '>= 2.0.3'
 
-gem 'rollbar'
+gem 'rollbar', '~> 2.16'
 
 gem 'rubocop' # Not in Test group due to: https://github.com/chapmanu/imposter/issues/4
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -161,6 +161,7 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (0.9.0)
       concurrent-ruby (~> 1.0)
+    ipaddr (1.2.0)
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
@@ -406,6 +407,7 @@ DEPENDENCIES
   govuk_template
   haml-rails
   httparty
+  ipaddr
   jbuilder (~> 2.5)
   jquery-rails
   kaminari

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -285,7 +285,7 @@ GEM
     roadie-rails (1.2.1)
       railties (>= 3.0, < 5.2)
       roadie (~> 3.1)
-    rollbar (2.15.5)
+    rollbar (2.16.0)
       multi_json
     rspec-collection_matchers (1.1.3)
       rspec-expectations (>= 2.99.0.beta1)
@@ -424,7 +424,7 @@ DEPENDENCIES
   rails-controller-testing (~> 1.0, >= 1.0.2)
   rails-html-sanitizer (~> 1.0.4, >= 1.0.4)
   roadie-rails
-  rollbar
+  rollbar (~> 2.16)
   rspec-collection_matchers
   rspec-rails
   rubocop

--- a/app/controllers/concerns/ip.rb
+++ b/app/controllers/concerns/ip.rb
@@ -1,12 +1,34 @@
 module Ip
+  require 'ipaddr'
+
   extend ActiveSupport::Concern
 
   def request_ip
-    remove_the_last_octet(request.ip)
+    anonymize_ip(request.ip)
   end
 
-  def remove_the_last_octet(ip)
-    # Strip everything after and including the third decimal
-    "#{ip.gsub(/[^.]*.[^.]*.[^.]*\K.*$/, '')}…"
+  def anonymize_ip(ip_string)
+    ip = IPAddr.new(ip_string)
+
+    return anonymize_ipv4(ip) if ip.ipv4?
+    return anonymize_ipv6(ip) if ip.ipv6?
+  rescue
+    nil
+  end
+
+  def anonymize_ipv4(ip)
+    ip_parts = ip.to_s.split '.'
+
+    ip_parts[ip_parts.count - 1] = '0'
+
+    IPAddr.new(ip_parts.join('.')).to_s
+  end
+
+  def anonymize_ipv6(ip)
+    ip_parts = ip.to_s.split ':'
+
+    ip_string = ip_parts[0..2].join(':') + ':0000:0000:0000:0000:0000'
+
+    IPAddr.new(ip_string).to_s
   end
 end

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -64,4 +64,6 @@ Rollbar.configure do |config|
   # setup for Heroku. See:
   # https://devcenter.heroku.com/articles/deploying-to-a-custom-rails-environment
   config.environment = ENV['ROLLBAR_ENV'].presence || Rails.env
+
+  config.anonymize_user_ip = true
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -8,16 +8,16 @@ RSpec.describe ApplicationController, type: :controller do
   end
 
   describe '#request_ip' do
-    it 'returns the partial IP with the last octet removed' do
-      expect(controller.request_ip).to eql('0.0.0…')
+    it 'returns the anonymized IP with the last octet zero padded' do
+      expect(controller.request_ip).to eql('0.0.0.0')
     end
 
     context 'when the IP is at the max range' do
-      it 'returns the partial IP with the last octet removed' do
+      it 'returns the anonymized IP with the last octet zero padded' do
         allow_any_instance_of(ActionController::TestRequest)
           .to receive(:ip)
           .and_return('255.255.255.255')
-        expect(controller.request_ip).to eql('255.255.255…')
+        expect(controller.request_ip).to eql('255.255.255.0')
       end
     end
   end


### PR DESCRIPTION
* It is currently collecting the full IP address of requests that originate a Rollbar event. This change will anonymise every IP by zero padding the last value `192.168.0.1` will become `192.168.0.0`.
* On investigating Rollbar's recently configuration to anonymise this data, they are referencing Googles approach. This then seems like a sensible place to start compared to our approach of removing the last value. https://support.google.com/analytics/answer/2763052
* Support this approach with ipv6