### PR TITLE
(fix): DfE Sign In SSO returns information about the user

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -15,6 +15,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
            response_type: :code,
            issuer: dfe_sign_in_issuer_url,
            client_signing_alg: :RS256,
+           scope: %i[openid profile email organisation],
            client_options: {
              port: dfe_sign_in_issuer_uri.port,
              scheme: dfe_sign_in_issuer_uri.scheme,


### PR DESCRIPTION
* This was missed from our initial proof of concept branch.

Before:
```
{"provider"=>:dfe,
 "uid"=>"001-",
 "info"=>
  {"name"=>nil,
   "email"=>nil,
   "nickname"=>nil,
   "first_name"=>nil,
   "last_name"=>nil,
   "gender"=>nil,
   "image"=>nil,
   "phone"=>nil,
   "urls"=>{"website"=>nil}},
 "credentials"=>
  {"id_token"=>"xxx",
   "token"=>"xx",
   "refresh_token"=>nil,
   "expires_in"=>3600,
   "scope"=>"openid"},
 "extra"=>{"raw_info"=>{"sub"=>"000-"}}}
```

After:
```
{"provider"=>:dfe,
 "uid"=>"001-",
 "info"=>
  {"name"=>nil,
   "email"=>"email@example.com",
   "nickname"=>nil,
   "first_name"=>"My",
   "last_name"=>"name",
   "gender"=>nil,
   "image"=>nil,
   "phone"=>nil,
   "urls"=>{"website"=>nil}},
 "credentials"=>
  {"id_token"=>"xxx",
   "token"=>"xx",
   "refresh_token"=>nil,
   "expires_in"=>3600,
   "scope"=>"openid email organisation"},
 "extra"=>
  {"raw_info"=>
    {"sub"=>"001",
     "email"=>"email@example.com",
     "organisation"=>
      {"id"=>"001",
       "name"=>"Newquay Junior School",
       "urn"=>"111885",
       "category"=>{"id"=>"001", "name"=>"Establishment"},
       "type"=>{"id"=>"01", "name"=>"Community School"}}}}}
```