### PR TITLE
(fix) add a title attribute to google maps iframe

### DIFF
--- a/app/assets/javascripts/addTitleToGoogleMapsIframe.js
+++ b/app/assets/javascripts/addTitleToGoogleMapsIframe.js
@@ -1,0 +1,3 @@
+$(window).bind("load", function() {
+  $('#map_zoom div div.gm-style iframe').attr("title", "Google Maps");
+});


### PR DESCRIPTION
- uses [a bit of jquery](https://css-tricks.com/snippets/jquery/run-javascript-only-after-entire-page-has-loaded/) to wait until the page is fully loaded before targeting the gmaps `<iframe>` and setting the `title` attribute
- if there's a better way to do this I'd love to know