### PR TITLE
(fix) fix aria labels for pay scale and salary

### DIFF
--- a/app/views/hiring_staff/vacancies/job_specification/edit.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/edit.html.haml
@@ -35,7 +35,7 @@
                 collection: Subject.order(:name),
                 required: false
       %fieldset.form-group#pay_scale_range
-        %legend.form-label.form-label-bold#pay_scale_range_label= "#{t('jobs.pay_scale_range')} (optional)"
+        %legend.form-label.form-label-bold= "#{t('jobs.pay_scale_range')} (optional)"
         %span.form-hint= t('jobs.form_hints.pay_scale_range')
 
         = f.input :min_pay_scale_id,
@@ -44,7 +44,7 @@
                   label: false,
                   required: false,
                   wrapper: false,
-                  input_html: { 'aria-label': t('jobs.aria_labels.minimum_pay_scale_range'), 'aria-labelledby': 'pay_scale_range_label' }
+                  input_html: { 'aria-label': t('jobs.aria_labels.minimum_pay_scale_range') }
 
         to
 
@@ -54,17 +54,17 @@
                   label: false,
                   required: false,
                   wrapper: false,
-                  input_html: { 'aria-label': t('jobs.aria_labels.maximum_pay_scale_range'), 'aria-labelledby': 'pay_scale_range_label' }
+                  input_html: { 'aria-label': t('jobs.aria_labels.maximum_pay_scale_range') }
 
       %fieldset.form-group#salary_range
-        %legend.form-label.form-label-bold#salary_range_label= t('jobs.salary_range')
+        %legend.form-label.form-label-bold= t('jobs.salary_range')
         = f.input :minimum_salary,
                   wrapper: 'money',
                   hint: t('jobs.form_hints.salary_range'),
                   required: true,
                   label: '£',
                   wrapper_html: { id: 'minimum_salary' },
-                  input_html: { class: 'form-control-1-8', 'aria-label': 'Minimum salary', 'aria-labelledby': 'salary_range_label' }
+                  input_html: { class: 'form-control-1-8', 'aria-label': t('jobs.aria_labels.minimum_salary') }
         to
 
         = f.input :maximum_salary,
@@ -72,7 +72,7 @@
                   required: true,
                   label: '£',
                   wrapper_html: { id: 'maximum_salary' },
-                  input_html: { class: 'form-control-1-8', 'aria-label': 'Maximum salary', 'aria-labelledby': 'salary_range_label' }
+                  input_html: { class: 'form-control-1-8', 'aria-label': t('jobs.aria_labels.maximum_salary') }
       = f.input :working_pattern,
                 label: t('jobs.working_pattern'),
                 collection: working_pattern_options,

--- a/app/views/hiring_staff/vacancies/job_specification/new.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/new.html.haml
@@ -37,7 +37,7 @@
                 collection: Subject.order(:name),
                 required: false
       %fieldset.form-group#pay_scale_range
-        %legend.form-label.form-label-bold#pay_scale_range_label= "#{t('jobs.pay_scale_range')} (optional)"
+        %legend.form-label.form-label-bold= "#{t('jobs.pay_scale_range')} (optional)"
         %span.form-hint= t('jobs.form_hints.pay_scale_range')
 
         = f.input :min_pay_scale_id,
@@ -46,7 +46,7 @@
                   label: false,
                   required: false,
                   wrapper: false,
-                  input_html: { 'aria-label': t('jobs.aria_labels.minimum_pay_scale_range'), 'aria-labelledby': 'pay_scale_range_label' }
+                  input_html: { 'aria-label': t('jobs.aria_labels.minimum_pay_scale_range') }
 
         to
 
@@ -56,17 +56,17 @@
                   required: false,
                   label: false,
                   wrapper: false,
-                  input_html: { 'aria-label': t('jobs.aria_labels.maximum_pay_scale_range'), 'aria-labelledby': 'pay_scale_range_label' }
+                  input_html: { 'aria-label': t('jobs.aria_labels.maximum_pay_scale_range') }
 
       %fieldset.form-group#salary_range
-        %legend.form-label.form-label-bold#salary_range_label= t('jobs.salary_range')
+        %legend.form-label.form-label-bold= t('jobs.salary_range')
         = f.input :minimum_salary,
                   wrapper: 'money',
                   hint: t('jobs.form_hints.salary_range'),
                   required: true,
                   label: '£',
                   wrapper_html: { id: 'minimum_salary' },
-                  input_html: { class: 'form-control-1-8', 'aria-label': 'Minimum salary', 'aria-labelledby': 'salary_range_label' }
+                  input_html: { class: 'form-control-1-8', 'aria-label': t('jobs.aria_labels.minimum_salary') }
 
         to
 
@@ -75,7 +75,7 @@
                   required: true,
                   label: '£',
                   wrapper_html: { id: 'maximum_salary' },
-                  input_html: { class: 'form-control-1-8', 'aria-label': 'Maximum salary', 'aria-labelledby': 'salary_range_label' }
+                  input_html: { class: 'form-control-1-8', 'aria-label': t('jobs.aria_labels.maximum_salary') }
 
       = f.input :working_pattern,
                 label: t('jobs.working_pattern'),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -101,7 +101,7 @@ en:
       job_title: "For secondary school roles include subject to be taught and, if applicable, level of seniority ('Subject leader for Science', for example)"
       description: 'Briefly describe the duties and responsibilities involved in the role'
       main_subject: 'What subject will the teacher focus on?'
-      salary_range: 'Annual pay before tax. No commas or decimal points, for example 30000'
+      salary_range: 'Enter annual pay before tax, without commas or decimal points (for example 30000)'
       flexible_working: 'Tick this box if any flexible working arrangements are possible (job sharing or compressed hours, for example). Candidates will be asked to email for further information.'
       pay_scale_range: 'What pay scale range does the job’s salary fall in?'
       weekly_hours: 'Number of hours to be worked each week'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -71,8 +71,10 @@ en:
     already_published: 'This job has already been published'
     draft: 'This job is currently a draft version.'
     aria_labels:
-      minimum_pay_scale_range: 'Minimum pay scale range'
-      maximum_pay_scale_range: 'Maximum pay scale range'
+      minimum_salary: 'Minimum salary'
+      maximum_salary: 'Maximum salary'
+      minimum_pay_scale_range: 'Minimum pay scale range (optional)'
+      maximum_pay_scale_range: 'Maximum pay scale range (optional)'
       change_job_specification: 'Change job specification'
       change_job_title: 'Change job title'
       change_job_description: 'Change job description'


### PR DESCRIPTION
- remove `aria-labelledby` attributes — these were overriding the individual `aria-label` attributes which in this instance allow a more accurate description
- improve `aria-label` text for pay scale
- put `aria-label` text for salary into i18n