### PR TITLE
(chore): Secure application cookies by enabling site wide SSL only

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -47,7 +47,7 @@ Rails.application.configure do
 
   # Force all access to the app over SSL, use Strict-Transport-Security,
   # and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
As advised by: http://guides.rubyonrails.org/security.html#session-hijacking

With `curl -X HEAD -i https://teaching-jobs.service.gov.uk -k` we can see that our cookie setting currently looks like:

```
$ curl -X HEAD -i https://teaching-jobs.service.gov.uk -k
Warning: Setting custom HTTP method to HEAD with -X/--request may not work the
Warning: way you want. Consider using -I/--head instead.
HTTP/2 200
content-type: text/html; charset=utf-8
date: Thu, 19 Jul 2018 09:30:35 GMT
x-frame-options: SAMEORIGIN
x-xss-protection: 1; mode=block
x-content-type-options: nosniff
x-robots-tag: none
etag: W/"74dfb9a4ab86d75ed907f22bab5c1c07"
cache-control: max-age=0, private, must-revalidate
set-cookie: _teachingjobs_session=aaf55073c31b6da014e2bd20b0680348; path=/; expires=Thu, 19 Jul 2018 10:30:35 -0000; HttpOnly
x-request-id: 02c685f2-f656-4aba-9695-f99a9f16c993
x-runtime: 0.239087
x-cache: Miss from cloudfront
via: 1.1 68126347056de2d05be3dd362ccba987.cloudfront.net (CloudFront)
x-amz-cf-id:
```

and now after this change `secure` is set in set-cookie and Strict-Transport-Security is set:

```
$ curl -X HEAD -i https://localhost:3000/ -k
Warning: Setting custom HTTP method to HEAD with -X/--request may not work the
Warning: way you want. Consider using -I/--head instead.
HTTP/1.1 200 OK
X-Frame-Options: SAMEORIGIN
X-XSS-Protection: 1; mode=block
X-Content-Type-Options: nosniff
X-Robots-Tag: none
Content-Type: text/html; charset=utf-8
ETag: W/"e47c77651ba3d69fb066c2555ebdbf82"
Cache-Control: max-age=0, private, must-revalidate
Set-Cookie: _teachingjobs_session=a412819d47de1ed741736c32d7b2717c; path=/; expires=Thu, 19 Jul 2018 10:30:13 -0000; secure; HttpOnly
X-Request-Id: a6ad9dcc-8892-432c-8925-266540fce322
X-Runtime: 2.352722
Strict-Transport-Security: max-age=15552000; includeSubDomains
```