### PR TITLE
(fix) Provide Google ENV to ECS terraform module

### DIFF
--- a/terraform.tf
+++ b/terraform.tf
@@ -104,6 +104,8 @@ module "ecs" {
   redis_url                = "redis://${module.elasticache_redis.endpoint}"
   authorisation_service_token = "${var.authorisation_service_token}"
   authorisation_service_url   = "${var.authorisation_service_url}"
+  google_drive_json_key = "${var.google_drive_json_key}"
+  auth_spreadsheet_id = "${var.auth_spreadsheet_id}"
 }
 
 module "logs" {

--- a/terraform/modules/ecs/ecs.tf
+++ b/terraform/modules/ecs/ecs.tf
@@ -113,8 +113,8 @@ data "template_file" "web_container_definition" {
     redis_url                = "${var.redis_url}"
     authorisation_service_url   = "${var.authorisation_service_url}"
     authorisation_service_token = "${var.authorisation_service_token}"
-    google_drive_json_key    = "#{var.google_drive_json_key}"
-    auth_spreadsheet_id      = "#{var.auth_spreadsheet_id}"
+    google_drive_json_key    = "${var.google_drive_json_key}"
+    auth_spreadsheet_id      = "${var.auth_spreadsheet_id}"
   }
 }
 


### PR DESCRIPTION
* This was missed during the review of  https://github.com/dxw/teacher-vacancy-service/pull/342 and has been added manually to a terraform deploy to support the feature that relies upon it until this is merged.