### PR TITLE
(feature) change `/schools/:school_id*`to `/school*`

### DIFF
--- a/app/controllers/hiring_staff/schools_controller.rb
+++ b/app/controllers/hiring_staff/schools_controller.rb
@@ -5,8 +5,7 @@ class HiringStaff::SchoolsController < HiringStaff::BaseController
   end
 
   def edit
-    @school = School.find(params[:id])
-
+    @school = current_school
     return if params[:description].nil?
 
     @school.description = params[:description].presence
@@ -14,16 +13,16 @@ class HiringStaff::SchoolsController < HiringStaff::BaseController
   end
 
   def update
-    school = School.find(params[:id])
+    school = current_school
     school.description = params[:school][:description]
 
     if school.valid?
       Auditor::Audit.new(school, 'school.update', current_session_id).log do
         school.save
       end
-      redirect_to school_path(school)
+      redirect_to school_path
     else
-      redirect_to edit_school_path(school, description: school.description)
+      redirect_to edit_school_path(description: school.description)
     end
   end
 end

--- a/app/controllers/hiring_staff/vacancies/application_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/application_controller.rb
@@ -4,7 +4,7 @@ class HiringStaff::Vacancies::ApplicationController < HiringStaff::BaseControlle
   private
 
   def school
-    @school ||= School.find_by!(id: school_id)
+    @school ||= School.find_by! urn: session[:urn]
   end
 
   def school_id

--- a/app/controllers/hiring_staff/vacancies/application_details_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/application_details_controller.rb
@@ -15,7 +15,7 @@ class HiringStaff::Vacancies::ApplicationDetailsController < HiringStaff::Vacanc
       redirect_to next_step(vacancy)
     else
       session[:current_step] = :step_3 unless session[:current_step].eql?(:review)
-      redirect_to application_details_school_job_path(@school, anchor: 'errors')
+      redirect_to application_details_school_job_path(anchor: 'errors')
     end
   end
 
@@ -36,11 +36,10 @@ class HiringStaff::Vacancies::ApplicationDetailsController < HiringStaff::Vacanc
     if @application_details_form.valid?
       reset_session_vacancy!
       update_vacancy(application_details_form, vacancy)
-      redirect_to edit_school_job_path(school, vacancy.id), notice: I18n.t('messages.jobs.updated')
+      redirect_to edit_school_job_path(vacancy.id), notice: I18n.t('messages.jobs.updated')
     else
       store_vacancy_attributes(@application_details_form.vacancy.attributes.compact!)
