### PR TITLE
(feature) CloudFront will cache all requests to /assets/

### DIFF
--- a/terraform/modules/cloudfront/cloudfront.tf
+++ b/terraform/modules/cloudfront/cloudfront.tf
@@ -76,6 +76,28 @@ resource "aws_cloudfront_distribution" "default" {
     viewer_protocol_policy = "redirect-to-https"
   }
 
+  cache_behavior {
+    allowed_methods  = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "${var.project_name}-${var.environment}-default-origin"
+
+    path_pattern = "/assets/*"
+
+    forwarded_values = {
+      query_string = false
+      headers = ["Host"]
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl     = 0
+    default_ttl = 3600
+    max_ttl     = 86400
+
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
   price_class = "PriceClass_100"
 
   restrictions {


### PR DESCRIPTION
* Asset pipeline precompiles assets like images, stylesheets and fonts. These all take up bandwidth and so we can avoid redudant calls to our web server (Puma) with this new CloufFront behaviour.
* We tested this by adding it manually to AWS first and verifying (after it’s deployment) that our assets were hitting the cache. You can use `curl -v https://www.teaching-jobs.service.gov.uk/assets/govuk-template-750a59548b69602b355c5c7c90f2aa1668e600ad07911b44c2e696a1d5c081cf.css > /dev/null` (beware you’ll need a new link the next time these assets are compiled) and looking for `< x-cache: Hit from cloudfront` Instead of `Miss`.

Before:
```
* Connection state changed (MAX_CONCURRENT_STREAMS updated)!
< HTTP/2 200
< content-type: text/css
< content-length: 30828
< date: Thu, 19 Jul 2018 10:17:31 GMT
< last-modified: Tue, 10 Jul 2018 08:45:05 GMT
< vary: Accept-Encoding
< x-cache: Miss from cloudfront
< via: 1.1 b029ee882e6b0b302c9c841990ea3e04.cloudfront.net (CloudFront)
< x-amz-cf-id: vfDTsy36jbMyawIu0jSA2oxwMhkZiU2kqx0u-hcxk3qHOnsgnJ67gA==
```

After:
```
* Connection state changed (MAX_CONCURRENT_STREAMS updated)!
< HTTP/2 200
< content-type: text/css
< content-length: 14544
< date: Thu, 19 Jul 2018 10:19:12 GMT
< last-modified: Tue, 10 Jul 2018 08:45:05 GMT
< vary: Accept-Encoding
< age: 119
< x-cache: Hit from cloudfront
< via: 1.1 967425266468bd56bf14d0a928942c04.cloudfront.net (CloudFront)
< x-amz-cf-id: UcVOuGd0DSRHz7CkzbzA8VXGcf-6Vnmu6ZNyhYRCYAC-0KckHMp-kg==
```