### PR TITLE
No job listings content

### DIFF
--- a/app/presenters/vacancies_presenter.rb
+++ b/app/presenters/vacancies_presenter.rb
@@ -11,13 +11,17 @@ class VacanciesPresenter < BasePresenter
     decorated_collection.each(&block)
   end
 
-  def total_count
-    if model.total_count == 1
-      return I18n.t('jobs.job_count_without_search', count: model.total_count) unless @searched
-      I18n.t('jobs.job_count', count: model.total_count)
+  def total_count_message
+    if total_count == 1
+      return I18n.t('jobs.job_count_without_search', count: total_count) unless @searched
+      I18n.t('jobs.job_count', count: total_count)
     else
-      return I18n.t('jobs.job_count_plural_without_search', count: model.total_count) unless @searched
-      I18n.t('jobs.job_count_plural', count: model.total_count)
+      return I18n.t('jobs.job_count_plural_without_search', count: total_count) unless @searched
+      I18n.t('jobs.job_count_plural', count: total_count)
     end
+  end
+
+  private def total_count
+    model.total_count
   end
 end

--- a/app/presenters/vacancies_presenter.rb
+++ b/app/presenters/vacancies_presenter.rb
@@ -1,5 +1,5 @@
 class VacanciesPresenter < BasePresenter
-  attr_reader :decorated_collection
+  attr_reader :decorated_collection, :searched
 
   def initialize(vacancies, searched:)
     @decorated_collection = vacancies.map { |v| VacancyPresenter.new(v) }

--- a/app/views/vacancies/index.html.haml
+++ b/app/views/vacancies/index.html.haml
@@ -8,7 +8,7 @@
   .column-one-third
     = render 'filters'
   .column-two-thirds
-    %p.heading-medium.mt0= @vacancies.total_count
+    %p.heading-medium.mt0= @vacancies.total_count_message
     - if @vacancies.any?
       %div.sortable-links
         = t('jobs.sort_by')

--- a/app/views/vacancies/index.html.haml
+++ b/app/views/vacancies/index.html.haml
@@ -19,8 +19,12 @@
         - @vacancies.each do |vacancy|
           = render partial: 'vacancy', locals: { vacancy: vacancy }
 
-    - else
+    - elsif @vacancies.searched
       %div.empty
         = t('jobs.no_jobs')
+    - else
+      %div.empty
+        - t('jobs.none_listed').each do |sentence|
+          %p= sentence
 
 = paginate @vacancies

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,6 +42,9 @@ en:
     job_count: 'There is %{count} job that matches your search.'
     job_count_plural: 'There are %{count} jobs that match your search.'
     no_jobs: 'No jobs found. Try expanding your search.'
+    none_listed:
+      - 'This is because schools are on summer holidays and this isn’t a peak period in the teacher recruitment cycle.'
+      - 'We’re still growing as a service. Even more schools will be able to list jobs on the service from September. So please check back soon!'
     job_title: 'Job title'
     benefits: 'Employee benefits'
     salary_range: 'Salary range'

--- a/spec/features/job_seekers_can_view_vacancies_spec.rb
+++ b/spec/features/job_seekers_can_view_vacancies_spec.rb
@@ -99,7 +99,16 @@ RSpec.feature 'Viewing vacancies' do
     Vacancy.__elasticsearch__.client.indices.flush
     visit jobs_path
 
+    click_on I18n.t('buttons.apply_filters')
     expect(page).to have_content(I18n.t('jobs.no_jobs'))
+  end
+
+  scenario 'Should advise users to check back soon when no jobs are listed' do
+    visit jobs_path
+    I18n.t('jobs.none_listed').each do |sentence|
+      expect(page).to have_content(sentence)
+    end
+    expect(page).not_to have_content(I18n.t('jobs.no_jobs'))
   end
 
   context 'when the vacancy is part_time' do

--- a/spec/presenters/vacancies_presenter_spec.rb
+++ b/spec/presenters/vacancies_presenter_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe VacanciesPresenter do
     end
   end
 
-  describe '#total_count' do
+  describe '#total_count_message' do
     it 'returns the correct number for a single vacancy', elasticsearch: true do
       create(:vacancy, job_title: 'School teacher')
       Vacancy.__elasticsearch__.client.indices.flush
@@ -22,7 +22,7 @@ RSpec.describe VacanciesPresenter do
       vacancies = Vacancy.search('Teacher').records
       searched = true
       vacancies_presenter = VacanciesPresenter.new(vacancies, searched: searched)
-      expect(vacancies_presenter.total_count).to eq(I18n.t('jobs.job_count', count: 1))
+      expect(vacancies_presenter.total_count_message).to eq(I18n.t('jobs.job_count', count: 1))
     end
 
     it 'returns the correct number for multiple vacancies', elasticsearch: true do
@@ -34,7 +34,7 @@ RSpec.describe VacanciesPresenter do
       vacancies = Vacancy.search('Teacher').records
       searched = true
       vacancies_presenter = VacanciesPresenter.new(vacancies, searched: searched)
-      expect(vacancies_presenter.total_count).to eq(I18n.t('jobs.job_count_plural', count: 3))
+      expect(vacancies_presenter.total_count_message).to eq(I18n.t('jobs.job_count_plural', count: 3))
     end
 
     it 'returns the correct number for a single vacancy without a search', elasticsearch: true do
@@ -44,7 +44,7 @@ RSpec.describe VacanciesPresenter do
       vacancies = Vacancy.search('Teacher').records
       searched = false
       vacancies_presenter = VacanciesPresenter.new(vacancies, searched: searched)
-      expect(vacancies_presenter.total_count).to eq(I18n.t('jobs.job_count_without_search', count: 1))
+      expect(vacancies_presenter.total_count_message).to eq(I18n.t('jobs.job_count_without_search', count: 1))
     end
 
     it 'returns the correct number for multiple vacancies without a search', elasticsearch: true do
@@ -56,7 +56,7 @@ RSpec.describe VacanciesPresenter do
       vacancies = Vacancy.search('Teacher').records
       searched = false
       vacancies_presenter = VacanciesPresenter.new(vacancies, searched: searched)
-      expect(vacancies_presenter.total_count).to eq(I18n.t('jobs.job_count_plural_without_search', count: 3))
+      expect(vacancies_presenter.total_count_message).to eq(I18n.t('jobs.job_count_plural_without_search', count: 3))
     end
   end
 end


### PR DESCRIPTION
# User need
> As a user
> When I visit the service and there are no job listings
> So that I know to revisit the service in future
> I want to know that this is an expected slow point

# Description
The content is time specific and only applicable while we're in summer holidays. We may want to refactor the code to have a toggle to flip this message off, however I thought I'd raise the PR as this is the minimum that meets the needs on the card.

# Screenshot
![image](https://user-images.githubusercontent.com/2804149/42893015-2335bbf8-8aab-11e8-986b-5543f81e1e6b.png)
