### PR TITLE
(chore) ensure that only job posts that have been published and have …

### DIFF
--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -18,7 +18,7 @@ class VacanciesController < ApplicationController
   end
 
   def show
-    vacancy = Vacancy.published.friendly.find(id)
+    vacancy = Vacancy.listed.friendly.find(id)
     @vacancy = VacancyPresenter.new(vacancy)
   end
 

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -61,6 +61,7 @@ class Vacancy < ApplicationRecord
 
   scope :applicable, (-> { where('expires_on >= ?', Time.zone.today) })
   scope :active, (-> { where(status: %i[published draft]) })
+  scope :listed, (-> { published.where('publish_on <= ?', Time.zone.today) })
 
   paginates_per 10
 

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -72,6 +72,11 @@ FactoryBot.define do
       expires_on { Faker::Time.backward(7) }
     end
 
+    trait :future_publish do
+      publish_on { Time.zone.today + 2.days }
+      expires_on { Time.zone.today + 2.months }
+    end
+
     trait :job_schema do
       weekly_hours '8.5'
       education { Faker::Lorem.paragraph }

--- a/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
@@ -363,7 +363,7 @@ RSpec.feature 'Creating a vacancy' do
         click_on 'Confirm and submit job'
 
         expect(page).to have_content("The job will be posted on #{vacancy.publish_on}, you can preview it here:")
-        visit job_url(vacancy)
+        visit school_job_path(school, vacancy.id)
         expect(page).to have_content("Date posted #{format_date(vacancy.publish_on)}")
       end
 

--- a/spec/features/job_seekers_can_view_a_vacancy_spec.rb
+++ b/spec/features/job_seekers_can_view_a_vacancy_spec.rb
@@ -9,13 +9,22 @@ RSpec.feature 'Viewing a single published vacancy' do
     verify_vacancy_show_page_details(published_vacancy)
   end
 
-  scenario 'Unpublished vacancies are not viewable' do
+  scenario 'Unpublished vacancies are not accessible' do
     draft_vacancy = create(:vacancy, :draft)
 
     visit job_path(draft_vacancy)
 
     expect(page).to have_content('Page not found')
     expect(page).to_not have_content(draft_vacancy.job_title)
+  end
+
+  scenario 'Job post with a future publish_on date are not accessible' do
+    job_post = create(:vacancy, :future_publish)
+
+    visit job_path(job_post)
+
+    expect(page).to have_content('Page not found')
+    expect(page).to_not have_content(job_post.job_title)
   end
 
   scenario 'Expired vacancies display a warning message' do

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -298,6 +298,16 @@ RSpec.describe Vacancy, type: :model do
         expect(Vacancy.active.count).to eq(draft.count + published.count)
       end
     end
+
+    describe '#listed' do
+      it 'retrieves  vacancies that have a status of :published and a future publish_on date' do
+        published = create_list(:vacancy, 5, :published)
+        create_list(:vacancy, 3, :future_publish)
+        create_list(:vacancy, 4, :trashed)
+
+        expect(Vacancy.listed.count).to eq(published.count)
+      end
+    end
   end
 
   describe 'delegate school_name' do


### PR DESCRIPTION
…a future `publish_on` date can be accessed