### PR TITLE
(chore) improved hint text for application email

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -84,7 +84,7 @@ en:
       deadline_date: 'For example, %{date}'
       publication_date: 'For example, %{date}'
       benefits: 'For example, financial benefits, job training, continuing professional development and whether Special Educational Needs (SEN) allowances or Teaching and Learning Responsibility (TLR) payments are available.'
-      contact_email: 'This will appear in the public listing'
+      contact_email: 'This email address will be shown publicly as a point of contact'
       application_link: 'This is the url linking the job to your existing application page'
     filters:
       title: 'Search job listings'


### PR DESCRIPTION
For service assessment: hint text explains purpose of collecting email address

before
<img width="514" alt="screen shot 2018-05-23 at 15 10 28" src="https://user-images.githubusercontent.com/822507/40429991-e757b220-5e9b-11e8-8218-aedc5185548c.png">

after
<img width="496" alt="screen shot 2018-05-23 at 15 10 40" src="https://user-images.githubusercontent.com/822507/40430002-eb5c8ab2-5e9b-11e8-8b3c-79fd512524f8.png">
