### PR TITLE
(fix) add aria-label to sort links

### DIFF
--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -16,13 +16,11 @@ module VacanciesHelper
       order = sort.reverse_order
       active_class = ' active'
     end
-    link_to jobs_path(
-      vacancy_params(sort_column: column, sort_order: order)
-    ), class: "sortby--#{order}#{active_class || ''}" do
-      concat(content_tag('span', 'Sort jobs by ', class: 'visually-hidden'))
-      concat(content_tag('span', title))
-      concat(content_tag('span', "(#{order}ending)", class: 'visually-hidden'))
-    end
+    link_to title,
+            jobs_path(vacancy_params(sort_column: column,
+                                     sort_order: order)),
+            class: "sortby--#{order}#{active_class || ''}",
+            'aria-label': "Sort jobs by #{title} in #{order}ending order"
   end
 
   def vacancy_params_whitelist

--- a/spec/helpers/vacancies_helper_spec.rb
+++ b/spec/helpers/vacancies_helper_spec.rb
@@ -40,9 +40,8 @@ RSpec.describe VacanciesHelper, type: :helper do
       sort = OpenStruct.new(column: 'maximum_salary')
       result = helper.link_to_sort_by('foo', column: 'starts_on', order: 'asc', sort: sort)
       expect(result).to eq(
-        '<a class="sortby--asc" href="/jobs?sort_column=starts_on&amp;sort_order=asc">' \
-        '<span class="visually-hidden">Sort jobs by </span><span>foo</span>' \
-        '<span class="visually-hidden">(ascending)</span></a>'
+        '<a class="sortby--asc" aria-label="Sort jobs by foo in ascending order" '\
+        'href="/jobs?sort_column=starts_on&amp;sort_order=asc">foo</a>'
       )
     end
 
@@ -51,9 +50,8 @@ RSpec.describe VacanciesHelper, type: :helper do
         sort = OpenStruct.new(column: 'starts_on', reverse_order: 'desc')
         result = helper.link_to_sort_by('foo', column: 'starts_on', order: 'asc', sort: sort)
         expect(result).to eq(
-          '<a class="sortby--desc active" href="/jobs?sort_column=starts_on&amp;sort_order=desc">' \
-          '<span class="visually-hidden">Sort jobs by </span><span>foo</span>' \
-          '<span class="visually-hidden">(descending)</span></a>'
+          '<a class="sortby--desc active" aria-label="Sort jobs by foo in descending order" '\
+          'href="/jobs?sort_column=starts_on&amp;sort_order=desc">foo</a>'
         )
       end
     end


### PR DESCRIPTION
- this is a more elegant solution than that implemented in https://github.com/dxw/teacher-vacancy-service/pull/303