### PR TITLE
(fix) Healthchecks can be made on HTTP

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -48,6 +48,7 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security,
   # and use secure cookies.
   config.force_ssl = true
+  config.ssl_options = { redirect: { exclude: ->(request) { request.path =~ /check/ } } }
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -47,7 +47,8 @@ Rails.application.configure do
 
   # Force all access to the app over SSL, use Strict-Transport-Security,
   # and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
+  config.ssl_options = { redirect: { exclude: ->(request) { request.path =~ /check/ } } }
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
* This allows AWS target group health checks to always succeed and therefore for new deployments to succeed. The previous production deployments stall because the target group cannot complete health checks on the new containers since it isn't available on HTTPS. I attempted to try and make the target group make HTTPS health checks but they all failed. On further reading I thought we could just ignore the SSL rule on only the `/check` endpoint so that it can be hit using HTTP in CI and either HTTP or HTTPS in live. There are no foreseen consequences to allowing this as it just returns an 'OK' string and a 200 but it does allow our CI pipelines to continue working 
* Apply the same config in both staging and production so any future problems are caught before production before hand.
* You can test this locally by adding the same 2 lines of code to your development.rb file and requesting https://localhost:3000 to confirm SSL is valid and then http://localhost:3000 to see it fail without SSL and finally http://localhost:3000/check and https://localhost:3000/check to see if it succeeds both times.