-      redirect_to edit_school_job_application_details_path(school,
-                                                           vacancy.id,
+      redirect_to edit_school_job_application_details_path(vacancy.id,
                                                            anchor: 'errors',
                                                            source: 'update')
     end

--- a/app/controllers/hiring_staff/vacancies/candidate_specification_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/candidate_specification_controller.rb
@@ -2,7 +2,7 @@ class HiringStaff::Vacancies::CandidateSpecificationController < HiringStaff::Va
   before_action :school, :redirect_unless_vacancy_session_id, only: %i[new create]
 
   def new
-    redirect_to job_specification_school_job_path(school_id: school.id) unless session_vacancy_id
+    redirect_to job_specification_school_job_path unless session_vacancy_id
 
     @candidate_specification_form = ::CandidateSpecificationForm.new(session[:vacancy_attributes])
     @candidate_specification_form.valid? if %i[step_2 review].include?(session[:current_step])
@@ -18,7 +18,7 @@ class HiringStaff::Vacancies::CandidateSpecificationController < HiringStaff::Va
     end
 
     session[:current_step] = :step_2 unless session[:current_step].eql?(:review)
-    redirect_to candidate_specification_school_job_path(@school, anchor: 'errors')
+    redirect_to candidate_specification_school_job_path(anchor: 'errors')
   end
 
   def edit
@@ -38,11 +38,10 @@ class HiringStaff::Vacancies::CandidateSpecificationController < HiringStaff::Va
     if @candidate_specification_form.valid?
       reset_session_vacancy!
       update_vacancy(candidate_specification_form, vacancy)
-      redirect_to edit_school_job_path(school, vacancy.id), notice: I18n.t('messages.jobs.updated')
+      redirect_to edit_school_job_path(vacancy.id), notice: I18n.t('messages.jobs.updated')
     else
       store_vacancy_attributes(@candidate_specification_form.vacancy.attributes.compact!)
-      redirect_to edit_school_job_candidate_specification_path(school,
-                                                               vacancy.id,
+      redirect_to edit_school_job_candidate_specification_path(vacancy.id,
                                                                anchor: 'errors',
                                                                source: 'update')
     end
@@ -56,6 +55,6 @@ class HiringStaff::Vacancies::CandidateSpecificationController < HiringStaff::Va
   end
 
   def next_step
-    application_details_school_job_path(school_id: school.id)
+    application_details_school_job_path
   end
 end

--- a/app/controllers/hiring_staff/vacancies/job_specification_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/job_specification_controller.rb
@@ -19,7 +19,7 @@ class HiringStaff::Vacancies::JobSpecificationController < HiringStaff::Vacancie
       redirect_to_next_step(vacancy)
     else
       session[:current_step] = :step_1 if session[:current_step].blank?
-      redirect_to job_specification_school_job_path(school, anchor: 'errors')
+      redirect_to job_specification_school_job_path(anchor: 'errors')
     end
   end
   # rubocop:enable Metrics/AbcSize
@@ -41,11 +41,10 @@ class HiringStaff::Vacancies::JobSpecificationController < HiringStaff::Vacancie
     if @job_specification_form.valid?
       reset_session_vacancy!
       update_vacancy(job_specification_form, vacancy)
-      redirect_to edit_school_job_path(school, vacancy.id), notice: I18n.t('messages.jobs.updated')
+      redirect_to edit_school_job_path(vacancy.id), notice: I18n.t('messages.jobs.updated')
     else
       store_vacancy_attributes(@job_specification_form.vacancy.attributes.compact!)
-      redirect_to edit_school_job_job_specification_path(school,
-                                                         vacancy.id,
+      redirect_to edit_school_job_job_specification_path(vacancy.id,
                                                          anchor: 'errors',
                                                          source: 'update')
     end
@@ -74,7 +73,7 @@ class HiringStaff::Vacancies::JobSpecificationController < HiringStaff::Vacancie
   end
 
   def next_step
-    candidate_specification_school_job_path(school_id: school.id)
+    candidate_specification_school_job_path
   end
 
   def called_from_update_method

--- a/app/controllers/hiring_staff/vacancies/publish_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/publish_controller.rb
@@ -5,7 +5,7 @@ class HiringStaff::Vacancies::PublishController < HiringStaff::Vacancies::Applic
     if PublishVacancy.new(vacancy: vacancy).call
       Auditor::Audit.new(vacancy, 'vacancy.publish', current_session_id).log
       reset_session_vacancy!
-      redirect_to school_job_summary_path(school, vacancy.id)
+      redirect_to school_job_summary_path(vacancy.id)
     else
       redirect_to review_path(vacancy), notice: I18n.t('errors.jobs.unable_to_publish')
     end

--- a/app/controllers/hiring_staff/vacancies_controller.rb
+++ b/app/controllers/hiring_staff/vacancies_controller.rb
@@ -2,7 +2,7 @@ class HiringStaff::VacanciesController < HiringStaff::Vacancies::ApplicationCont
   def show
     vacancy = school.vacancies.active.find(id)
     unless vacancy.published?
-      return redirect_to school_job_review_path(school, vacancy.id),
+      return redirect_to school_job_review_path(vacancy.id),
                          alert: I18n.t('messages.jobs.view.only_published')
     end
     @vacancy = VacancyPresenter.new(vacancy)
@@ -10,12 +10,12 @@ class HiringStaff::VacanciesController < HiringStaff::Vacancies::ApplicationCont
 
   def new
     reset_session_vacancy!
-    redirect_to job_specification_school_job_path(school)
+    redirect_to job_specification_school_job_path
   end
 
   def edit
     vacancy = school.vacancies.find(id)
-    redirect_to school_job_review_path(school, vacancy.id) unless vacancy.published?
+    redirect_to school_job_review_path(vacancy.id) unless vacancy.published?
 
     @vacancy = VacancyPresenter.new(vacancy)
   end
@@ -23,7 +23,7 @@ class HiringStaff::VacanciesController < HiringStaff::Vacancies::ApplicationCont
   def review
     vacancy = school.vacancies.active.find(vacancy_id)
     if vacancy.published?
-      redirect_to school_job_path(school_id: school.id, id: vacancy.id),
+      redirect_to school_job_path(vacancy.id),
                   notice: t('messages.vacancies.already_published')
     end
 

--- a/app/views/hiring_staff/schools/_vacancy.html.haml
+++ b/app/views/hiring_staff/schools/_vacancy.html.haml
@@ -1,8 +1,8 @@
 %tr.vacancy[vacancy]
-  %td= link_to vacancy.job_title, school_job_path(school.id, vacancy.id), class: 'view-vacancy-link'
+  %td= link_to vacancy.job_title, school_job_path(vacancy.id), class: 'view-vacancy-link'
   %td= format_date(vacancy.publish_on)
   %td= format_date(vacancy.expires_on)
   %td= vacancy.status.titleize
-  %td= link_to 'Edit', edit_school_job_path(school, vacancy.id)
-  %td= link_to 'Delete', school_job_path(school_id: school.id, id: vacancy.id), method: :delete, data: { confirm: "Are you sure you want to delete the '#{vacancy.job_title}' job?" }
+  %td= link_to 'Edit', edit_school_job_path(vacancy.id)
+  %td= link_to 'Delete', school_job_path(id: vacancy.id), method: :delete, data: { confirm: "Are you sure you want to delete the '#{vacancy.job_title}' job?" }
 

--- a/app/views/hiring_staff/schools/show.html.haml
+++ b/app/views/hiring_staff/schools/show.html.haml
@@ -11,7 +11,7 @@
     - else
       = render partial: 'no_vacancies', locals: { school: @school }
     .form-group.mt1
-      = link_to t('buttons.create_job'), new_school_job_path(@school), class: 'button'
+      = link_to t('buttons.create_job'), new_school_job_path, class: 'button'
 
 .grid-row
   .column-full
@@ -29,7 +29,7 @@
           %td
             = @school.description.presence || 'Not provided'
           %td.change-answer
-            = link_to edit_school_path(@school) do
+            = link_to edit_school_path do
               = t('buttons.change')
               %span.visually-hidden
                 description

--- a/app/views/hiring_staff/vacancies/application_details/edit.html.haml
+++ b/app/views/hiring_staff/vacancies/application_details/edit.html.haml
@@ -1,7 +1,7 @@
 %h1.heading-large
   = t('jobs.edit_heading', school: @school.name)
 = render 'hiring_staff/vacancies/error_messages', errors: @application_details_form.errors
-= simple_form_for @application_details_form, html: { class: 'vacancy-form' }, method: :put, url: school_job_application_details_path(@school, @application_details_form.id) do |f|
+= simple_form_for @application_details_form, html: { class: 'vacancy-form' }, method: :put, url: school_job_application_details_path(@application_details_form.id) do |f|
   %h2.heading-medium
     = t('jobs.application_details')
 

--- a/app/views/hiring_staff/vacancies/candidate_specification/edit.html.haml
+++ b/app/views/hiring_staff/vacancies/candidate_specification/edit.html.haml
@@ -1,7 +1,7 @@
 %h1.heading-large
   = t('jobs.edit_heading', school: @school.name)
 = render 'hiring_staff/vacancies/error_messages', errors: @candidate_specification_form.errors
-= simple_form_for @candidate_specification_form, html: { class: 'vacancy-form' }, method: :put, url: school_job_candidate_specification_path(@school, @candidate_specification_form.id)  do |f|
+= simple_form_for @candidate_specification_form, html: { class: 'vacancy-form' }, method: :put, url: school_job_candidate_specification_path(@candidate_specification_form.id)  do |f|
   %h2.heading-medium
     = t('jobs.candidate_specification')
 

--- a/app/views/hiring_staff/vacancies/edit.html.haml
+++ b/app/views/hiring_staff/vacancies/edit.html.haml
@@ -13,63 +13,63 @@
         %dd.cya-answer
           = @vacancy.job_title
         %dd.cya-change
-          = link_to t('buttons.change'), edit_school_job_job_specification_path(@school, @vacancy.id, anchor: 'job_title')
+          = link_to t('buttons.change'), edit_school_job_job_specification_path(@vacancy.id, anchor: 'job_title')
       %div
         %dt.cya-question
           = t('jobs.description')
         %dd.cya-answer
           = @vacancy.job_description
         %dd.cya-change
-          = link_to t('buttons.change'), edit_school_job_job_specification_path(@school, @vacancy.id, anchor: 'job_description')
+          = link_to t('buttons.change'), edit_school_job_job_specification_path(@vacancy.id, anchor: 'job_description')
       %div
         %dt.cya-question
           = t('jobs.main_subject')
         %dd.cya-answer
           = @vacancy.main_subject
         %dd.cya-change
-          = link_to t('buttons.change'), edit_school_job_job_specification_path(@school, @vacancy.id, anchor: 'subject')
+          = link_to t('buttons.change'), edit_school_job_job_specification_path(@vacancy.id, anchor: 'subject')
       %div
         %dt.cya-question
           = t('jobs.salary_range')
         %dd.cya-answer
           = @vacancy.salary_range("to")
         %dd.cya-change
-          = link_to t('buttons.change'), edit_school_job_job_specification_path(@school, @vacancy.id, anchor: 'salary_range')
+          = link_to t('buttons.change'), edit_school_job_job_specification_path(@vacancy.id, anchor: 'salary_range')
       %div
         %dt.cya-question
           = t('jobs.working_pattern')
         %dd.cya-answer
           = @vacancy.working_pattern.humanize
         %dd.cya-change
-          = link_to t('buttons.change'), edit_school_job_job_specification_path(@school, @vacancy.id, anchor: 'working_pattern')
+          = link_to t('buttons.change'), edit_school_job_job_specification_path(@vacancy.id, anchor: 'working_pattern')
       %div
         %dt.cya-question
           = t('jobs.flexible_working')
         %dd.cya-answer
           = @vacancy.flexible_working
         %dd.cya-change
-          = link_to t('buttons.change'), edit_school_job_job_specification_path(@school, @vacancy.id, anchor: 'flexible_working')
+          = link_to t('buttons.change'), edit_school_job_job_specification_path(@vacancy.id, anchor: 'flexible_working')
       %div
         %dt.cya-question
           = t('jobs.benefits')
         %dd.cya-answer
           = @vacancy.benefits
         %dd.cya-change
-          = link_to t('buttons.change'), edit_school_job_job_specification_path(@school, @vacancy.id, anchor: 'benefits')
+          = link_to t('buttons.change'), edit_school_job_job_specification_path(@vacancy.id, anchor: 'benefits')
       %div
         %dt.cya-question
           = t('jobs.pay_scale')
         %dd.cya-answer
           =@vacancy.pay_scale_range
         %dd.cya-change
-          = link_to t('buttons.change'), edit_school_job_job_specification_path(@school, @vacancy.id, anchor: 'pay_scale_range')
+          = link_to t('buttons.change'), edit_school_job_job_specification_path(@vacancy.id, anchor: 'pay_scale_range')
       %div
         %dt.cya-question
           = t('jobs.weekly_hours')
         %dd.cya-answer
           = @vacancy.weekly_hours
         %dd.cya-change
-          = link_to t('buttons.change'), edit_school_job_job_specification_path(@school, @vacancy.id, anchor: 'weekly_hours')
+          = link_to t('buttons.change'), edit_school_job_job_specification_path(@vacancy.id, anchor: 'weekly_hours')
       %div
         %dt.cya-question
           = t('jobs.leadership_level')
@@ -77,21 +77,21 @@
           - if @vacancy.leadership
             = @vacancy.leadership.title
         %dd.cya-change
-          = link_to t('buttons.change'), edit_school_job_job_specification_path(@school, @vacancy.id, anchor: 'leadership')
+          = link_to t('buttons.change'), edit_school_job_job_specification_path(@vacancy.id, anchor: 'leadership')
       %div
         %dt.cya-question
           = t('jobs.starts_on')
         %dd.cya-answer
           = format_date @vacancy.starts_on
         %dd.cya-change
-          = link_to t('buttons.change'), edit_school_job_job_specification_path(@school, @vacancy.id, anchor: 'starts_on')
+          = link_to t('buttons.change'), edit_school_job_job_specification_path(@vacancy.id, anchor: 'starts_on')
       %div
         %dt.cya-question
           = t('jobs.ends_on')
         %dd.cya-answer
           = format_date @vacancy.ends_on
         %dd.cya-change
-          = link_to t('buttons.change'), edit_school_job_job_specification_path(@school, @vacancy.id, anchor: 'ends_on')
+          = link_to t('buttons.change'), edit_school_job_job_specification_path(@vacancy.id, anchor: 'ends_on')
 
     %h2.heading-medium= t('jobs.candidate_specification')
     %dl.govuk-check-your-answers.cya-questions-short
@@ -101,21 +101,21 @@
         %dd.cya-answer
           = @vacancy.education
         %dd.cya-change
-          = link_to t('buttons.change'), edit_school_job_candidate_specification_path(@school, @vacancy.id, anchor: 'education')
+          = link_to t('buttons.change'), edit_school_job_candidate_specification_path(@vacancy.id, anchor: 'education')
       %div
         %dt.cya-question
           = t('jobs.qualifications')
         %dd.cya-answer
           = @vacancy.qualifications
         %dd.cya-change
-          = link_to t('buttons.change'), edit_school_job_candidate_specification_path(@school, @vacancy.id, anchor: 'qualifications')
+          = link_to t('buttons.change'), edit_school_job_candidate_specification_path(@vacancy.id, anchor: 'qualifications')
       %div
         %dt.cya-question
           = t('jobs.experience')
         %dd.cya-answer
           = @vacancy.experience
         %dd.cya-change
-          = link_to t('buttons.change'), edit_school_job_candidate_specification_path(@school, @vacancy.id, anchor: 'experience')
+          = link_to t('buttons.change'), edit_school_job_candidate_specification_path(@vacancy.id, anchor: 'experience')
 
     %h2.heading-medium= t('jobs.application_details')
     %dl.govuk-check-your-answers.cya-questions-short
@@ -125,25 +125,25 @@
         %dd.cya-answer
           = @vacancy.contact_email
         %dd.cya-change
-          = link_to t('buttons.change'), edit_school_job_application_details_path(@school, @vacancy.id, anchor: 'contact_email')
+          = link_to t('buttons.change'), edit_school_job_application_details_path(@vacancy.id, anchor: 'contact_email')
       %div
         %dt.cya-question
           = t('jobs.application_link')
         %dd.cya-answer
           = @vacancy.application_link
         %dd.cya-change
-          = link_to t('buttons.change'), edit_school_job_application_details_path(@school, @vacancy.id, anchor: 'application_link')
+          = link_to t('buttons.change'), edit_school_job_application_details_path(@vacancy.id, anchor: 'application_link')
       %div
         %dt.cya-question
           = t('jobs.publication_date')
         %dd.cya-answer
           = format_date @vacancy.publish_on
         %dd.cya-change
-          = link_to t('buttons.change'), edit_school_job_application_details_path(@school, @vacancy.id, anchor: 'publish_on')
+          = link_to t('buttons.change'), edit_school_job_application_details_path(@vacancy.id, anchor: 'publish_on')
       %div
         %dt.cya-question
           = t('jobs.deadline_date')
         %dd.cya-answer
           = format_date @vacancy.expires_on
         %dd.cya-change
-          = link_to t('buttons.change'), edit_school_job_application_details_path(@school, @vacancy.id, anchor: 'expires_on')
+          = link_to t('buttons.change'), edit_school_job_application_details_path(@vacancy.id, anchor: 'expires_on')

--- a/app/views/hiring_staff/vacancies/job_specification/edit.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/edit.html.haml
@@ -1,7 +1,7 @@
 %h1.heading-large
   = t('jobs.edit_heading', school: @school.name)
 = render 'hiring_staff/vacancies/error_messages', errors: @job_specification_form.errors
-= simple_form_for @job_specification_form, html: { class: 'vacancy-form' }, method: :put, url: school_job_job_specification_path(@school, @job_specification_form.id) do |f|
+= simple_form_for @job_specification_form, html: { class: 'vacancy-form' }, method: :put, url: school_job_job_specification_path(@job_specification_form.id) do |f|
   %h2.heading-medium
     = t('jobs.job_specification')
 

--- a/app/views/hiring_staff/vacancies/review.html.haml
+++ b/app/views/hiring_staff/vacancies/review.html.haml
@@ -17,49 +17,49 @@
         %dd.cya-answer
           = @vacancy.job_title
         %dd.cya-change
-          = link_to t('buttons.change'), job_specification_school_job_path(@school, anchor: 'job_title')
+          = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'job_title')
       %div
         %dt.cya-question
           = t('jobs.description')
         %dd.cya-answer
           = @vacancy.job_description
         %dd.cya-change
-          = link_to t('buttons.change'), job_specification_school_job_path(@school, anchor: 'job_description')
+          = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'job_description')
       %div
         %dt.cya-question
           = t('jobs.main_subject')
         %dd.cya-answer
           = @vacancy.main_subject
         %dd.cya-change
-          = link_to t('buttons.change'), job_specification_school_job_path(@school, anchor: 'subject')
+          = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'subject')
       %div
         %dt.cya-question
           = t('jobs.pay_scale')
         %dd.cya-answer
           =@vacancy.pay_scale_range
         %dd.cya-change
