### PR TITLE
(fix) correct markup of school info table

### DIFF
--- a/app/assets/stylesheets/base/_utilities.scss
+++ b/app/assets/stylesheets/base/_utilities.scss
@@ -22,3 +22,7 @@
 .overflow-scroll {
   overflow: scroll;
 }
+
+.strong {
+  font-weight: bold;
+}

--- a/app/views/hiring_staff/schools/show.html.haml
+++ b/app/views/hiring_staff/schools/show.html.haml
@@ -15,46 +15,45 @@
 
 .grid-row
   .column-full
-    %h2.heading-medium
-      = t('schools.info', school: @school.name)
-
-    %dl.govuk-check-your-answers.cya-questions-short
-      %div
-        %dt.cya-question
-          = t('schools.description')
-        %dd.cya-answer
-          = @school.description.presence || 'Not provided'
-        %dd.cya-change
-          = link_to edit_school_path(@school) do
-            = t('buttons.change')
-            %span.visually-hidden
-              description
-
-      %div
-        %dt.cya-question
-          = t('schools.address')
-        %dd.cya-answer
-          = @school.full_address
-        %dd.cya-change
-
-      %div
-        %dt.cya-question
-          = t('schools.school_age')
-        %dd.cya-answer
-          = @school.age_range
-        %dd.cya-change
-
-      %div
-        %dt.cya-question
-          = t('schools.type')
-        %dd.cya-answer
-          = @school.school_type.label
-        %dd.cya-change
-
-      - if @school.url.present?
-        %div
-          %dt.cya-question
-            Website
-          %dd.cya-answer
+    %table.check-your-answers
+      %thead
+        %tr
+          %th{:colspan => "2"}
+            %h2.heading-medium
+              = t('schools.info', school: @school.name)
+          %th
+      %tbody
+        %tr
+          %td
+            %strong.strong= t('schools.description')
+          %td
+            = @school.description.presence || 'Not provided'
+          %td.change-answer
+            = link_to edit_school_path(@school) do
+              = t('buttons.change')
+              %span.visually-hidden
+                description
+        %tr
+          %td
+            %strong.strong= t('schools.address')
+          %td
+            = @school.full_address
+          %td
+        %tr
+          %td
+            %strong.strong= t('schools.school_age')
+          %td
+            = @school.age_range
+          %td
+        %tr
+          %td
+            %strong.strong= t('schools.type')
+          %td
+            = @school.school_type.label
+          %td
+        %tr
+          %td
+            %strong.strong Website
+          %td
             = link_to @school.url, @school.url
-          %dd.cya-change
+          %td


### PR DESCRIPTION
This table was marked up as a definition list, using code based on [an example from the GOV UK prototype kit which contained invalid markup](https://govuk-prototype-kit.herokuapp.com/docs/examples/check-your-answers-page) (as detailed in the DAC report, see attachment).

I've altered the markup to match [another example within the prototype kit marked up as a `<table>`](https://govuk-prototype-kit.herokuapp.com/docs/examples/pass-data/vehicle-check-answers), which doesn't require any change to `check_your_answers.scss`. 

I've added a `.strong` class to `_utilities.scss` for emboldening the first column.

before:
<img width="546" alt="before" src="https://user-images.githubusercontent.com/822507/40790617-58a51416-64ed-11e8-8778-19710f12198a.png">

after:
<img width="1022" alt="after" src="https://user-images.githubusercontent.com/822507/40790629-5d72b426-64ed-11e8-9e71-30e7181c8b6e.png">
