### PR TITLE
Fix/186 table on review job post page incorrectly marked up

### DIFF
--- a/app/assets/stylesheets/base/_utilities.scss
+++ b/app/assets/stylesheets/base/_utilities.scss
@@ -11,6 +11,10 @@
   margin-bottom: $gutter;
 }
 
+.mb0 {
+  margin-bottom: 0;
+}
+
 .mt1 {
   margin-top: $gutter;
 }

--- a/app/assets/stylesheets/components/check_your_answers.scss
+++ b/app/assets/stylesheets/components/check_your_answers.scss
@@ -1,4 +1,6 @@
 // Recommended - Use these styles for the check your answers pattern
+
+// NOTE: these styles are for the <dl> markup versions of CYA, which are invalid.
 .govuk-check-your-answers {
 
   @include media(desktop) {
@@ -82,14 +84,46 @@
 }
 
 // Deprecated - these styles will be removed in a later release
+
+// NOTE: these styles are for the valid <table> versions of the CYA pattern.
 .check-your-answers {
+
+  @include media(desktop) {
+    // to make group of q&a line up horizontally (unless there is just one group)
+    &.cya-questions-short,
+    &.cya-questions-long {
+      width: 100%;
+    } // recommended for mostly short questions
+    &.cya-questions-short .cya-question {
+      width: 30%;
+    } // recommended for mostly long questions
+    &.cya-questions-long .cya-question {
+      width: 50%;
+    }
+  }
+
   td {
     @include core-19;
     vertical-align: top;
+
+    p {
+      margin: 0;
+    }
   }
-  .change-answer {
-    text-align: right;
+
+  .cya-question {
     font-weight: bold;
+  }
+
+  .cya-answer {
+
+  }
+
+  .cya-change {
+    text-align: right;
     padding-right: 0;
   }
+
 }
+
+

--- a/app/views/hiring_staff/vacancies/edit.html.haml
+++ b/app/views/hiring_staff/vacancies/edit.html.haml
@@ -13,8 +13,12 @@
       %thead
         %tr
           %th{:colspan => "2"}
-            %h2.heading-medium
-              = link_to t('jobs.job_specification'), edit_school_job_job_specification_path(@vacancy.id)
+            %h2.heading-medium.mb0
+              = t('jobs.job_specification')
+            .font-xsmall.mb1
+              = link_to edit_school_job_job_specification_path(@vacancy.id) do
+                Change
+                %span.visually-hidden the job specification
           %th
       %tbody
         %tr
@@ -107,8 +111,12 @@
       %thead
         %tr
           %th{:colspan => "2"}
-            %h2.heading-medium
-              = link_to t('jobs.candidate_specification'), edit_school_job_candidate_specification_path(@vacancy.id)
+            %h2.heading-medium.mb0
+              = t('jobs.candidate_specification')
+            .font-xsmall.mb1
+              = link_to edit_school_job_candidate_specification_path(@vacancy.id) do
+                Change
+                %span.visually-hidden the candidate specification
           %th
       %tbody
         %tr
@@ -137,8 +145,12 @@
       %thead
         %tr
           %th{:colspan => "2"}
-            %h2.heading-medium
-              = link_to t('jobs.application_details'), edit_school_job_application_details_path(@vacancy.id)
+            %h2.heading-medium.mb0
+              = t('jobs.application_details')
+            .font-xsmall.mb1
+              = link_to edit_school_job_application_details_path(@vacancy.id) do
+                Change
+                %span.visually-hidden the application details
           %th
       %tbody
         %tr

--- a/app/views/hiring_staff/vacancies/edit.html.haml
+++ b/app/views/hiring_staff/vacancies/edit.html.haml
@@ -9,145 +9,163 @@
 
 .vacancy.grid-row
   .column-two-thirds
-    %h2.heading-medium= t('jobs.job_specification')
-    %dl.govuk-check-your-answers.cya-questions-short
-      %div
-        %dt.cya-question
-          = t('jobs.job_title')
-        %dd.cya-answer
-          = @vacancy.job_title
-        %dd.cya-change
-          = link_to t('buttons.change'), edit_school_job_job_specification_path(@vacancy.id, anchor: 'job_title')
-      %div
-        %dt.cya-question
-          = t('jobs.description')
-        %dd.cya-answer
-          = @vacancy.job_description
-        %dd.cya-change
-          = link_to t('buttons.change'), edit_school_job_job_specification_path(@vacancy.id, anchor: 'job_description')
-      %div
-        %dt.cya-question
-          = t('jobs.main_subject')
-        %dd.cya-answer
-          = @vacancy.main_subject
-        %dd.cya-change
-          = link_to t('buttons.change'), edit_school_job_job_specification_path(@vacancy.id, anchor: 'subject')
-      %div
-        %dt.cya-question
-          = t('jobs.salary_range')
-        %dd.cya-answer
-          = @vacancy.salary_range("to")
-        %dd.cya-change
-          = link_to t('buttons.change'), edit_school_job_job_specification_path(@vacancy.id, anchor: 'salary_range')
-      %div
-        %dt.cya-question
-          = t('jobs.working_pattern')
-        %dd.cya-answer
-          = @vacancy.working_pattern.humanize
-        %dd.cya-change
-          = link_to t('buttons.change'), edit_school_job_job_specification_path(@vacancy.id, anchor: 'working_pattern')
-      %div
-        %dt.cya-question
-          = t('jobs.flexible_working')
-        %dd.cya-answer
-          = @vacancy.flexible_working
-        %dd.cya-change
-          = link_to t('buttons.change'), edit_school_job_job_specification_path(@vacancy.id, anchor: 'flexible_working')
-      %div
-        %dt.cya-question
-          = t('jobs.benefits')
-        %dd.cya-answer
-          = @vacancy.benefits
-        %dd.cya-change
-          = link_to t('buttons.change'), edit_school_job_job_specification_path(@vacancy.id, anchor: 'benefits')
-      %div
-        %dt.cya-question
-          = t('jobs.pay_scale')
-        %dd.cya-answer
-          =@vacancy.pay_scale_range
-        %dd.cya-change
-          = link_to t('buttons.change'), edit_school_job_job_specification_path(@vacancy.id, anchor: 'pay_scale_range')
-      %div
-        %dt.cya-question
-          = t('jobs.weekly_hours')
-        %dd.cya-answer
-          = @vacancy.weekly_hours
-        %dd.cya-change
-          = link_to t('buttons.change'), edit_school_job_job_specification_path(@vacancy.id, anchor: 'weekly_hours')
-      %div
-        %dt.cya-question
-          = t('jobs.leadership_level')
-        %dd.cya-answer
-          - if @vacancy.leadership
-            = @vacancy.leadership.title
-        %dd.cya-change
-          = link_to t('buttons.change'), edit_school_job_job_specification_path(@vacancy.id, anchor: 'leadership')
-      %div
-        %dt.cya-question
-          = t('jobs.starts_on')
-        %dd.cya-answer
-          = format_date @vacancy.starts_on
-        %dd.cya-change
-          = link_to t('buttons.change'), edit_school_job_job_specification_path(@vacancy.id, anchor: 'starts_on')
-      %div
-        %dt.cya-question
-          = t('jobs.ends_on')
-        %dd.cya-answer
-          = format_date @vacancy.ends_on
-        %dd.cya-change
-          = link_to t('buttons.change'), edit_school_job_job_specification_path(@vacancy.id, anchor: 'ends_on')
+    %table.check-your-answers.cya-questions-short
+      %thead
+        %tr
+          %th{:colspan => "2"}
+            %h2.heading-medium
+              = t('jobs.job_specification')
+          %th
+      %tbody
+        %tr
+          %td.cya-question
+            = t('jobs.job_title')
+          %td.cya-answer
+            = @vacancy.job_title
+          %td.cya-change
+            = link_to t('buttons.change'), edit_school_job_job_specification_path(@vacancy.id, anchor: 'job_title')
+        %tr
+          %td.cya-question
+            = t('jobs.description')
+          %td.cya-answer
+            = @vacancy.job_description
+          %td.cya-change
+            = link_to t('buttons.change'), edit_school_job_job_specification_path(@vacancy.id, anchor: 'job_description')
+        %tr
+          %td.cya-question
+            = t('jobs.main_subject')
+          %td.cya-answer
+            = @vacancy.main_subject
+          %td.cya-change
+            = link_to t('buttons.change'), edit_school_job_job_specification_path(@vacancy.id, anchor: 'subject')
+        %tr
+          %td.cya-question
+            = t('jobs.salary_range')
+          %td.cya-answer
+            = @vacancy.salary_range("to")
+          %td.cya-change
+            = link_to t('buttons.change'), edit_school_job_job_specification_path(@vacancy.id, anchor: 'salary_range')
+        %tr
+          %td.cya-question
+            = t('jobs.working_pattern')
+          %td.cya-answer
+            = @vacancy.working_pattern.humanize
+          %td.cya-change
+            = link_to t('buttons.change'), edit_school_job_job_specification_path(@vacancy.id, anchor: 'working_pattern')
+        %tr
+          %td.cya-question
+            = t('jobs.flexible_working')
+          %td.cya-answer
+            = @vacancy.flexible_working
+          %td.cya-change
+            = link_to t('buttons.change'), edit_school_job_job_specification_path(@vacancy.id, anchor: 'flexible_working')
+        %tr
+          %td.cya-question
+            = t('jobs.benefits')
+          %td.cya-answer
+            = @vacancy.benefits
+          %td.cya-change
+            = link_to t('buttons.change'), edit_school_job_job_specification_path(@vacancy.id, anchor: 'benefits')
+        %tr
+          %td.cya-question
+            = t('jobs.pay_scale')
+          %td.cya-answer
+            =@vacancy.pay_scale_range
+          %td.cya-change
+            = link_to t('buttons.change'), edit_school_job_job_specification_path(@vacancy.id, anchor: 'pay_scale_range')
+        %tr
+          %td.cya-question
+            = t('jobs.weekly_hours')
+          %td.cya-answer
+            = @vacancy.weekly_hours
+          %td.cya-change
+            = link_to t('buttons.change'), edit_school_job_job_specification_path(@vacancy.id, anchor: 'weekly_hours')
+        %tr
+          %td.cya-question
+            = t('jobs.leadership_level')
+          %td.cya-answer
+            - if @vacancy.leadership
+              = @vacancy.leadership.title
+          %td.cya-change
+            = link_to t('buttons.change'), edit_school_job_job_specification_path(@vacancy.id, anchor: 'leadership')
+        %tr
+          %td.cya-question
+            = t('jobs.starts_on')
+          %td.cya-answer
+            = format_date @vacancy.starts_on
+          %td.cya-change
+            = link_to t('buttons.change'), edit_school_job_job_specification_path(@vacancy.id, anchor: 'starts_on')
+        %tr
+          %td.cya-question
+            = t('jobs.ends_on')
+          %td.cya-answer
+            = format_date @vacancy.ends_on
+          %td.cya-change
+            = link_to t('buttons.change'), edit_school_job_job_specification_path(@vacancy.id, anchor: 'ends_on')
 
-    %h2.heading-medium= t('jobs.candidate_specification')
-    %dl.govuk-check-your-answers.cya-questions-short
-      %div
-        %dt.cya-question
-          = t('jobs.education')
-        %dd.cya-answer
-          = @vacancy.education
-        %dd.cya-change
-          = link_to t('buttons.change'), edit_school_job_candidate_specification_path(@vacancy.id, anchor: 'education')
-      %div
-        %dt.cya-question
-          = t('jobs.qualifications')
-        %dd.cya-answer
-          = @vacancy.qualifications
-        %dd.cya-change
-          = link_to t('buttons.change'), edit_school_job_candidate_specification_path(@vacancy.id, anchor: 'qualifications')
-      %div
-        %dt.cya-question
-          = t('jobs.experience')
-        %dd.cya-answer
-          = @vacancy.experience
-        %dd.cya-change
-          = link_to t('buttons.change'), edit_school_job_candidate_specification_path(@vacancy.id, anchor: 'experience')
+    %table.check-your-answers.cya-questions-short
+      %thead
+        %tr
+          %th{:colspan => "2"}
+            %h2.heading-medium
+              = t('jobs.candidate_specification')
+          %th
+      %tbody
+        %tr
+          %td.cya-question
+            = t('jobs.education')
+          %td.cya-answer
+            = @vacancy.education
+          %td.cya-change
+            = link_to t('buttons.change'), edit_school_job_candidate_specification_path(@vacancy.id, anchor: 'education')
+        %tr
+          %td.cya-question
+            = t('jobs.qualifications')
+          %td.cya-answer
+            = @vacancy.qualifications
+          %td.cya-change
+            = link_to t('buttons.change'), edit_school_job_candidate_specification_path(@vacancy.id, anchor: 'qualifications')
+        %tr
+          %td.cya-question
+            = t('jobs.experience')
+          %td.cya-answer
+            = @vacancy.experience
+          %td.cya-change
+            = link_to t('buttons.change'), edit_school_job_candidate_specification_path(@vacancy.id, anchor: 'experience')
 
-    %h2.heading-medium= t('jobs.application_details')
-    %dl.govuk-check-your-answers.cya-questions-short
-      %div
-        %dt.cya-question
-          = t('jobs.contact_email')
-        %dd.cya-answer
-          = @vacancy.contact_email
-        %dd.cya-change
-          = link_to t('buttons.change'), edit_school_job_application_details_path(@vacancy.id, anchor: 'contact_email')
-      %div
-        %dt.cya-question
-          = t('jobs.application_link')
-        %dd.cya-answer
-          = @vacancy.application_link
-        %dd.cya-change
-          = link_to t('buttons.change'), edit_school_job_application_details_path(@vacancy.id, anchor: 'application_link')
-      %div
-        %dt.cya-question
-          = t('jobs.publication_date')
-        %dd.cya-answer
-          = format_date @vacancy.publish_on
-        %dd.cya-change
-          = link_to t('buttons.change'), edit_school_job_application_details_path(@vacancy.id, anchor: 'publish_on')
-      %div
-        %dt.cya-question
-          = t('jobs.deadline_date')
-        %dd.cya-answer
-          = format_date @vacancy.expires_on
-        %dd.cya-change
-          = link_to t('buttons.change'), edit_school_job_application_details_path(@vacancy.id, anchor: 'expires_on')
+    %table.check-your-answers.cya-questions-short
+      %thead
+        %tr
+          %th{:colspan => "2"}
+            %h2.heading-medium
+              = t('jobs.application_details')
+          %th
+      %tbody
+        %tr
+          %td.cya-question
+            = t('jobs.contact_email')
+          %td.cya-answer
+            = @vacancy.contact_email
+          %td.cya-change
+            = link_to t('buttons.change'), edit_school_job_application_details_path(@vacancy.id, anchor: 'contact_email')
+        %tr
+          %td.cya-question
+            = t('jobs.application_link')
+          %td.cya-answer
+            = @vacancy.application_link
+          %td.cya-change
+            = link_to t('buttons.change'), edit_school_job_application_details_path(@vacancy.id, anchor: 'application_link')
+        %tr
+          %td.cya-question
+            = t('jobs.publication_date')
+          %td.cya-answer
+            = format_date @vacancy.publish_on
+          %td.cya-change
+            = link_to t('buttons.change'), edit_school_job_application_details_path(@vacancy.id, anchor: 'publish_on')
+        %tr
+          %td.cya-question
+            = t('jobs.deadline_date')
+          %td.cya-answer
+            = format_date @vacancy.expires_on
+          %td.cya-change
+            = link_to t('buttons.change'), edit_school_job_application_details_path(@vacancy.id, anchor: 'expires_on')

--- a/app/views/hiring_staff/vacancies/edit.html.haml
+++ b/app/views/hiring_staff/vacancies/edit.html.haml
@@ -14,7 +14,7 @@
         %tr
           %th{:colspan => "2"}
             %h2.heading-medium
-              = t('jobs.job_specification')
+              = link_to t('jobs.job_specification'), edit_school_job_job_specification_path(@vacancy.id)
           %th
       %tbody
         %tr
@@ -108,7 +108,7 @@
         %tr
           %th{:colspan => "2"}
             %h2.heading-medium
-              = t('jobs.candidate_specification')
+              = link_to t('jobs.candidate_specification'), edit_school_job_candidate_specification_path(@vacancy.id)
           %th
       %tbody
         %tr
@@ -138,7 +138,7 @@
         %tr
           %th{:colspan => "2"}
             %h2.heading-medium
-              = t('jobs.application_details')
+              = link_to t('jobs.application_details'), edit_school_job_application_details_path(@vacancy.id)
           %th
       %tbody
         %tr

--- a/app/views/hiring_staff/vacancies/edit.html.haml
+++ b/app/views/hiring_staff/vacancies/edit.html.haml
@@ -2,8 +2,10 @@
 
 =render partial: 'school_vacancy_breadcrumb'
 
-%h1.heading-large
-  = t('jobs.edit_heading', school: @vacancy.school.name)
+.grid-row
+  .column-two-thirds
+    %h1.heading-large
+      = t('jobs.edit_heading', school: @vacancy.school.name)
 
 .vacancy.grid-row
   .column-two-thirds

--- a/app/views/hiring_staff/vacancies/review.html.haml
+++ b/app/views/hiring_staff/vacancies/review.html.haml
@@ -15,8 +15,12 @@
       %thead
         %tr
           %th{:colspan => "2"}
-            %h2.heading-medium
-              = link_to t('jobs.job_specification'), job_specification_school_job_path
+            %h2.heading-medium.mb0
+              = t('jobs.job_specification')
+            .font-xsmall.mb1
+              = link_to job_specification_school_job_path do
+                Change
+                %span.visually-hidden the job specification
           %th
       %tbody
         %tr
@@ -109,8 +113,12 @@
       %thead
         %tr
           %th{:colspan => "2"}
-            %h2.heading-medium
-              = link_to t('jobs.candidate_specification'), candidate_specification_school_job_path
+            %h2.heading-medium.mb0
+              = t('jobs.candidate_specification')
+            .font-xsmall.mb1
+              = link_to candidate_specification_school_job_path do
+                Change
+                %span.visually-hidden the candidate specification
           %th
       %tbody
         %tr
@@ -139,8 +147,12 @@
       %thead
         %tr
           %th{:colspan => "2"}
-            %h2.heading-medium
-              = link_to t('jobs.application_details'), application_details_school_job_path
+            %h2.heading-medium.mb0
+              = t('jobs.application_details')
+            .font-xsmall.mb1
+              = link_to application_details_school_job_path do
+                Change
+                %span.visually-hidden the application details
           %th
       %tbody
         %tr

--- a/app/views/hiring_staff/vacancies/review.html.haml
+++ b/app/views/hiring_staff/vacancies/review.html.haml
@@ -22,13 +22,6 @@
         %tr
           %td.cya-question
             = t('jobs.job_title')
-          %td
-            = @vacancy.job_title
-          %td.cya-change
-            = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'job_title')
-        %tr
-          %td.cya-question
-            = t('jobs.job_title')
           %td.cya-answer
             = @vacancy.job_title
           %td.cya-change

--- a/app/views/hiring_staff/vacancies/review.html.haml
+++ b/app/views/hiring_staff/vacancies/review.html.haml
@@ -2,11 +2,12 @@
 
 =render partial: 'school_vacancy_breadcrumb'
 
-%h1.heading-large
-  = t('jobs.review_heading', school: @vacancy.school.name)
-
-%p.lede
-  = t('jobs.review')
+.grid-row
+  .column-two-thirds
+    %h1.heading-large
+      = t('jobs.review_heading', school: @vacancy.school.name)
+    %p.lede
+      = t('jobs.review')
 
 .vacancy.grid-row
   .column-two-thirds

--- a/app/views/hiring_staff/vacancies/review.html.haml
+++ b/app/views/hiring_staff/vacancies/review.html.haml
@@ -11,150 +11,173 @@
 
 .vacancy.grid-row
   .column-two-thirds
+    %table.check-your-answers.cya-questions-short
+      %thead
+        %tr
+          %th{:colspan => "2"}
+            %h2.heading-medium
+              = t('jobs.job_specification')
+          %th
+      %tbody
+        %tr
+          %td.cya-question
+            = t('jobs.job_title')
+          %td
+            = @vacancy.job_title
+          %td.cya-change
+            = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'job_title')
+        %tr
+          %td.cya-question
+            = t('jobs.job_title')
+          %td.cya-answer
+            = @vacancy.job_title
+          %td.cya-change
+            = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'job_title')
+        %tr
+          %td.cya-question
+            = t('jobs.description')
+          %td.cya-answer
+            = @vacancy.job_description
+          %td.cya-change
+            = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'job_description')
+        %tr
+          %td.cya-question
+            = t('jobs.main_subject')
+          %td.cya-answer
+            = @vacancy.main_subject
+          %td.cya-change
+            = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'subject')
+        %tr
+          %td.cya-question
+            = t('jobs.pay_scale')
+          %td.cya-answer
+            =@vacancy.pay_scale_range
+          %td.cya-change
+            = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'pay_scale_range')
+        %tr
+          %td.cya-question
+            = t('jobs.salary_range')
+          %td.cya-answer
+            = @vacancy.salary_range("to")
+          %td.cya-change
+            = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'salary_range')
+        %tr
+          %td.cya-question
+            = t('jobs.working_pattern')
+          %td.cya-answer
+            = @vacancy.working_pattern.humanize
+          %td.cya-change
+            = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'working_pattern')
+        %tr
+          %td.cya-question
+            = t('jobs.flexible_working')
+          %td.cya-answer
+            = @vacancy.flexible_working
+          %td.cya-change
+            = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'flexible_working')
+        %tr
+          %td.cya-question
+            = t('jobs.benefits')
+          %td.cya-answer
+            = @vacancy.benefits
+          %td.cya-change
+            = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'benefits')
+        %tr
+          %td.cya-question
+            = t('jobs.weekly_hours')
+          %td.cya-answer
+            = @vacancy.weekly_hours
+          %td.cya-change
+            = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'weekly_hours')
+        %tr
+          %td.cya-question
+            = t('jobs.leadership_level')
+          %td.cya-answer
+            - if @vacancy.leadership
+              =@vacancy.leadership.title
+          %td.cya-change
+            = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'leadership')
+        %tr
+          %td.cya-question
+            = t('jobs.starts_on')
+          %td.cya-answer
+            = format_date @vacancy.starts_on
+          %td.cya-change
+            = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'starts_on')
+        %tr
+          %td.cya-question
+            = t('jobs.ends_on')
+          %td.cya-answer
+            = format_date @vacancy.ends_on
+          %td.cya-change
+            = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'ends_on')
 
