### PR TITLE
Fix/192 use descriptive text when displaying website links

### DIFF
--- a/app/views/hiring_staff/vacancies/edit.html.haml
+++ b/app/views/hiring_staff/vacancies/edit.html.haml
@@ -157,14 +157,17 @@
           %td.cya-question
             = t('jobs.contact_email')
           %td.cya-answer
-            = @vacancy.contact_email
+            =mail_to 'Job contact email', @vacancy.contact_email, 'aria-label': t('jobs.aria_labels.contact_email_link', email: @vacancy.contact_email)
           %td.cya-change
             = link_to t('buttons.change'), edit_school_job_application_details_path(@vacancy.id, anchor: 'contact_email'), 'aria-label': t('jobs.aria_labels.change_job_contact_email')
         %tr
           %td.cya-question
             = t('jobs.application_link')
           %td.cya-answer
-            = @vacancy.application_link
+            = link_to @vacancy.application_link, 'aria-label': t('jobs.aria_labels.application_link_url', url: @vacancy.application_link)  do
+              %span= t('jobs.application_link_url')
+              %br
+              %span.font-xsmall= @vacancy.application_link
           %td.cya-change
             = link_to t('buttons.change'), edit_school_job_application_details_path(@vacancy.id, anchor: 'application_link'), 'aria-label': t('jobs.aria_labels.change_application_link_URL')
         %tr

--- a/app/views/hiring_staff/vacancies/review.html.haml
+++ b/app/views/hiring_staff/vacancies/review.html.haml
@@ -159,14 +159,17 @@
           %td.cya-question
             = t('jobs.contact_email')
           %td.cya-answer
-            = @vacancy.contact_email
+            =mail_to 'Job contact email', @vacancy.contact_email, 'aria-label': t('jobs.aria_labels.contact_email_link', email: @vacancy.contact_email)
           %td.cya-change
             = link_to t('buttons.change'), application_details_school_job_path(anchor: 'contact_email'), 'aria-label': t('jobs.aria_labels.change_job_contact_email')
         %tr
           %td.cya-question
             = t('jobs.application_link')
           %td.cya-answer
-            = @vacancy.application_link
+            = link_to @vacancy.application_link, 'aria-label': t('jobs.aria_labels.application_link_url', url: @vacancy.application_link)  do
+              %span= t('jobs.application_link_url')
+              %br
+              %span.font-xsmall= @vacancy.application_link
           %td.cya-change
             = link_to t('buttons.change'), application_details_school_job_path(anchor: 'application_link'), 'aria-label': t('jobs.aria_labels.change_application_link_URL')
         %tr

--- a/app/views/hiring_staff/vacancies/review.html.haml
+++ b/app/views/hiring_staff/vacancies/review.html.haml
@@ -116,7 +116,7 @@
             %h2.heading-medium.mb0
               = t('jobs.candidate_specification')
             .font-xsmall.mb1
-              = link_to candidate_specification_school_job_path do
+              = link_to candidate_specification_school_job_path, 'aria-label': 'Change candidate specification' do
                 Change
                 %span.visually-hidden the candidate specification
           %th
@@ -150,7 +150,7 @@
             %h2.heading-medium.mb0
               = t('jobs.application_details')
             .font-xsmall.mb1
-              = link_to application_details_school_job_path do
+              = link_to application_details_school_job_path, 'aria-label': 'Change application details' do
                 Change
                 %span.visually-hidden the application details
           %th

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -173,6 +173,7 @@ en:
     find: 'Find'
     delete: 'Delete'
     create_job: 'Create a job'
+    change: 'Change'
 
   messages:
     jobs:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,7 +65,8 @@ en:
     view_posted_job: 'The job has been posted, you can view it here:'
     preview_posted_job: 'The job will be posted on %{date}, you can preview it here:'
     apply: 'Get more information'
-    application_link: 'Application link'
+    application_link: 'Link for more information'
+    application_link_url: 'Link for more information (link opens external website in a new window)'
     actions: 'Actions'
     status: 'Status'
     already_published: 'This job has already been published'
@@ -98,6 +99,8 @@ en:
       change_date_role_will_be_listed: 'Change date role will be listed'
       change_application_deadline: 'Change application deadline'
       apply_link: 'Learn more about this role and how to apply for it (link opens external website in a new window)'
+      contact_email_link: 'Email link for job contact email — %{email}'
+      application_link_url: 'Link for more information (link opens external website in a new window) — %{url}'
     form_hints:
       job_title: "For secondary school roles include subject to be taught and, if applicable, level of seniority ('Subject leader for Science', for example)"
       description: 'Briefly describe the duties and responsibilities involved in the role'

--- a/spec/support/capybara_helper.rb
+++ b/spec/support/capybara_helper.rb
@@ -1,6 +1,6 @@
 module CapybaraHelper
   def click_link_in_container_with_text(text)
-    find(:xpath, "//tr[td[contains(text(), '#{text}')]]").find('a').click
+    find(:xpath, "//tr[td[contains(text(), '#{text}')]]").find('td.cya-change a').click
   end
 
   def within_row_for(element: 'label', text:, &block)


### PR DESCRIPTION
before:
<img width="689" alt="before" src="https://user-images.githubusercontent.com/822507/41233117-5031704a-6d80-11e8-8480-26987a25dcc1.png">

after:
<img width="675" alt="after" src="https://user-images.githubusercontent.com/822507/41233119-5175ea26-6d80-11e8-98a5-bc657e21c0f7.png">
