### PR TITLE
(fix) add legend and aria-label to pay scale range

### DIFF
--- a/app/views/hiring_staff/vacancies/job_specification/edit.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/edit.html.haml
@@ -35,7 +35,7 @@
                 collection: Subject.order(:name),
                 required: false
       %fieldset.form-group#pay_scale_range
-        %legend.form-label.form-label-bold= "#{t('jobs.pay_scale_range')} (optional)"
+        %legend.form-label.form-label-bold#pay_scale_range_label= "#{t('jobs.pay_scale_range')} (optional)"
         %span.form-hint= t('jobs.form_hints.pay_scale_range')
 
         = f.input :min_pay_scale_id,
@@ -44,7 +44,7 @@
                   label: false,
                   required: false,
                   wrapper: false,
-                  input_html: { 'aria-label': 'Minimum pay scale range' }
+                  input_html: { 'aria-label': 'Minimum pay scale range', 'aria-labelledby': 'pay_scale_range_label' }
 
         to
 
@@ -54,7 +54,7 @@
                   label: false,
                   required: false,
                   wrapper: false,
-                  input_html: { 'aria-label': 'Maximum pay scale range' }
+                  input_html: { 'aria-label': 'Maximum pay scale range', 'aria-labelledby': 'pay_scale_range_label' }
 
       %fieldset.form-group#salary_range
         %label.form-label.form-label-bold= t('jobs.salary_range')

--- a/app/views/hiring_staff/vacancies/job_specification/edit.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/edit.html.haml
@@ -35,7 +35,7 @@
                 collection: Subject.order(:name),
                 required: false
       %fieldset.form-group#pay_scale_range
-        %label.form-label.form-label-bold= "#{t('jobs.pay_scale_range')} (optional)"
+        %legend.form-label.form-label-bold= "#{t('jobs.pay_scale_range')} (optional)"
         %span.form-hint= t('jobs.form_hints.pay_scale_range')
 
         = f.input :min_pay_scale_id,
@@ -43,7 +43,8 @@
                   label_method: :label,
                   label: false,
                   required: false,
-                  wrapper: false
+                  wrapper: false,
+                  input_html: { 'aria-label': 'Minimum pay scale range' }
 
         to
 
@@ -52,7 +53,8 @@
                   label_method: :label,
                   label: false,
                   required: false,
-                  wrapper: false
+                  wrapper: false,
+                  input_html: { 'aria-label': 'Maximum pay scale range' }
 
       %fieldset.form-group#salary_range
         %label.form-label.form-label-bold= t('jobs.salary_range')

--- a/app/views/hiring_staff/vacancies/job_specification/edit.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/edit.html.haml
@@ -44,7 +44,7 @@
                   label: false,
                   required: false,
                   wrapper: false,
-                  input_html: { 'aria-label': 'Minimum pay scale range', 'aria-labelledby': 'pay_scale_range_label' }
+                  input_html: { 'aria-label': t('jobs.aria_labels.minimum_pay_scale_range'), 'aria-labelledby': 'pay_scale_range_label' }
 
         to
 
@@ -54,7 +54,7 @@
                   label: false,
                   required: false,
                   wrapper: false,
-                  input_html: { 'aria-label': 'Maximum pay scale range', 'aria-labelledby': 'pay_scale_range_label' }
+                  input_html: { 'aria-label': t('jobs.aria_labels.maximum_pay_scale_range'), 'aria-labelledby': 'pay_scale_range_label' }
 
       %fieldset.form-group#salary_range
         %label.form-label.form-label-bold= t('jobs.salary_range')

--- a/app/views/hiring_staff/vacancies/job_specification/new.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/new.html.haml
@@ -37,7 +37,7 @@
                 collection: Subject.order(:name),
                 required: false
       %fieldset.form-group#pay_scale_range
-        %legend.form-label.form-label-bold= "#{t('jobs.pay_scale_range')} (optional)"
+        %legend.form-label.form-label-bold#pay_scale_range_label= "#{t('jobs.pay_scale_range')} (optional)"
         %span.form-hint= t('jobs.form_hints.pay_scale_range')
 
         = f.input :min_pay_scale_id,
