### PR TITLE
(fix) fixes for error pages

### DIFF
--- a/app/views/errors/internal_server_error.html.haml
+++ b/app/views/errors/internal_server_error.html.haml
@@ -1,2 +1,4 @@
-%h1.heading-xlarge Something went wrong at our end.
+- content_for :page_title_prefix, t('error_pages.server_error')
+
+%h1.heading-xlarge=t('error_pages.server_error')
 %p You can email #{mail_to t('help.email')} if the problem persists.

--- a/app/views/errors/not_found.html.haml
+++ b/app/views/errors/not_found.html.haml
@@ -1,3 +1,5 @@
-%h1.heading-xlarge Page not found
+- content_for :page_title_prefix, t('error_pages.not_found')
+
+%h1.heading-xlarge=t('error_pages.not_found')
 %p If you entered a web address please check it was correct.
 %p You can #{link_to 'return to the homepage', '/'} to try and find the information you need.

--- a/app/views/errors/unprocessable_entity.html.haml
+++ b/app/views/errors/unprocessable_entity.html.haml
@@ -1,1 +1,3 @@
-%h1.heading-xlarge We're unable to be process your request.
+- content_for :page_title_prefix, t('error_pages.unprocessable_entity')
+
+%h1.heading-xlarge=t('error_pages.unprocessable_entity')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -194,5 +194,10 @@ en:
     url:
       invalid: is not a valid URL
 
+  error_pages:
+    unprocessable_entity: We're unable to process your request.
+    not_found: Page not found.
+    server_error: Something went wrong at our end.
+
   help:
     email: teachingjobs@digital.education.gov.uk


### PR DESCRIPTION
- fix typo
- put error headings into i18n
- add error headings to page titles

### before:
<img width="982" alt="screen_shot_2018-05-31_at_11 47 15" src="https://user-images.githubusercontent.com/822507/41853565-f996ae38-7885-11e8-8e23-ad37afc05fd9.png">

### after: 
![screen_shot_2018-06-25_at_14 30 34](https://user-images.githubusercontent.com/822507/41853613-12c2c752-7886-11e8-9c2e-5197757a17cb.png)