-    %h2.heading-medium= t('jobs.job_specification')
-    %dl.govuk-check-your-answers.cya-questions-short
-      %div
-        %dt.cya-question
-          = t('jobs.job_title')
-        %dd.cya-answer
-          = @vacancy.job_title
-        %dd.cya-change
-          = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'job_title')
-      %div
-        %dt.cya-question
-          = t('jobs.description')
-        %dd.cya-answer
-          = @vacancy.job_description
-        %dd.cya-change
-          = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'job_description')
-      %div
-        %dt.cya-question
-          = t('jobs.main_subject')
-        %dd.cya-answer
-          = @vacancy.main_subject
-        %dd.cya-change
-          = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'subject')
-      %div
-        %dt.cya-question
-          = t('jobs.pay_scale')
-        %dd.cya-answer
-          =@vacancy.pay_scale_range
-        %dd.cya-change
-          = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'pay_scale_range')
-      %div
-        %dt.cya-question
-          = t('jobs.salary_range')
-        %dd.cya-answer
-          = @vacancy.salary_range("to")
-        %dd.cya-change
-          = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'salary_range')
-      %div
-        %dt.cya-question
-          = t('jobs.working_pattern')
-        %dd.cya-answer
-          = @vacancy.working_pattern.humanize
-        %dd.cya-change
-          = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'working_pattern')
-      %div
-        %dt.cya-question
-          = t('jobs.flexible_working')
-        %dd.cya-answer
-          = @vacancy.flexible_working
-        %dd.cya-change
-          = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'flexible_working')
+    %table.check-your-answers.cya-questions-short
+      %thead
+        %tr
+          %th{:colspan => "2"}
+            %h2.heading-medium
+              = t('jobs.candidate_specification')
+          %th
+      %tbody
+        %tr
+          %td.cya-question
+            = t('jobs.education')
+          %td.cya-answer
+            = @vacancy.education
+          %td.cya-change
+            = link_to t('buttons.change'), candidate_specification_school_job_path(anchor: 'education')
+        %tr
+          %td.cya-question
+            = t('jobs.qualifications')
+          %td.cya-answer
+            = @vacancy.qualifications
+          %td.cya-change
+            = link_to t('buttons.change'), candidate_specification_school_job_path(anchor: 'qualifications')
+        %tr
+          %td.cya-question
+            = t('jobs.experience')
+          %td.cya-answer
+            = @vacancy.experience
+          %td.cya-change
+            = link_to t('buttons.change'), candidate_specification_school_job_path(anchor: 'experience')
 
