### PR TITLE
(feature): Anonymise all IP sent to Google analytics

### DIFF
--- a/app/views/shared/_gtag.html.haml
+++ b/app/views/shared/_gtag.html.haml
@@ -4,4 +4,4 @@
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
-  gtag('config', "#{ENV['GOOGLE_ANALYTICS']}");
+  gtag('config', "#{ENV['GOOGLE_ANALYTICS']}", { 'anonymize_ip': true });


### PR DESCRIPTION
* Following https://developers.google.com/analytics/devguides/collection/gtagjs/ip-anonymization which uses the behaviour documented here https://support.google.com/analytics/answer/2763052?hl=en
* With this change we will no longer be able to infer what person performed that any particular action on our service.
* For example a request with the IP of `192.168.0.1` will be stored instead stored as `192.168.0.0`.