-          = link_to t('buttons.change'), job_specification_school_job_path(@school, anchor: 'pay_scale_range')
+          = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'pay_scale_range')
       %div
         %dt.cya-question
           = t('jobs.salary_range')
         %dd.cya-answer
           = @vacancy.salary_range("to")
         %dd.cya-change
-          = link_to t('buttons.change'), job_specification_school_job_path(@school, anchor: 'salary_range')
+          = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'salary_range')
       %div
         %dt.cya-question
           = t('jobs.working_pattern')
         %dd.cya-answer
           = @vacancy.working_pattern.humanize
         %dd.cya-change
-          = link_to t('buttons.change'), job_specification_school_job_path(@school, anchor: 'working_pattern')
+          = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'working_pattern')
       %div
         %dt.cya-question
           = t('jobs.flexible_working')
         %dd.cya-answer
           = @vacancy.flexible_working
         %dd.cya-change
-          = link_to t('buttons.change'), job_specification_school_job_path(@school, anchor: 'flexible_working')
+          = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'flexible_working')
 
       %div
         %dt.cya-question
@@ -67,14 +67,14 @@
         %dd.cya-answer
           = @vacancy.benefits
         %dd.cya-change
-          = link_to t('buttons.change'), job_specification_school_job_path(@school, anchor: 'benefits')
+          = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'benefits')
       %div
         %dt.cya-question
           = t('jobs.weekly_hours')
         %dd.cya-answer
           = @vacancy.weekly_hours
         %dd.cya-change
