### PR TITLE
(fix): Hiring staff who are not in the right region don’t go to Azure

### DIFF
--- a/app/controllers/hiring_staff/identifications_controller.rb
+++ b/app/controllers/hiring_staff/identifications_controller.rb
@@ -22,7 +22,7 @@ class HiringStaff::IdentificationsController < HiringStaff::BaseController
   end
 
   private def halt_other_regions
-    return unless choice.eql?('Other')
+    return unless choice.eql?(OTHER_SIGN_IN_OPTION.map(&:name).first)
 
     flash[:notice] = safe_join(
       [

--- a/spec/controllers/hiring_staff/identifications_controller_spec.rb
+++ b/spec/controllers/hiring_staff/identifications_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe HiringStaff::IdentificationsController, type: :controller do
   describe '#create' do
     context 'when the area is other' do
       it 'redirects to the root path with an explanation' do
-        choice = HiringStaff::IdentificationsController::OTHER_SIGN_IN_OPTION.first.to_radio.last
+        choice = HiringStaff::IdentificationsController::OTHER_SIGN_IN_OPTION.first.name
         post :create, params: { identifications: { name: choice } }
         expect(controller).to set_flash[:notice]
         expect(response).to redirect_to(root_path)

--- a/spec/features/hiring_staff_not_invited_dont_sign_in_spec.rb
+++ b/spec/features/hiring_staff_not_invited_dont_sign_in_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.feature 'Hiring staff from a school in an area that has not been invited yet' do
+  scenario 'redirects the user to the root path with a call to action' do
+    visit root_path
+    click_on(I18n.t('nav.sign_in'))
+    choose(HiringStaff::IdentificationsController::OTHER_SIGN_IN_OPTION.first.to_radio.last)
+    click_on(I18n.t('sign_in.link'))
+    expect(page).to have_content(I18n.t('app.title'))
+    expect(page).to have_content("Other areas have not been invited yet, \
+      please register your interest by emailing us at #{I18n.t('help.email')}")
+  end
+end


### PR DESCRIPTION
* This fixes a bug introduced in a refactoring and makes sure it's tested https://github.com/dxw/teacher-vacancy-service/pull/347