### PR TITLE
Fix/208 add a active class to links in header

### DIFF
--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -1,0 +1,5 @@
+module LinkHelper
+  def active_link_class(link_path)
+    current_page?(link_path) ? 'active' : ''
+  end
+end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -24,7 +24,7 @@
           = t('app.title')
         %ul#proposition-links
           - if authenticated?
-            %li= link_to t('nav.school_page_link'), new_sessions_path
+            %li= link_to t('nav.school_page_link'), new_sessions_path, class: active_link_class(school_path)
             %li= link_to t('nav.sign_out'), sessions_path, method: :delete
           - else
             %li= link_to t('nav.sign_in'), new_sessions_path

--- a/spec/features/hiring_staff_can_sign_in_spec.rb
+++ b/spec/features/hiring_staff_can_sign_in_spec.rb
@@ -33,6 +33,7 @@ RSpec.feature 'Hiring staff can sign in' do
     expect(page).to have_content("Jobs at #{school.name}")
     within('#proposition-links') { expect(page).to have_content(I18n.t('nav.sign_out')) }
     within('#proposition-links') { expect(page).to have_content(I18n.t('nav.school_page_link')) }
+    within('#proposition-links') { expect(page).to have_selector('a.active', text: 'My jobs') }
   end
 
   scenario 'with valid credentials that do not match a school', elasticsearch: true do


### PR DESCRIPTION
Adds the [`active_link_to` gem](https://github.com/comfy/active_link_to) for active nav highlighting.

![screen shot 2018-06-25 at 15 37 06](https://user-images.githubusercontent.com/822507/41856694-a1e53044-788d-11e8-9732-f2d2e77f330e.png)