-      %div
-        %dt.cya-question
-          = t('jobs.benefits')
-        %dd.cya-answer
-          = @vacancy.benefits
-        %dd.cya-change
-          = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'benefits')
-      %div
-        %dt.cya-question
-          = t('jobs.weekly_hours')
-        %dd.cya-answer
-          = @vacancy.weekly_hours
-        %dd.cya-change
-          = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'weekly_hours')
-      %div
-        %dt.cya-question
-          = t('jobs.leadership_level')
-        %dd.cya-answer
-          - if @vacancy.leadership
-            = @vacancy.leadership.title
-        %dd.cya-change
-          = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'leadership')
-      %div
-        %dt.cya-question
-          = t('jobs.starts_on')
-        %dd.cya-answer
-          = format_date @vacancy.starts_on
-        %dd.cya-change
-          = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'starts_on')
-      %div
-        %dt.cya-question
-          = t('jobs.ends_on')
-        %dd.cya-answer
-          = format_date @vacancy.ends_on
-        %dd.cya-change
-          = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'ends_on')
-
-    %h2.heading-medium= t('jobs.candidate_specification')
-    %dl.govuk-check-your-answers.cya-questions-short
-      %div
-        %dt.cya-question
-          = t('jobs.education')
-        %dd.cya-answer
-          = @vacancy.education
-        %dd.cya-change
-          = link_to t('buttons.change'), candidate_specification_school_job_path(anchor: 'education')
-      %div
-        %dt.cya-question
-          = t('jobs.qualifications')
-        %dd.cya-answer
-          = @vacancy.qualifications
-        %dd.cya-change
-          = link_to t('buttons.change'), candidate_specification_school_job_path(anchor: 'qualifications')
-      %div
-        %dt.cya-question
-          = t('jobs.experience')
-        %dd.cya-answer
-          = @vacancy.experience
-        %dd.cya-change
-          = link_to t('buttons.change'), candidate_specification_school_job_path(anchor: 'experience')
-
-    %h2.heading-medium= t('jobs.application_details')
-    %dl.govuk-check-your-answers.cya-questions-short
-      %div
-        %dt.cya-question
-          = t('jobs.contact_email')
-        %dd.cya-answer
-          = @vacancy.contact_email
-        %dd.cya-change
-          = link_to t('buttons.change'), application_details_school_job_path(anchor: 'contact_email')
-      %div
-        %dt.cya-question
-          = t('jobs.application_link')
-        %dd.cya-answer
-          = @vacancy.application_link
-        %dd.cya-change
-          = link_to t('buttons.change'), application_details_school_job_path(anchor: 'application_link')
-      %div
-        %dt.cya-question
-          = t('jobs.publication_date')
-        %dd.cya-answer
-          = format_date @vacancy.publish_on
-        %dd.cya-change
-          = link_to t('buttons.change'), application_details_school_job_path(anchor: 'publish_on')
-      %div
-        %dt.cya-question
-          = t('jobs.deadline_date')
-        %dd.cya-answer
-          = format_date @vacancy.expires_on
-        %dd.cya-change
-          = link_to t('buttons.change'), application_details_school_job_path(anchor: 'expires_on')
+    %table.check-your-answers.cya-questions-short
+      %thead
+        %tr
+          %th{:colspan => "2"}
+            %h2.heading-medium
+              = t('jobs.application_details')
+          %th
+      %tbody
+        %tr
+          %td.cya-question
+            = t('jobs.contact_email')
+          %td.cya-answer
+            = @vacancy.contact_email
+          %td.cya-change
+            = link_to t('buttons.change'), application_details_school_job_path(anchor: 'contact_email')
+        %tr
+          %td.cya-question
+            = t('jobs.application_link')
+          %td.cya-answer
+            = @vacancy.application_link
+          %td.cya-change
+            = link_to t('buttons.change'), application_details_school_job_path(anchor: 'application_link')
+        %tr
+          %td.cya-question
+            = t('jobs.publication_date')
+          %td.cya-answer
+            = format_date @vacancy.publish_on
+          %td.cya-change
+            = link_to t('buttons.change'), application_details_school_job_path(anchor: 'publish_on')
+        %tr
+          %td.cya-question
+            = t('jobs.deadline_date')
+          %td.cya-answer
+            = format_date @vacancy.expires_on
+          %td.cya-change
+            = link_to t('buttons.change'), application_details_school_job_path(anchor: 'expires_on')
 
     %h2.heading-medium Now submit your job
     %p= t('jobs.confirmation_summary')

