### PR TITLE
(feature) Redirect unauthorised users to static page

### DIFF
--- a/app/controllers/hiring_staff/sign_in/azure/sessions_controller.rb
+++ b/app/controllers/hiring_staff/sign_in/azure/sessions_controller.rb
@@ -11,7 +11,7 @@ class HiringStaff::SignIn::Azure::SessionsController < HiringStaff::BaseControll
       session.update(urn: permissions.school_urn)
       redirect_to school_path
     else
-      redirect_to root_path, notice: I18n.t('errors.sign_in.unauthorised')
+      redirect_to page_path('user-not-authorised')
     end
   end
 

--- a/app/controllers/hiring_staff/sign_in/dfe/sessions_controller.rb
+++ b/app/controllers/hiring_staff/sign_in/dfe/sessions_controller.rb
@@ -11,7 +11,7 @@ class HiringStaff::SignIn::Dfe::SessionsController < HiringStaff::BaseController
       session.update(urn: permissions.school_urn)
       redirect_to school_path
     else
-      redirect_to root_path, notice: I18n.t('errors.sign_in.unauthorised')
+      redirect_to page_path('user-not-authorised')
     end
   end
 

--- a/spec/features/hiring_staff_can_sign_in_with_azure_spec.rb
+++ b/spec/features/hiring_staff_can_sign_in_with_azure_spec.rb
@@ -73,7 +73,7 @@ RSpec.feature 'Hiring staff can sign in with Azure' do
 
     click_on(I18n.t('nav.sign_in'))
 
-    expect(page).to have_content(I18n.t('errors.sign_in.unauthorised'))
+    expect(page).to have_content(I18n.t('static_pages.not_authorised.title'))
     within('#proposition-links') { expect(page).not_to have_content(I18n.t('nav.school_page_link')) }
   end
 

--- a/spec/features/hiring_staff_can_sign_in_with_dfe_spec.rb
+++ b/spec/features/hiring_staff_can_sign_in_with_dfe_spec.rb
@@ -61,7 +61,7 @@ RSpec.feature 'Hiring staff can sign in with DfE Sign In' do
 
     click_on(I18n.t('nav.sign_in'))
 
-    expect(page).to have_content(I18n.t('errors.sign_in.unauthorised'))
+    expect(page).to have_content(I18n.t('static_pages.not_authorised.title'))
     within('#proposition-links') { expect(page).not_to have_content(I18n.t('nav.school_page_link')) }
   end
 end


### PR DESCRIPTION
We now have a static page for unauthorised users, we should redirect to that when the user doesn’t have the correct permissions.