-          = link_to t('buttons.change'), job_specification_school_job_path(@school, anchor: 'weekly_hours')
+          = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'weekly_hours')
       %div
         %dt.cya-question
           = t('jobs.leadership_level')
@@ -82,21 +82,21 @@
           - if @vacancy.leadership
             = @vacancy.leadership.title
         %dd.cya-change
-          = link_to t('buttons.change'), job_specification_school_job_path(@school, anchor: 'leadership')
+          = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'leadership')
       %div
         %dt.cya-question
           = t('jobs.starts_on')
         %dd.cya-answer
           = format_date @vacancy.starts_on
         %dd.cya-change
-          = link_to t('buttons.change'), job_specification_school_job_path(@school, anchor: 'starts_on')
+          = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'starts_on')
       %div
         %dt.cya-question
           = t('jobs.ends_on')
         %dd.cya-answer
           = format_date @vacancy.ends_on
         %dd.cya-change
-          = link_to t('buttons.change'), job_specification_school_job_path(@school, anchor: 'ends_on')
+          = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'ends_on')
 
     %h2.heading-medium= t('jobs.candidate_specification')
     %dl.govuk-check-your-answers.cya-questions-short
@@ -106,21 +106,21 @@
         %dd.cya-answer
           = @vacancy.education
         %dd.cya-change
-          = link_to t('buttons.change'), candidate_specification_school_job_path(@school, anchor: 'education')
+          = link_to t('buttons.change'), candidate_specification_school_job_path(anchor: 'education')
       %div
         %dt.cya-question
           = t('jobs.qualifications')
         %dd.cya-answer
           = @vacancy.qualifications
         %dd.cya-change
