### PR TITLE
(fix) prefix page title on pages with errors

### DIFF
--- a/app/views/hiring_staff/vacancies/application_details/edit.html.haml
+++ b/app/views/hiring_staff/vacancies/application_details/edit.html.haml
@@ -1,4 +1,4 @@
-- content_for :page_title_prefix, "Edit the Application details"
+- content_for :page_title_prefix, "#{@application_details_form.errors.present? ? 'Error: ' : ''}Edit the Application details"
 
 %h1.heading-large
   = t('jobs.edit_heading', school: @school.name)

--- a/app/views/hiring_staff/vacancies/application_details/new.html.haml
+++ b/app/views/hiring_staff/vacancies/application_details/new.html.haml
@@ -1,4 +1,4 @@
-- content_for :page_title_prefix, "Application details — Publish a job for #{@school.name}"
+- content_for :page_title_prefix, "#{@application_details_form.errors.present? ? 'Error: ' : ''}Application details — Publish a job for #{@school.name}"
 
 %h1.heading-large
   = t('jobs.publish_heading', school: @application_details_form.school.name)

--- a/app/views/hiring_staff/vacancies/candidate_specification/edit.html.haml
+++ b/app/views/hiring_staff/vacancies/candidate_specification/edit.html.haml
@@ -1,4 +1,4 @@
-- content_for :page_title_prefix, "Edit the Candidate specification"
+- content_for :page_title_prefix, "#{@candidate_specification_form.errors.present? ? 'Error: ' : ''}Edit the Candidate specification"
 
 %h1.heading-large
   = t('jobs.edit_heading', school: @school.name)

--- a/app/views/hiring_staff/vacancies/candidate_specification/new.html.haml
+++ b/app/views/hiring_staff/vacancies/candidate_specification/new.html.haml
@@ -1,4 +1,4 @@
-- content_for :page_title_prefix, "Candidate specification — Publish a job for #{@school.name}"
+- content_for :page_title_prefix, "#{@candidate_specification_form.errors.present? ? 'Error: ' : ''}Candidate specification — Publish a job for #{@school.name}"
 
 %h1.heading-large
   = t('jobs.publish_heading', school: @school.name)

--- a/app/views/hiring_staff/vacancies/job_specification/edit.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/edit.html.haml
@@ -1,4 +1,4 @@
-- content_for :page_title_prefix, "Edit the Job specification"
+- content_for :page_title_prefix, "#{@job_specification_form.errors.present? ? 'Error: ' : ''}Edit the Job specification"
 
 %h1.heading-large
   = t('jobs.edit_heading', school: @school.name)

--- a/app/views/hiring_staff/vacancies/job_specification/new.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/new.html.haml
@@ -1,4 +1,4 @@
-- content_for :page_title_prefix, "Job specification — Publish a job for #{@school.name}"
+- content_for :page_title_prefix, "#{@job_specification_form.errors.present? ? 'Error: ' : ''}Job specification — Publish a job for #{@school.name}"
 
 %h1.heading-large
   = t('jobs.publish_heading', school: @school.name)


### PR DESCRIPTION
as per guidance on [GOV.UK Elements](https://govuk-elements.herokuapp.com/errors/):

> Additionally, you should reflect that there's been an error in the <title> by prefixing the existing title with "Error: ". That will make sure screen readers are alerted to there being an error as soon as possible.