### PR TITLE
Add support for future pay scales

### DIFF
--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -47,6 +47,6 @@ module VacanciesHelper
   end
 
   def pay_scale_options
-    @pay_scale_options ||= PayScale.all
+    @pay_scale_options ||= PayScale.current
   end
 end

--- a/app/models/pay_scale.rb
+++ b/app/models/pay_scale.rb
@@ -2,6 +2,7 @@ class PayScale < ApplicationRecord
   has_many :vacancies
 
   default_scope { order(:index) }
+  scope :current, (-> { where('expires_at >= ?', Time.zone.today).where('starts_at <= ?', Time.zone.today) })
 
   def self.minimum_payscale_salary
     PayScale.minimum(:salary).to_i

--- a/app/models/pay_scale.rb
+++ b/app/models/pay_scale.rb
@@ -5,6 +5,6 @@ class PayScale < ApplicationRecord
   scope :current, (-> { where('expires_at >= ?', Time.zone.today).where('starts_at <= ?', Time.zone.today) })
 
   def self.minimum_payscale_salary
-    PayScale.minimum(:salary).to_i
+    PayScale.current.minimum(:salary).to_i
   end
 end

--- a/db/migrate/20180719103034_add_starts_at_to_pay_scales.rb
+++ b/db/migrate/20180719103034_add_starts_at_to_pay_scales.rb
@@ -1,0 +1,5 @@
+class AddStartsAtToPayScales < ActiveRecord::Migration[5.1]
+  def change
+    add_column :pay_scales, :starts_at, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180709141534) do
+ActiveRecord::Schema.define(version: 20180719103034) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -60,6 +60,7 @@ ActiveRecord::Schema.define(version: 20180709141534) do
     t.integer "salary"
     t.date "expires_at"
     t.integer "index"
+    t.date "starts_at"
     t.index ["code", "expires_at"], name: "index_pay_scales_on_code_and_expires_at", unique: true
     t.index ["label"], name: "index_pay_scales_on_label", unique: true
   end

--- a/lib/tasks/data/update.rake
+++ b/lib/tasks/data/update.rake
@@ -4,7 +4,7 @@ namespace :data do
     task pay_scale: :environment do
       PAYSCALE_DATA.each_with_index do |scale, index|
         payscale = PayScale.find_by(code: scale[0])
-        payscale.update_attributes(index: index, label: scale[1]) if payscale.present?
+        payscale.update_attributes(index: index, label: scale[1], starts_at: Date.new(2017, 9, 1)) if payscale.present?
       end
     end
   end

--- a/spec/factories/pay_scales.rb
+++ b/spec/factories/pay_scales.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :pay_scale do
     label { Faker::Lorem.unique.words(2).join(' ') }
-    code { Faker::Code.asin }
+    sequence(:code) { |n| "MPS#{n}" }
     salary { Faker::Number.number(4) }
     starts_at { Time.zone.today - 5.months }
     expires_at { Time.zone.today + 5.months }

--- a/spec/factories/pay_scales.rb
+++ b/spec/factories/pay_scales.rb
@@ -3,5 +3,7 @@ FactoryBot.define do
     label { Faker::Lorem.unique.words(2).join(' ') }
     code { Faker::Code.asin }
     salary { Faker::Number.number(4) }
+    starts_at { Time.zone.today - 5.months }
+    expires_at { Time.zone.today + 5.months }
   end
 end

--- a/spec/models/pay_scale_spec.rb
+++ b/spec/models/pay_scale_spec.rb
@@ -38,4 +38,21 @@ RSpec.describe PayScale, type: :model do
       end
     end
   end
+
+  describe '#minimum_payscale_salary' do
+    it 'returns the lowest current pay scale salary' do
+      Timecop.freeze(Time.zone.today) do
+        minimum = create(:pay_scale,
+                         salary: 1000, starts_at: Time.zone.today - 2.days, expires_at: Time.zone.today + 2.days)
+        create(:pay_scale, salary: 2000, starts_at: Time.zone.today - 2.days, expires_at: Time.zone.today + 2.days)
+        future_minimum = create(:pay_scale, salary: 5000, starts_at: Time.zone.today + 2.months)
+        create(:pay_scale, salary: 6000, starts_at: Time.zone.today + 2.months)
+
+        expect(PayScale.minimum_payscale_salary).to be minimum.salary
+
+        Timecop.travel(Time.zone.today + 3.months)
+        expect(PayScale.minimum_payscale_salary).to be future_minimum.salary
+      end
+    end
+  end
 end

--- a/spec/models/pay_scale_spec.rb
+++ b/spec/models/pay_scale_spec.rb
@@ -12,5 +12,30 @@ RSpec.describe PayScale, type: :model do
         expect(PayScale.all.last).to eq(last)
       end
     end
+
+    describe '#current' do
+      it 'also orders by index' do
+        last = create(:pay_scale, index: 30)
+        first = create(:pay_scale, index: 1)
+
+        expect(PayScale.current.first).to eq(first)
+        expect(PayScale.current.last).to eq(last)
+      end
+
+      it 'includes pay scales that are current' do
+        current = create(:pay_scale, starts_at: Time.zone.today - 2.days, expires_at: Time.zone.today + 2.days)
+        expect(PayScale.current).to include(current)
+      end
+
+      it 'doesn’t include pay scales that haven’t started' do
+        not_started = create(:pay_scale, starts_at: Time.zone.today + 2.days)
+        expect(PayScale.current).not_to include(not_started)
+      end
+
+      it 'doesn’t include pay scales that have expired' do
+        expired = create(:pay_scale, expires_at: Time.zone.today - 2.days)
+        expect(PayScale.current).not_to include(expired)
+      end
+    end
   end
 end


### PR DESCRIPTION
## User need
As a member of hiring staff
I need to only see current pay scales
So that I am up-to-date with the job market

## Description 
Adds `#current` scope to `PayScale` which is any records that have a start date earlier than today and an end date later than today.