-          = link_to t('buttons.change'), candidate_specification_school_job_path(@school, anchor: 'qualifications')
+          = link_to t('buttons.change'), candidate_specification_school_job_path(anchor: 'qualifications')
       %div
         %dt.cya-question
           = t('jobs.experience')
         %dd.cya-answer
           = @vacancy.experience
         %dd.cya-change
-          = link_to t('buttons.change'), candidate_specification_school_job_path(@school, anchor: 'experience')
+          = link_to t('buttons.change'), candidate_specification_school_job_path(anchor: 'experience')
 
     %h2.heading-medium= t('jobs.application_details')
     %dl.govuk-check-your-answers.cya-questions-short
@@ -130,30 +130,30 @@
         %dd.cya-answer
           = @vacancy.contact_email
         %dd.cya-change
-          = link_to t('buttons.change'), application_details_school_job_path(@school, anchor: 'contact_email')
+          = link_to t('buttons.change'), application_details_school_job_path(anchor: 'contact_email')
       %div
         %dt.cya-question
           = t('jobs.application_link')
         %dd.cya-answer
           = @vacancy.application_link
         %dd.cya-change
-          = link_to t('buttons.change'), application_details_school_job_path(@school, anchor: 'application_link')
+          = link_to t('buttons.change'), application_details_school_job_path(anchor: 'application_link')
       %div
         %dt.cya-question
           = t('jobs.publication_date')
         %dd.cya-answer
           = format_date @vacancy.publish_on
         %dd.cya-change
-          = link_to t('buttons.change'), application_details_school_job_path(@school, anchor: 'publish_on')
+          = link_to t('buttons.change'), application_details_school_job_path(anchor: 'publish_on')
       %div
         %dt.cya-question
           = t('jobs.deadline_date')
         %dd.cya-answer
           = format_date @vacancy.expires_on
         %dd.cya-change
-          = link_to t('buttons.change'), application_details_school_job_path(@school, anchor: 'expires_on')
+          = link_to t('buttons.change'), application_details_school_job_path(anchor: 'expires_on')
 
     %h2.heading-medium Now submit your job
     %p= t('jobs.confirmation_summary')
 
-    = link_to t('jobs.submit'), school_job_publish_path(school_id: @school.id, vacancy_id: @vacancy.id), method: :post, class: "button"
+    = link_to t('jobs.submit'), school_job_publish_path(vacancy_id: @vacancy.id), method: :post, class: "button"

--- a/app/views/hiring_staff/vacancies/summary.html.haml
+++ b/app/views/hiring_staff/vacancies/summary.html.haml
@@ -16,4 +16,4 @@
       %p
         = t('jobs.preview_posted_job', date: @vacancy.publish_on)
       %p
-        = link_to school_job_url(school_id: @school.id, id: @vacancy.id), school_job_path(school_id: @school.id, id: @vacancy.id)
+        = link_to school_job_url(@vacancy.id), school_job_path(@vacancy.id)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,7 @@ Rails.application.routes.draw do
   get '/auth/failure', to: 'hiring_staff/sessions#failure' # For OmniAuth testing only
   post '/auth/azureactivedirectory/callback', to: 'hiring_staff/sessions#create'
 
-  resources :schools, only: %i[show edit update], controller: 'hiring_staff/schools' do
+  resource :school, only: %i[show edit update], controller: 'hiring_staff/schools' do
     resources :jobs, only: %i[new edit destroy delete show], controller: 'hiring_staff/vacancies' do
       get 'review'
       get 'summary'

--- a/spec/features/hiring_staff_can_edit_a_published_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_edit_a_published_vacancy_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
   context 'attempting to edit a draft vacancy' do
     scenario 'redirects to the review vacancy page' do
       vacancy = create(:vacancy, :draft, school: school)
-      visit edit_school_job_path(school, vacancy.id)
+      visit edit_school_job_path(vacancy.id)
 
       expect(page).to have_content("Review the job for #{school.name}")
     end
@@ -19,7 +19,7 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
   context 'navigation' do
     scenario 'links to the school page' do
       vacancy = create(:vacancy, :published, school: school)
-      visit edit_school_job_path(school, vacancy.id)
+      visit edit_school_job_path(vacancy.id)
 
       click_on school.name
       expect(page).to have_content("Jobs at #{school.name}")
@@ -29,7 +29,7 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
   context 'editing a published vacancy' do
     scenario 'takes your to the edit page' do
       vacancy = create(:vacancy, :published, school: school)
-      visit edit_school_job_path(school, vacancy.id)
+      visit edit_school_job_path(vacancy.id)
 
       expect(page).to have_content("Edit job for #{school.name}")
     end
@@ -37,7 +37,7 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
     context '#job_specification' do
       scenario 'can not be edited when validation fails' do
         vacancy = create(:vacancy, :published, school: school)
-        visit edit_school_job_path(school, vacancy.id)
+        visit edit_school_job_path(vacancy.id)
 
         expect(page).to have_content("Edit job for #{school.name}")
         click_link_in_container_with_text('Job title')
@@ -50,7 +50,7 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
 
       scenario 'can be succesfuly edited' do
         vacancy = create(:vacancy, :published, school: school)
-        visit edit_school_job_path(school, vacancy.id)
+        visit edit_school_job_path(vacancy.id)
         click_link_in_container_with_text('Job title')
 
         fill_in 'job_specification_form[job_title]', with: 'Assistant Head Teacher'
@@ -64,7 +64,7 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
         vacancy = create(:vacancy, :published, school: school)
         job_title = vacancy.job_title
 
-        visit edit_school_job_path(school, vacancy.id)
+        visit edit_school_job_path(vacancy.id)
         click_link_in_container_with_text('Job title')
 
         fill_in 'job_specification_form[job_title]', with: 'Assistant Head Teacher'
@@ -80,7 +80,7 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
     context '#candidate_specification' do
       scenario 'can not be edited when validation fails' do
         vacancy = create(:vacancy, :published, school: school)
-        visit edit_school_job_path(school, vacancy.id)
+        visit edit_school_job_path(vacancy.id)
 
         expect(page).to have_content("Edit job for #{school.name}")
         click_link_in_container_with_text(I18n.t('jobs.experience'))
