### PR TITLE
(fix) school URLs have descriptive text

### DIFF
--- a/app/views/hiring_staff/schools/show.html.haml
+++ b/app/views/hiring_staff/schools/show.html.haml
@@ -57,5 +57,5 @@
           %td
             %strong.strong Website
           %td
-            = link_to @school.url, @school.url
+            = link_to("#{@school.name} website (opens in a new window)", @school.url, class: 'wordwrap', target: '_blank')
           %td

--- a/app/views/vacancies/_show.html.haml
+++ b/app/views/vacancies/_show.html.haml
@@ -53,7 +53,8 @@
 
       - if @vacancy.school.url.present?
         %dt= t('schools.website')
-        %dd.wordwrap= @vacancy.school.url
+        %dd
+          = link_to("#{@vacancy.school.name} website (opens in a new window)", @vacancy.school.url, class: 'wordwrap', target: '_blank')
 
     - if @vacancy.school.geolocation
       %div#map_zoom


### PR DESCRIPTION
school page before:
<img width="1023" alt="school page before" src="https://user-images.githubusercontent.com/822507/41037919-9bc0cad0-698c-11e8-9b41-65e9730effe9.png">

school page after:
<img width="1014" alt="school page after" src="https://user-images.githubusercontent.com/822507/41037924-9d8fd644-698c-11e8-98a4-a93790bc74a5.png">

job post before:
<img width="711" alt="job post before" src="https://user-images.githubusercontent.com/822507/41037927-9f1e6520-698c-11e8-84ea-af29fd9dae19.png">

job post after:
<img width="689" alt="job post after" src="https://user-images.githubusercontent.com/822507/41037930-a041db58-698c-11e8-948f-d4a04e9b9b4a.png">
