### PR TITLE
(chore) Reiterate over current elasticsearch configuration

### DIFF
--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -37,8 +37,8 @@ class Vacancy < ApplicationRecord
     indexes :publish_on, type: :date
     indexes :status, type: :keyword
     indexes :working_pattern, type: :keyword
-    indexes :minimum_salary, type: :string
-    indexes :maximum_salary, type: :string
+    indexes :minimum_salary, type: :text
+    indexes :maximum_salary, type: :text
   end
 
   extend FriendlyId

--- a/lib/tasks/elasticsearch.rake
+++ b/lib/tasks/elasticsearch.rake
@@ -2,9 +2,8 @@ namespace :elasticsearch do
   desc 'Index vacancies'
   namespace :vacancies do
     task index: :environment do
-      Rails.logger.debug("Indexing vacancies in #{Rails.env}")
-      Vacancy.__elasticsearch__.client.indices.flush
-      Vacancy.import
+      Rails.logger.debug("Re-index job listings in #{Rails.env}")
+      Vacancy.import(force: true)
     end
   end
 end


### PR DESCRIPTION
After this is deployed we need to run the `elasticsearch:vacancies:index` to recreate the indices.
 
```
{"error":{"root_cause":[{"type":"mapper_parsing_exception","reason":"Failed to parse mapping [vacancy]: The [string] type is removed in 5.0 and automatic upgrade failed because parameters [ignore_malformed] are not supported for automatic upgrades. You should now use either a [text] or [keyword] field instead for field [maximum_salary]"}],"type":"mapper_parsing_exception","reason":"Failed to parse mapping [vacancy]: The [string] type is removed in 5.0 and automatic upgrade failed because parameters [ignore_malformed] are not supported for automatic upgrades. You should now use either a [text] or [keyword] field instead for field [maximum_salary]","caused_by":{"type":"illegal_argument_exception","reason":"The [string] type is removed in 5.0 and automatic upgrade failed because parameters [ignore_malformed] are not supported for automatic upgrades. You should now use either a [text] or [keyword] field instead for field [maximum_salary]"}},"status":400}
```