@@ -95,7 +95,7 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
 
       scenario 'can be succesfuly edited' do
         vacancy = create(:vacancy, :published, school: school)
-        visit edit_school_job_path(school, vacancy.id)
+        visit edit_school_job_path(vacancy.id)
         click_link_in_container_with_text(I18n.t('jobs.qualifications'))
 
         fill_in 'candidate_specification_form[qualifications]', with: 'Teaching deegree'
@@ -109,7 +109,7 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
         vacancy = create(:vacancy, :published, school: school)
         qualifications = vacancy.qualifications
 
-        visit edit_school_job_path(school, vacancy.id)
+        visit edit_school_job_path(vacancy.id)
         click_link_in_container_with_text(I18n.t('jobs.qualifications'))
 
         fill_in 'candidate_specification_form[qualifications]', with: 'Teaching deegree'
@@ -126,7 +126,7 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
     context '#application_details' do
       scenario 'can not be edited when validation fails' do
         vacancy = create(:vacancy, :published, school: school)
-        visit edit_school_job_path(school, vacancy.id)
+        visit edit_school_job_path(vacancy.id)
 
         expect(page).to have_content("Edit job for #{school.name}")
         click_link_in_container_with_text(I18n.t('jobs.application_link'))
@@ -142,7 +142,7 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
       scenario 'can be succesfuly edited' do
         vacancy = create(:vacancy, :published, school: school)
         vacancy = VacancyPresenter.new(vacancy)
-        visit edit_school_job_path(school, vacancy.id)
+        visit edit_school_job_path(vacancy.id)
 
         click_link_in_container_with_text(I18n.t('jobs.application_link'))
         vacancy.application_link = 'https://tvs.com'
@@ -159,7 +159,7 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
       vacancy = create(:vacancy, :published, school: school)
       application_link = vacancy.application_link
 
-      visit edit_school_job_path(school, vacancy.id)
+      visit edit_school_job_path(vacancy.id)
       click_link_in_container_with_text(I18n.t('jobs.application_link'))
 
       fill_in 'application_details_form[application_link]', with: 'https://schooljobs.com'

--- a/spec/features/hiring_staff_can_edit_a_school_description_spec.rb
+++ b/spec/features/hiring_staff_can_edit_a_school_description_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature 'Editing a School’s description' do
   end
 
   scenario 'updating a description' do
-    visit school_path(school)
+    visit school_path
 
     expect(page).to have_content(school.name)
     expect(page).to have_content(school.description)
@@ -21,7 +21,7 @@ RSpec.feature 'Editing a School’s description' do
   end
 
   scenario 'removing a description' do
-    visit school_path(school)
+    visit school_path
 
     expect(page).to have_content(school.name)
     expect(page).to have_content(school.description)
@@ -35,7 +35,7 @@ RSpec.feature 'Editing a School’s description' do
 
   scenario 'audits changes to the school\'s description' do
     description = school.description
-    visit school_path(school)
+    visit school_path
 
     click_on 'Change description'
     fill_in 'Description', with: ''

--- a/spec/features/hiring_staff_can_only_see_their_school_spec.rb
+++ b/spec/features/hiring_staff_can_only_see_their_school_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature 'Hiring staff can only see their school' do
       school = create(:school)
       stub_hiring_staff_auth(urn: school.urn)
 
-      visit school_path(school)
+      visit school_path
 
       expect(page).to have_content(school.name)
     end
@@ -14,10 +14,10 @@ RSpec.feature 'Hiring staff can only see their school' do
 
   context 'when the log in is NOT connected to a school' do
     scenario 'returns a 404' do
-      school = create(:school)
+      create(:school)
       stub_hiring_staff_auth(urn: 'foo')
 
-      visit school_path(school)
+      visit school_path
 
       expect(page).to have_content('Page not found')
     end

--- a/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature 'Creating a vacancy' do
     school = create(:school, name: 'Salisbury School')
     stub_hiring_staff_auth(urn: school.urn)
 