@@ -46,7 +46,7 @@
                   label: false,
                   required: false,
                   wrapper: false,
-                  input_html: { 'aria-label': 'Minimum pay scale range' }
+                  input_html: { 'aria-label': 'Minimum pay scale range', 'aria-labelledby': 'pay_scale_range_label' }
 
         to
 
@@ -56,7 +56,7 @@
                   required: false,
                   label: false,
                   wrapper: false,
-                  input_html: { 'aria-label': 'Maximum pay scale range' }
+                  input_html: { 'aria-label': 'Maximum pay scale range', 'aria-labelledby': 'pay_scale_range_label' }
 
       %fieldset.form-group#salary_range
         %label.form-label.form-label-bold= t('jobs.salary_range')

--- a/app/views/hiring_staff/vacancies/job_specification/new.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/new.html.haml
@@ -46,7 +46,7 @@
                   label: false,
                   required: false,
                   wrapper: false,
-                  input_html: { 'aria-label': 'Minimum pay scale range', 'aria-labelledby': 'pay_scale_range_label' }
+                  input_html: { 'aria-label': t('jobs.aria_labels.minimum_pay_scale_range'), 'aria-labelledby': 'pay_scale_range_label' }
 
         to
 
@@ -56,7 +56,7 @@
                   required: false,
                   label: false,
                   wrapper: false,
-                  input_html: { 'aria-label': 'Maximum pay scale range', 'aria-labelledby': 'pay_scale_range_label' }
+                  input_html: { 'aria-label': t('jobs.aria_labels.maximum_pay_scale_range'), 'aria-labelledby': 'pay_scale_range_label' }
 
       %fieldset.form-group#salary_range
         %label.form-label.form-label-bold= t('jobs.salary_range')

--- a/app/views/hiring_staff/vacancies/job_specification/new.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/new.html.haml
@@ -37,14 +37,16 @@
                 collection: Subject.order(:name),
                 required: false
       %fieldset.form-group#pay_scale_range
-        %label.form-label.form-label-bold="#{t('jobs.pay_scale_range')} (optional)"
+        %legend.form-label.form-label-bold= "#{t('jobs.pay_scale_range')} (optional)"
         %span.form-hint= t('jobs.form_hints.pay_scale_range')
+
         = f.input :min_pay_scale_id,
                   collection: pay_scale_options,
                   label_method: :label,
                   label: false,
                   required: false,
-                  wrapper: false
+                  wrapper: false,
+                  input_html: { 'aria-label': 'Minimum pay scale range' }
 
         to
 
@@ -53,7 +55,8 @@
                   label_method: :label,
                   required: false,
                   label: false,
-                  wrapper: false
+                  wrapper: false,
+                  input_html: { 'aria-label': 'Maximum pay scale range' }
 
       %fieldset.form-group#salary_range
         %label.form-label.form-label-bold= t('jobs.salary_range')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -70,6 +70,9 @@ en:
     status: 'Status'
     already_published: 'This job has already been published'
     draft: 'This job is currently a draft version.'
+    aria_labels:
+      minimum_pay_scale_range: 'Minimum pay scale range'
+      maximum_pay_scale_range: 'Maximum pay scale range'
     form_hints:
       job_title: "For secondary school roles include subject to be taught and, if applicable, level of seniority ('Subject leader for Science', for example)"
       description: 'Briefly describe the duties and responsibilities involved in the role'


### PR DESCRIPTION
Two inputs cannot share a single ambiguous <label> — replaced `<label>` with a descriptive`<legend>` (see [‘When to use a fieldset and legend’](https://accessibility.blog.gov.uk/2016/07/22/using-the-fieldset-and-legend-elements/) on the GDS a11y blog)

Also added [`aria-label` attributes](https://webaim.org/techniques/forms/advanced#arialabel) to both `<select>`s for assistive technology.