### PR TITLE
(fix) use strict GOV.UK palette for flashes

### DIFF
--- a/app/assets/stylesheets/components/flashes.scss
+++ b/app/assets/stylesheets/components/flashes.scss
@@ -1,27 +1,25 @@
-$notice: $light-blue;
-$success: $green;
-$error: $error-colour;
-$alert: $yellow;
-
-@mixin flash($name) {
-  background-color: tint($name, 80%);
-  color: shade($name, 50%);
-  border: 1px solid shade($name, 50%);
+@mixin flash {
+  color: $black;
+  border: 1px solid $black;
 }
 
 .flash {
   margin-top: $gutter/2;
   padding: 14px 15px 10px 15px;
   &.notice {
-    @include flash($notice);
+    background-color: $light-blue-25;
+    @include flash;
   }
   &.success {
-    @include flash($success);
+    background-color: $green-25;
+    @include flash;
   }
   &.error {
-    @include flash($error);
+    background-color: $red-25;
+    @include flash;
   }
   &.alert {
-    @include flash($alert);
+    background-color: $yellow-25;
+    @include flash;
   }
 }


### PR DESCRIPTION
- removes sass color functions, applies set tints from GOV.UK palette
- uses GOV.UK `$black` for borders and text in flashes 

before:
<img width="360" alt="before" src="https://user-images.githubusercontent.com/822507/40780019-f7b94e10-64ce-11e8-92a7-3864fdc5b7ee.png">

after:
<img width="984" alt="after" src="https://user-images.githubusercontent.com/822507/40780020-fc0debf6-64ce-11e8-9e1e-b79513d0334c.png">

