### PR TITLE
(chore) Update README with correct env filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 1. Copy the docker environment variables and fill in any missing secrets:
 
 ```
-$ cp docker-compose.env.example docker-compose.env
+$ cp docker-compose.env.sample docker-compose.env
 ```
 
 2. Build the docker container and set up the database


### PR DESCRIPTION
I noticed when I was setting up the project that the filename of the sample env file was incorrect in the readme.

This is a pretty insignificant change but thought I'd document it.