### PR TITLE
(fix) add aria attributes to salary range fields

### DIFF
--- a/app/views/hiring_staff/vacancies/job_specification/edit.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/edit.html.haml
@@ -57,15 +57,14 @@
                   input_html: { 'aria-label': t('jobs.aria_labels.maximum_pay_scale_range'), 'aria-labelledby': 'pay_scale_range_label' }
 
       %fieldset.form-group#salary_range
-        %label.form-label.form-label-bold= t('jobs.salary_range')
+        %legend.form-label.form-label-bold#salary_range_label= t('jobs.salary_range')
         = f.input :minimum_salary,
                   wrapper: 'money',
                   hint: t('jobs.form_hints.salary_range'),
                   required: true,
                   label: '£',
                   wrapper_html: { id: 'minimum_salary' },
-                  input_html: { class: 'form-control-1-8' }
-
+                  input_html: { class: 'form-control-1-8', 'aria-label': 'Minimum salary', 'aria-labelledby': 'salary_range_label' }
         to
 
         = f.input :maximum_salary,
@@ -73,8 +72,7 @@
                   required: true,
                   label: '£',
                   wrapper_html: { id: 'maximum_salary' },
-                  input_html: { class: 'form-control-1-8' }
-
+                  input_html: { class: 'form-control-1-8', 'aria-label': 'Maximum salary', 'aria-labelledby': 'salary_range_label' }
       = f.input :working_pattern,
                 label: t('jobs.working_pattern'),
                 collection: working_pattern_options,

--- a/app/views/hiring_staff/vacancies/job_specification/new.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/new.html.haml
@@ -59,14 +59,14 @@
                   input_html: { 'aria-label': t('jobs.aria_labels.maximum_pay_scale_range'), 'aria-labelledby': 'pay_scale_range_label' }
 
       %fieldset.form-group#salary_range
-        %label.form-label.form-label-bold= t('jobs.salary_range')
+        %legend.form-label.form-label-bold#salary_range_label= t('jobs.salary_range')
         = f.input :minimum_salary,
                   wrapper: 'money',
                   hint: t('jobs.form_hints.salary_range'),
                   required: true,
                   label: '£',
                   wrapper_html: { id: 'minimum_salary' },
-                  input_html: { class: 'form-control-1-8'}
+                  input_html: { class: 'form-control-1-8', 'aria-label': 'Minimum salary', 'aria-labelledby': 'salary_range_label' }
 
         to
 
@@ -75,7 +75,7 @@
                   required: true,
                   label: '£',
                   wrapper_html: { id: 'maximum_salary' },
-                  input_html: { class: 'form-control-1-8' }
+                  input_html: { class: 'form-control-1-8', 'aria-label': 'Maximum salary', 'aria-labelledby': 'salary_range_label' }
 
       = f.input :working_pattern,
                 label: t('jobs.working_pattern'),

--- a/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
@@ -60,7 +60,7 @@ RSpec.feature 'Creating a vacancy' do
           expect(page).to have_content(I18n.t('activerecord.errors.models.vacancy.attributes.job_description.blank'))
         end
 
-        within_row_for(text: I18n.t('jobs.salary_range')) do
+        within_row_for(element: 'legend', text: I18n.t('jobs.salary_range')) do
           expect(page).to have_content(I18n.t('activerecord.errors.models.vacancy.attributes.minimum_salary.blank'))
         end
 


### PR DESCRIPTION
- add a `<legend>` with an ID to the `<fieldset>`
- add `aria-label` to each field
- add `aria-labelledby` to each field to use the legend text as a label for assistive technology