--- a/app/views/hiring_staff/vacancies/review.html.haml
+++ b/app/views/hiring_staff/vacancies/review.html.haml
@@ -16,7 +16,7 @@
         %tr
           %th{:colspan => "2"}
             %h2.heading-medium
-              = t('jobs.job_specification')
+              = link_to t('jobs.job_specification'), job_specification_school_job_path
           %th
       %tbody
         %tr
@@ -117,7 +117,7 @@
         %tr
           %th{:colspan => "2"}
             %h2.heading-medium
-              = t('jobs.candidate_specification')
+              = link_to t('jobs.candidate_specification'), candidate_specification_school_job_path
           %th
       %tbody
         %tr
@@ -147,7 +147,7 @@
         %tr
           %th{:colspan => "2"}
             %h2.heading-medium
-              = t('jobs.application_details')
+              = link_to t('jobs.application_details'), application_details_school_job_path
           %th
       %tbody
         %tr

--- a/spec/support/capybara_helper.rb
+++ b/spec/support/capybara_helper.rb
@@ -1,6 +1,6 @@
 module CapybaraHelper
   def click_link_in_container_with_text(text)
-    find(:xpath, "//div[dt[contains(text(), '#{text}')]]").find('a').click
+    find(:xpath, "//tr[td[contains(text(), '#{text}')]]").find('a').click
   end
 
   def within_row_for(element: 'label', text:, &block)


### PR DESCRIPTION
This PR has minor cosmetic changes; its purpose is altering the markup to be more accessible.

'Review' page before:
![review before](https://user-images.githubusercontent.com/822507/40971455-99cd284a-68b5-11e8-9dde-3eaf50487ed7.png)

'Review' page after:
![review after](https://user-images.githubusercontent.com/822507/40981821-d0139ce0-68d3-11e8-9016-751a6f231089.png)

'Edit' page before:
![edit before](https://user-images.githubusercontent.com/822507/40971463-9dde5b3e-68b5-11e8-9f6e-ee029584448d.png)

'Edit' page after:
![edit after](https://user-images.githubusercontent.com/822507/40981817-cd7b7976-68d3-11e8-8581-a4d53e817685.png)