-    visit school_path(school)
+    visit school_path
 
     expect(page).to have_content('Salisbury School')
     expect(page).to have_content(/#{school.address}/)
@@ -35,16 +35,16 @@ RSpec.feature 'Creating a vacancy' do
     end
 
     scenario 'redirects to step 1, job specification' do
-      visit new_school_job_path(school)
+      visit new_school_job_path
 
-      expect(page.current_path).to eq(job_specification_school_job_path(school))
+      expect(page.current_path).to eq(job_specification_school_job_path)
       expect(page).to have_content("Publish a job for #{school.name}")
       expect(page).to have_content('Step 1 of 3')
     end
 
     context '#job_specification' do
       scenario 'is invalid unless all mandatory fields are submitted' do
-        visit new_school_job_path(school)
+        visit new_school_job_path
 
         click_on 'Save and continue'
 
@@ -70,7 +70,7 @@ RSpec.feature 'Creating a vacancy' do
       end
 
       scenario 'redirects to step 2, candidate profile, when submitted succesfuly' do
-        visit new_school_job_path(school)
+        visit new_school_job_path
 
         fill_in_job_specification_form_fields(vacancy)
         click_on 'Save and continue'
@@ -79,7 +79,7 @@ RSpec.feature 'Creating a vacancy' do
       end
 
       scenario 'tracks the vacancy creation' do
-        visit new_school_job_path(school)
+        visit new_school_job_path
 
         fill_in_job_specification_form_fields(vacancy)
         click_on 'Save and continue'
@@ -93,7 +93,7 @@ RSpec.feature 'Creating a vacancy' do
 
     context '#candidate_profile' do
       scenario 'is invalid unless all mandatory fields are submitted' do
-        visit new_school_job_path(school)
+        visit new_school_job_path
 
         fill_in_job_specification_form_fields(vacancy)
         click_on 'Save and continue'
@@ -117,7 +117,7 @@ RSpec.feature 'Creating a vacancy' do
       end
 
       scenario 'redirects to step 3, application_details profile, when submitted succesfuly' do
-        visit new_school_job_path(school)
+        visit new_school_job_path
 
         fill_in_job_specification_form_fields(vacancy)
         click_on 'Save and continue'
@@ -130,7 +130,7 @@ RSpec.feature 'Creating a vacancy' do
 
     context '#application_details' do
       scenario 'is invalid unless all mandatory fields are submitted' do
-        visit new_school_job_path(school)
+        visit new_school_job_path
 
         fill_in_job_specification_form_fields(vacancy)
         click_on 'Save and continue'
@@ -156,7 +156,7 @@ RSpec.feature 'Creating a vacancy' do
       end
 
       scenario 'redirects to the vacancy review page when submitted succesfuly' do
-        visit new_school_job_path(school)
+        visit new_school_job_path
 
         fill_in_job_specification_form_fields(vacancy)
         click_on 'Save and continue'
@@ -174,14 +174,14 @@ RSpec.feature 'Creating a vacancy' do
       scenario 'is not available for published vacancies' do
         vacancy = create(:vacancy, :published, school_id: school.id)
 
-        visit school_job_review_path(school, vacancy.id)
+        visit school_job_review_path(vacancy.id)
 
-        expect(page).to have_current_path(school_job_path(school, vacancy.id))
+        expect(page).to have_current_path(school_job_path(vacancy.id))
       end
 
       scenario 'lists all the vacancy details correctly' do
         vacancy = VacancyPresenter.new(create(:vacancy, :complete, :draft, school_id: school.id))
-        visit school_job_review_path(school, vacancy.id)
+        visit school_job_review_path(vacancy.id)
 
         expect(page).to have_content("Review the job for #{school.name}")
 
@@ -191,7 +191,7 @@ RSpec.feature 'Creating a vacancy' do
       context 'edit job_specification_details' do
         scenario 'updates the vacancy details' do
           vacancy = create(:vacancy, :draft, :complete, school_id: school.id)
-          visit school_job_review_path(school, vacancy.id)
+          visit school_job_review_path(vacancy.id)
           click_link_in_container_with_text('Job title')
 
           expect(page).to have_content('Step 1 of 3')
@@ -206,7 +206,7 @@ RSpec.feature 'Creating a vacancy' do
         scenario 'tracks any changes to  the vacancy details' do
           vacancy = create(:vacancy, :draft, :complete, school_id: school.id)
           current_title = vacancy.job_title
-          visit school_job_review_path(school, vacancy.id)
+          visit school_job_review_path(vacancy.id)
           click_link_in_container_with_text('Job title')
 
           expect(page).to have_content('Step 1 of 3')
@@ -221,7 +221,7 @@ RSpec.feature 'Creating a vacancy' do
 
         scenario 'fails validation until values are set correctly' do
           vacancy = create(:vacancy, :draft, :complete, school_id: school.id)
-          visit school_job_review_path(school, vacancy.id)
+          visit school_job_review_path(vacancy.id)
           click_link_in_container_with_text('Job title')
 
           fill_in 'job_specification_form[job_title]', with: ''
@@ -240,7 +240,7 @@ RSpec.feature 'Creating a vacancy' do
       context 'editing the candidate_specification_details' do
         scenario 'updates the vacancy details' do
           vacancy = create(:vacancy, :draft, :complete, school_id: school.id)
-          visit school_job_review_path(school, vacancy.id)
+          visit school_job_review_path(vacancy.id)
           click_link_in_container_with_text('Essential qualifications')
 
           expect(page).to have_content('Step 2 of 3')
@@ -255,7 +255,7 @@ RSpec.feature 'Creating a vacancy' do
         scenario 'tracks any changes to  the vacancy details' do
           vacancy = create(:vacancy, :draft, :complete, school_id: school.id)
           qualifications = vacancy.qualifications
-          visit school_job_review_path(school, vacancy.id)
+          visit school_job_review_path(vacancy.id)
           click_link_in_container_with_text('Essential qualifications')
 
           fill_in 'candidate_specification_form[qualifications]', with: 'Teaching diploma'
@@ -268,7 +268,7 @@ RSpec.feature 'Creating a vacancy' do
 
         scenario 'fails validation until values are set correctly' do
           vacancy = create(:vacancy, :draft, :complete, school_id: school.id)
-          visit school_job_review_path(school, vacancy.id)
+          visit school_job_review_path(vacancy.id)
           click_link_in_container_with_text('Essential educational requirements')
 
           expect(page).to have_content('Step 2 of 3')
@@ -289,7 +289,7 @@ RSpec.feature 'Creating a vacancy' do
       context 'editing the application_details' do
         scenario 'fails validation until values are set correctly' do
           vacancy = create(:vacancy, :draft, :complete, school_id: school.id)
-          visit school_job_review_path(school, vacancy.id)
+          visit school_job_review_path(vacancy.id)
           click_link_in_container_with_text('Job contact email')
 
           expect(page).to have_content('Step 3 of 3')
@@ -308,7 +308,7 @@ RSpec.feature 'Creating a vacancy' do
 
         scenario 'updates the vacancy details' do
           vacancy = create(:vacancy, :draft, :complete, school_id: school.id)
-          visit school_job_review_path(school, vacancy.id)
+          visit school_job_review_path(vacancy.id)
           click_link_in_container_with_text('Job contact email')
 
           expect(page).to have_content('Step 3 of 3')
@@ -323,7 +323,7 @@ RSpec.feature 'Creating a vacancy' do
         scenario 'tracks any changes' do
           vacancy = create(:vacancy, :draft, :complete, school_id: school.id)
           contact_email = vacancy.contact_email
-          visit school_job_review_path(school, vacancy.id)
+          visit school_job_review_path(vacancy.id)
           click_link_in_container_with_text('Job contact email')
 
           fill_in 'application_details_form[contact_email]', with: 'an@email.com'
@@ -337,7 +337,7 @@ RSpec.feature 'Creating a vacancy' do
 
       scenario 'redirects to the school vacancy page when published' do
         vacancy = create(:vacancy, :draft, school_id: school.id)
-        visit school_job_review_path(school, vacancy.id)
+        visit school_job_review_path(vacancy.id)
         click_on 'Confirm and submit job'
 
         expect(page).to have_content('The job has been posted, you can view it here:')
@@ -350,7 +350,7 @@ RSpec.feature 'Creating a vacancy' do
         vacancy.assign_attributes qualifications: nil
         vacancy.save(validate: false)
 
-        visit school_job_review_path(school, vacancy.id)
+        visit school_job_review_path(vacancy.id)
         click_on 'Confirm and submit job'
 
         expect(page).to have_content(I18n.t('errors.jobs.unable_to_publish'))
@@ -359,18 +359,18 @@ RSpec.feature 'Creating a vacancy' do
       scenario 'can be published at a later date' do
         vacancy = create(:vacancy, :draft, school_id: school.id, publish_on: Time.zone.tomorrow)
 
-        visit school_job_review_path(school, vacancy.id)
+        visit school_job_review_path(vacancy.id)
         click_on 'Confirm and submit job'
 
         expect(page).to have_content("The job will be posted on #{vacancy.publish_on}, you can preview it here:")
-        visit school_job_path(school, vacancy.id)
+        visit school_job_path(vacancy.id)
         expect(page).to have_content("Date posted #{format_date(vacancy.publish_on)}")
       end
 
       scenario 'tracks publishing information' do
         vacancy = create(:vacancy, :draft, school_id: school.id, publish_on: Time.zone.tomorrow)
 
-        visit school_job_review_path(school, vacancy.id)
+        visit school_job_review_path(vacancy.id)
         click_on 'Confirm and submit job'
 
         activity = vacancy.activities.last
@@ -379,7 +379,7 @@ RSpec.feature 'Creating a vacancy' do
       end
 
       scenario 'a published vacancy cannot be edited' do
-        visit new_school_job_path(school)
+        visit new_school_job_path
 
         fill_in_job_specification_form_fields(vacancy)
         click_on 'Save and continue'
@@ -390,11 +390,11 @@ RSpec.feature 'Creating a vacancy' do
         click_on 'Confirm and submit job'
         expect(page).to have_content('The job has been posted, you can view it here:')
 
-        visit candidate_specification_school_job_path(school)
-        expect(page.current_path).to eq(job_specification_school_job_path(school))
+        visit candidate_specification_school_job_path
+        expect(page.current_path).to eq(job_specification_school_job_path)
 
-        visit application_details_school_job_path(school)
-        expect(page.current_path).to eq(job_specification_school_job_path(school))
+        visit application_details_school_job_path
+        expect(page.current_path).to eq(job_specification_school_job_path)
       end
     end
   end

--- a/spec/features/hiring_staff_can_see_their_vacancies_spec.rb
+++ b/spec/features/hiring_staff_can_see_their_vacancies_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature 'Hiring staff can see their vacancies' do
     stub_hiring_staff_auth(urn: school.urn)
     vacancy = create(:vacancy, school: school, status: 'published')
 
-    visit school_path(school)
+    visit school_path
 
     click_on(vacancy.job_title)
 

--- a/spec/features/hiring_staff_can_view_vacancies_spec.rb
+++ b/spec/features/hiring_staff_can_view_vacancies_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature 'School viewing vacancies' do
   end
 
   scenario 'A school should see advisory text when there are no vacancies' do
-    visit school_path(school)
+    visit school_path
 
     expect(page).to have_content(I18n.t('schools.jobs.index', school: school.name))
     expect(page).not_to have_css('table.vacancies')
@@ -18,7 +18,7 @@ RSpec.feature 'School viewing vacancies' do
     vacancy1 = create(:vacancy, school: school)
     vacancy2 = create(:vacancy, school: school)
 
-    visit school_path(school)
+    visit school_path
 
     expect(page).to have_content(I18n.t('schools.jobs.index', school: school.name))
     expect(page).to have_content(vacancy1.job_title)
@@ -28,7 +28,7 @@ RSpec.feature 'School viewing vacancies' do
   scenario 'A draft vacancy show page should show a flash message with the status', elasticsearch: true do
     vacancy = create(:vacancy, school: school, status: 'draft')
 
-    visit school_job_path(school, vacancy.id)
+    visit school_job_path(vacancy.id)
 
     expect(page).to have_content(school.name)
     expect(page).to have_content(vacancy.job_title)
@@ -37,7 +37,7 @@ RSpec.feature 'School viewing vacancies' do
 
   scenario 'A published vacancy show page should not show a flash message with the status' do
     vacancy = create(:vacancy, school: school, status: 'published')
-    visit school_job_path(school, vacancy.id)
+    visit school_job_path(vacancy.id)
 
     expect(page).to have_content(school.name)
     expect(page).to have_content(vacancy.job_title)

--- a/spec/support/auth_helpers.rb
+++ b/spec/support/auth_helpers.rb
@@ -109,16 +109,16 @@ RSpec.shared_examples 'basic auth' do
 
   context 'when the path is schools show' do
     it 'returns 401 and asks for the basic auth credentials' do
-      school = create(:school)
+      create(:school)
 
-      get "/schools/#{school.id}"
+      get '/school'
 
       expect(response).to have_http_status(401)
     end
 
     context 'when the correct basic auth credentials are given' do
       it 'returns a 302 redirect to the OmniAuth provider' do
-        school = create(:school)
+        create(:school)
         username = 'username'
         password = 'foobar'
 
@@ -129,7 +129,7 @@ RSpec.shared_examples 'basic auth' do
 
         encoded_credentials = ActionController::HttpAuthentication::Basic.encode_credentials(username, password)
 
-        get "/schools/#{school.id}", env: { 'HTTP_AUTHORIZATION': encoded_credentials }
+        get '/school', env: { 'HTTP_AUTHORIZATION': encoded_credentials }
 
         expect(response).to have_http_status(302)
       end
@@ -137,7 +137,7 @@ RSpec.shared_examples 'basic auth' do
 
     context 'when the incorrect basic auth credentials are given' do
       it 'returns a 401' do
-        school = create(:school)
+        create(:school)
         stub_env_for_staging_auth(env_field_for_username: :http_user,
                                   env_field_for_password: :http_pass,
                                   env_value_for_username: nil,
@@ -145,7 +145,7 @@ RSpec.shared_examples 'basic auth' do
 
         encoded_credentials = ActionController::HttpAuthentication::Basic.encode_credentials('wrong-user', 'password')
 
-        get "/schools/#{school.id}", env: { 'HTTP_AUTHORIZATION': encoded_credentials }
+        get '/school', env: { 'HTTP_AUTHORIZATION': encoded_credentials }
 
         expect(response).to have_http_status(401)
       end


### PR DESCRIPTION
The `school_id`  url param is redundant. 
It also poses a potential security risj as there have already been some routes utilising the url param instead of the one stored in the user’s session, which maps a user to the correct school.