### PR TITLE
Automate browser testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,7 @@ workspace-variables/*.tfvars
 # Certificates
 config/localhost/https/*.key
 config/localhost/https/*.crt
+
+# BrowserStack
+browserstack.err
+local.log

--- a/Gemfile
+++ b/Gemfile
@@ -79,6 +79,8 @@ group :development, :test do
   gem 'teaspoon-mocha'
   gem 'coffee-rails'
   gem 'timecop'
+  gem 'browserstack-local'
+  gem 'selenium-webdriver'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,7 @@ GEM
     bindex (0.5.0)
     breasal (0.0.1)
     browser (2.5.3)
+    browserstack-local (1.3.0)
     builder (3.2.3)
     byebug (10.0.2)
     capybara (3.6.0)
@@ -90,6 +91,8 @@ GEM
       rack (>= 1.6.0)
       rack-test (>= 0.6.3)
       xpath (~> 3.1)
+    childprocess (0.9.0)
+      ffi (~> 1.0, >= 1.0.11)
     cliver (0.3.2)
     coderay (1.1.2)
     coffee-rails (4.2.2)
@@ -395,6 +398,7 @@ GEM
     ruby_dep (1.5.0)
     ruby_parser (3.10.1)
       sexp_processor (~> 4.9)
+    rubyzip (1.2.1)
     safe_yaml (1.0.4)
     sanitize (4.6.6)
       crass (~> 1.0.2)
@@ -411,6 +415,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    selenium-webdriver (3.13.1)
+      childprocess (~> 0.5)
+      rubyzip (~> 1.2)
     sexp_processor (4.10.0)
     signet (0.8.1)
       addressable (~> 2.3)
@@ -486,6 +493,7 @@ DEPENDENCIES
   addressable
   breasal (~> 0.0.1)
   browser
+  browserstack-local
   byebug
   capybara (~> 3.6)
   coffee-rails
@@ -533,6 +541,7 @@ DEPENDENCIES
   rubocop
   sanitize (~> 4.6)
   sass-rails (~> 5.0)
+  selenium-webdriver
   shoulda-matchers!
   simple_form
   spring

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ require_relative 'config/application'
 Rails.application.load_tasks
 
 desc 'Run all the specs'
-task default: %i[spec teaspoon]
+task default: %i[spec teaspoon browserstack:all]
 
 namespace :db do
   desc 'runs `data:seed:pay_scale` and `data:update:pay_scale`'

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,7 +11,6 @@
 // about supported directives.
 //
 //= require jquery
-//= require jquery_ujs
 //= require rails-ujs
 //= require turbolinks
 //= require_tree .

--- a/config/browserstack.yml
+++ b/config/browserstack.yml
@@ -6,9 +6,13 @@ common_caps:
 browser_caps:
   -
     "browser": "chrome"
-#  -
-#    "browser": "firefox"
-#  -
-#    "browser": "internet explorer"
-#  -
-#    "browser": "safari"
+  -
+    "browser": "firefox"
+  -
+    "browser": "safari"
+  -
+    "browser": "internet explorer"
+    "enablePersistentHover": false
+  -
+    "browser": "edge"
+    "enablePersistentHover": false

--- a/config/browserstack.yml
+++ b/config/browserstack.yml
@@ -12,8 +12,6 @@ browser_caps:
     "browser": "safari"
   -
     "browser": "IE"
-    "browser_version": "11.0"
-    "enablePersistentHover": false
+    "browser_version": "10.0"
   -
     "browser": "edge"
-    "enablePersistentHover": false

--- a/config/browserstack.yml
+++ b/config/browserstack.yml
@@ -1,7 +1,7 @@
 common_caps:
   "browserstack.debug": true
-  "browserstack.networkLogs": true
   "browserstack.local": true
+  "project": "TeachingJobs"
 
 browser_caps:
   -
@@ -11,7 +11,8 @@ browser_caps:
   -
     "browser": "safari"
   -
-    "browser": "internet explorer"
+    "browser": "IE"
+    "browser_version": "11.0"
     "enablePersistentHover": false
   -
     "browser": "edge"

--- a/config/browserstack.yml
+++ b/config/browserstack.yml
@@ -1,0 +1,14 @@
+common_caps:
+  "browserstack.debug": true
+  "browserstack.networkLogs": true
+  "browserstack.local": true
+
+browser_caps:
+  -
+    "browser": "chrome"
+#  -
+#    "browser": "firefox"
+#  -
+#    "browser": "internet explorer"
+#  -
+#    "browser": "safari"

--- a/lib/tasks/browserstack.rake
+++ b/lib/tasks/browserstack.rake
@@ -1,3 +1,5 @@
+CONFIG = YAML.safe_load(File.read(File.join(File.dirname(__FILE__), '../../config/browserstack.yml')))
+
 namespace :browserstack do
   RSpec::Core::RakeTask.new(:local) do |t|
     ENV['TEST_BROWSER'] = 'browserstack'
@@ -5,5 +7,13 @@ namespace :browserstack do
     t.rspec_opts = '--format documentation --tag browserstack'
     t.verbose = false
   end
+
+  task :all do
+    CONFIG['browser_caps'].each_with_index do |_browser, i|
+      ENV['TASK_ID'] = i.to_s
+      Rake::Task['browserstack:local'].execute
+    end
+  end
+
   task default: :local
 end

--- a/lib/tasks/browserstack.rake
+++ b/lib/tasks/browserstack.rake
@@ -2,7 +2,7 @@ namespace :browserstack do
   RSpec::Core::RakeTask.new(:local) do |t|
     ENV['TEST_BROWSER'] = "browserstack"
     t.pattern = Dir.glob('spec/features/**/*_spec.rb')
-    t.rspec_opts = "--format documentation"
+    t.rspec_opts = "--format documentation --tag browserstack"
     t.verbose = false
   end
   task default: :local

--- a/lib/tasks/browserstack.rake
+++ b/lib/tasks/browserstack.rake
@@ -9,6 +9,7 @@ namespace :browserstack do
   end
 
   task :all do
+    next if ENV['BROWSERSTACK_USERNAME'].blank?
     CONFIG['browser_caps'].each_with_index do |_browser, i|
       ENV['TASK_ID'] = i.to_s
       Rake::Task['browserstack:local'].execute

--- a/lib/tasks/browserstack.rake
+++ b/lib/tasks/browserstack.rake
@@ -1,0 +1,9 @@
+namespace :browserstack do
+  RSpec::Core::RakeTask.new(:local) do |t|
+    ENV['TEST_BROWSER'] = "browserstack"
+    t.pattern = Dir.glob('spec/features/**/*_spec.rb')
+    t.rspec_opts = "--format documentation"
+    t.verbose = false
+  end
+  task default: :local
+end

--- a/lib/tasks/browserstack.rake
+++ b/lib/tasks/browserstack.rake
@@ -1,8 +1,8 @@
 namespace :browserstack do
   RSpec::Core::RakeTask.new(:local) do |t|
-    ENV['TEST_BROWSER'] = "browserstack"
+    ENV['TEST_BROWSER'] = 'browserstack'
     t.pattern = Dir.glob('spec/features/**/*_spec.rb')
-    t.rspec_opts = "--format documentation --tag browserstack"
+    t.rspec_opts = '--format documentation --tag browserstack'
     t.verbose = false
   end
   task default: :local

--- a/spec/browser_test_helper.rb
+++ b/spec/browser_test_helper.rb
@@ -5,34 +5,29 @@ if ENV['TEST_BROWSER'] == 'browserstack'
   require 'yaml'
   require 'browserstack/local'
 
-  WebMock.disable_net_connect!(allow_localhost: true, allow: /browserstack/)
-
   # monkey patch to avoid reset sessions
   class Capybara::Selenium::Driver < Capybara::Driver::Base
     def reset!
-      if @browser
-        @browser.navigate.to('about:blank')
-      end
+      @browser.navigate.to('about:blank') if @browser
     end
   end
 
-  CONFIG = YAML.load(File.read(File.join(File.dirname(__FILE__), '../config/browserstack.yml')))
+  CONFIG = YAML.safe_load(File.read(File.join(File.dirname(__FILE__), '../config/browserstack.yml')))
   CONFIG['user'] = ENV['BROWSERSTACK_USERNAME']
   CONFIG['key'] = ENV['BROWSERSTACK_ACCESS_KEY']
   TASK_ID = ENV['TASK_ID'] ||= '0'
 
   Capybara.register_driver :browserstack do |app|
     caps = CONFIG['common_caps'].merge(CONFIG['browser_caps'][TASK_ID.to_i])
-    caps["browserstack.local"] = true
+    caps['browserstack.local'] = true
 
     @browserstack_local = BrowserStack::Local.new
-    @browserstack_local.start({"key" => "#{CONFIG['key']}", "forcelocal" => true})
+    @browserstack_local.start('key' => (CONFIG['key']).to_s, 'forcelocal' => true)
 
     Capybara::Selenium::Driver.new(app,
-      browser: :remote,
-      url: "http://#{CONFIG['user']}:#{CONFIG['key']}@hub-cloud.browserstack.com/wd/hub",
-      desired_capabilities: caps
-    )
+                                   browser: :remote,
+                                   url: "http://#{CONFIG['user']}:#{CONFIG['key']}@hub-cloud.browserstack.com/wd/hub",
+                                   desired_capabilities: caps)
   end
 
   Capybara.default_driver = :browserstack
@@ -41,10 +36,10 @@ if ENV['TEST_BROWSER'] == 'browserstack'
   Capybara.run_server = true
 
   at_exit do
-    @browserstack_local.stop unless @browserstack_local.nil?
+    @browserstack_local&.stop
   end
 
-  puts "Running specs with BrowserStack"
+  puts 'Running specs with BrowserStack'
 
 else
 
@@ -52,5 +47,4 @@ else
     Capybara::Poltergeist::Driver.new(app, phantomjs_options: ['--load-images=false'])
   end
   Capybara.javascript_driver = :poltergeist
-
 end

--- a/spec/browser_test_helper.rb
+++ b/spec/browser_test_helper.rb
@@ -34,6 +34,7 @@ if ENV['TEST_BROWSER'] == 'browserstack'
   Capybara.javascript_driver = :browserstack
   Capybara.current_driver = :browserstack
   Capybara.run_server = true
+  Capybara.ignore_hidden_elements = true
 
   at_exit do
     @browserstack_local&.stop

--- a/spec/browser_test_helper.rb
+++ b/spec/browser_test_helper.rb
@@ -8,13 +8,11 @@ if ENV['TEST_BROWSER'] == 'browserstack'
   # monkey patch to avoid reset sessions
   class Capybara::Selenium::Driver < Capybara::Driver::Base
     def reset!
-      @browser.navigate.to('about:blank') if @browser
+      @browser&.navigate&.to('about:blank')
     end
   end
 
-  CONFIG = YAML.safe_load(File.read(File.join(File.dirname(__FILE__), '../config/browserstack.yml')))
-  CONFIG['user'] = ENV['BROWSERSTACK_USERNAME']
-  CONFIG['key'] = ENV['BROWSERSTACK_ACCESS_KEY']
+  CONFIG ||= YAML.safe_load(File.read(File.join(File.dirname(__FILE__), '../config/browserstack.yml')))
   TASK_ID = ENV['TASK_ID'] ||= '0'
 
   Capybara.register_driver :browserstack do |app|
@@ -22,11 +20,12 @@ if ENV['TEST_BROWSER'] == 'browserstack'
     caps['browserstack.local'] = true
 
     @browserstack_local = BrowserStack::Local.new
-    @browserstack_local.start('key' => (CONFIG['key']).to_s, 'forcelocal' => true)
+    @browserstack_local.start('key' => (ENV['BROWSERSTACK_ACCESS_KEY']).to_s, 'forcelocal' => true)
 
+    url = "http://#{ENV['BROWSERSTACK_USERNAME']}:#{ENV['BROWSERSTACK_ACCESS_KEY']}@hub-cloud.browserstack.com/wd/hub"
     Capybara::Selenium::Driver.new(app,
                                    browser: :remote,
-                                   url: "http://#{CONFIG['user']}:#{CONFIG['key']}@hub-cloud.browserstack.com/wd/hub",
+                                   url: url,
                                    desired_capabilities: caps)
   end
 
@@ -34,13 +33,13 @@ if ENV['TEST_BROWSER'] == 'browserstack'
   Capybara.javascript_driver = :browserstack
   Capybara.current_driver = :browserstack
   Capybara.run_server = true
-  Capybara.ignore_hidden_elements = true
+  Capybara.ignore_hidden_elements = false
 
   at_exit do
     @browserstack_local&.stop
   end
 
-  puts 'Running specs with BrowserStack'
+  puts "Running specs with BrowserStack using #{CONFIG['browser_caps'][TASK_ID.to_i]['browser']}"
 
 else
 

--- a/spec/browser_test_helper.rb
+++ b/spec/browser_test_helper.rb
@@ -19,9 +19,10 @@ if ENV['TEST_BROWSER'] == 'browserstack'
   CONFIG = YAML.load(File.read(File.join(File.dirname(__FILE__), '../config/browserstack.yml')))
   CONFIG['user'] = ENV['BROWSERSTACK_USERNAME']
   CONFIG['key'] = ENV['BROWSERSTACK_ACCESS_KEY']
+  TASK_ID = ENV['TASK_ID'] ||= '0'
 
   Capybara.register_driver :browserstack do |app|
-    caps = CONFIG['common_caps'].merge(CONFIG['browser_caps'][0])
+    caps = CONFIG['common_caps'].merge(CONFIG['browser_caps'][TASK_ID.to_i])
     caps["browserstack.local"] = true
 
     @browserstack_local = BrowserStack::Local.new

--- a/spec/browser_test_helper.rb
+++ b/spec/browser_test_helper.rb
@@ -1,7 +1,55 @@
 require 'capybara/rspec'
 require 'capybara/poltergeist'
 
-Capybara.register_driver :poltergeist do |app|
-  Capybara::Poltergeist::Driver.new(app, phantomjs_options: ['--load-images=false'])
+if ENV['TEST_BROWSER'] == 'browserstack'
+  require 'yaml'
+  require 'browserstack/local'
+
+  WebMock.disable_net_connect!(allow_localhost: true, allow: /browserstack/)
+
+  # monkey patch to avoid reset sessions
+  class Capybara::Selenium::Driver < Capybara::Driver::Base
+    def reset!
+      if @browser
+        @browser.navigate.to('about:blank')
+      end
+    end
+  end
+
+  CONFIG = YAML.load(File.read(File.join(File.dirname(__FILE__), '../config/browserstack.yml')))
+  CONFIG['user'] = ENV['BROWSERSTACK_USERNAME']
+  CONFIG['key'] = ENV['BROWSERSTACK_ACCESS_KEY']
+
+  Capybara.register_driver :browserstack do |app|
+    caps = CONFIG['common_caps'].merge(CONFIG['browser_caps'][0])
+    caps["browserstack.local"] = true
+
+    @browserstack_local = BrowserStack::Local.new
+    @browserstack_local.start({"key" => "#{CONFIG['key']}", "forcelocal" => true})
+
+    Capybara::Selenium::Driver.new(app,
+      browser: :remote,
+      url: "http://#{CONFIG['user']}:#{CONFIG['key']}@hub-cloud.browserstack.com/wd/hub",
+      desired_capabilities: caps
+    )
+  end
+
+  Capybara.default_driver = :browserstack
+  Capybara.javascript_driver = :browserstack
+  Capybara.current_driver = :browserstack
+  Capybara.run_server = true
+
+  at_exit do
+    @browserstack_local.stop unless @browserstack_local.nil?
+  end
+
+  puts "Running specs with BrowserStack"
+
+else
+
+  Capybara.register_driver :poltergeist do |app|
+    Capybara::Poltergeist::Driver.new(app, phantomjs_options: ['--load-images=false'])
+  end
+  Capybara.javascript_driver = :poltergeist
+
 end
-Capybara.javascript_driver = :poltergeist

--- a/spec/database_cleaner_helper.rb
+++ b/spec/database_cleaner_helper.rb
@@ -7,11 +7,11 @@ RSpec.configure do |config|
   end
 
   config.before(:each) do
-    if Capybara.current_driver == :rack_test
-      DatabaseCleaner.strategy = :transaction
-    else
-      DatabaseCleaner.strategy = :truncation
-    end
+    DatabaseCleaner.strategy = if Capybara.current_driver == :rack_test
+                                 :transaction
+                               else
+                                 :truncation
+                               end
   end
 
   config.before(:each) do

--- a/spec/database_cleaner_helper.rb
+++ b/spec/database_cleaner_helper.rb
@@ -7,11 +7,11 @@ RSpec.configure do |config|
   end
 
   config.before(:each) do
-    DatabaseCleaner.strategy = :transaction
-  end
-
-  config.before(:each, js: true) do
-    DatabaseCleaner.strategy = :truncation
+    if Capybara.current_driver == :rack_test
+      DatabaseCleaner.strategy = :transaction
+    else
+      DatabaseCleaner.strategy = :truncation
+    end
   end
 
   config.before(:each) do

--- a/spec/features/hiring_staff_can_edit_a_published_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_edit_a_published_vacancy_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
   end
 
   context 'navigation' do
-    scenario 'links to the school page' do
+    scenario 'links to the school page', browserstack: true do
       vacancy = create(:vacancy, :published, school: school)
       visit edit_school_job_path(vacancy.id)
 
@@ -27,7 +27,7 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
   end
 
   context 'editing a published vacancy' do
-    scenario 'takes your to the edit page' do
+    scenario 'takes your to the edit page', browserstack: true do
       vacancy = create(:vacancy, :published, school: school)
       visit edit_school_job_path(vacancy.id)
 
@@ -48,7 +48,7 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
         expect(page).to have_content('Job title can\'t be blank')
       end
 
-      scenario 'can be succesfuly edited' do
+      scenario 'can be succesfuly edited', browserstack: true do
         vacancy = create(:vacancy, :published, school: school)
         visit edit_school_job_path(vacancy.id)
         click_link_in_container_with_text('Job title')
@@ -108,7 +108,7 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
         end
       end
 
-      scenario 'can be succesfuly edited' do
+      scenario 'can be succesfuly edited', browserstack: true do
         vacancy = create(:vacancy, :published, school: school)
         visit edit_school_job_path(vacancy.id)
         click_link_in_container_with_text(I18n.t('jobs.qualifications'))
@@ -154,7 +154,7 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
         end
       end
 
-      scenario 'can be succesfuly edited' do
+      scenario 'can be succesfuly edited', browserstack: true do
         vacancy = create(:vacancy, :published, school: school)
         vacancy = VacancyPresenter.new(vacancy)
         visit edit_school_job_path(vacancy.id)

--- a/spec/features/hiring_staff_can_edit_a_published_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_edit_a_published_vacancy_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
   end
 
   context 'navigation' do
-    scenario 'links to the school page', browserstack: true do
+    scenario 'links to the school page' do
       vacancy = create(:vacancy, :published, school: school)
       visit edit_school_job_path(vacancy.id)
 
@@ -27,7 +27,7 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
   end
 
   context 'editing a published vacancy' do
-    scenario 'takes your to the edit page', browserstack: true do
+    scenario 'takes your to the edit page' do
       vacancy = create(:vacancy, :published, school: school)
       visit edit_school_job_path(vacancy.id)
 
@@ -108,7 +108,7 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
         end
       end
 
-      scenario 'can be succesfuly edited', browserstack: true do
+      scenario 'can be succesfuly edited' do
         vacancy = create(:vacancy, :published, school: school)
         visit edit_school_job_path(vacancy.id)
         click_link_in_container_with_text(I18n.t('jobs.qualifications'))
@@ -154,7 +154,7 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
         end
       end
 
-      scenario 'can be succesfuly edited', browserstack: true do
+      scenario 'can be succesfuly edited' do
         vacancy = create(:vacancy, :published, school: school)
         vacancy = VacancyPresenter.new(vacancy)
         visit edit_school_job_path(vacancy.id)

--- a/spec/features/hiring_staff_can_edit_a_school_description_spec.rb
+++ b/spec/features/hiring_staff_can_edit_a_school_description_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature 'Editing a School’s description' do
     stub_hiring_staff_auth(urn: school.urn, session_id: session_id)
   end
 
-  scenario 'updating a description' do
+  scenario 'updating a description', browserstack: true do
     visit school_path
 
     expect(page).to have_content(school.name)

--- a/spec/features/hiring_staff_can_navigate_via_breadcrumbs.rb
+++ b/spec/features/hiring_staff_can_navigate_via_breadcrumbs.rb
@@ -4,7 +4,7 @@ RSpec.feature 'School viewing vacancies' do
   include_context 'when authenticated as a member of hiring staff',
                   stub_basic_auth_env: true
 
-  scenario 'Navigate from viewing a vacancy to all vacancies for that school' do
+  scenario 'Navigate from viewing a vacancy to all vacancies for that school', browserstack: true do
     school = create(:school)
     vacancy = create(:vacancy, school: school)
 

--- a/spec/features/hiring_staff_can_only_see_their_school_spec.rb
+++ b/spec/features/hiring_staff_can_only_see_their_school_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Hiring staff can only see their school' do
-  context 'when the session is connected to a school' do
+  context 'when the session is connected to a school', browserstack: true do
     scenario 'school page can be viewed' do
       school = create(:school)
       stub_hiring_staff_auth(urn: school.urn)

--- a/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature 'Creating a vacancy' do
     stub_hiring_staff_auth(urn: school.urn, session_id: session_id)
   end
 
-  scenario 'Visiting the school page', browserstack: true do
+  scenario 'Visiting the school page' do
     school = create(:school, name: 'Salisbury School')
     stub_hiring_staff_auth(urn: school.urn)
 
@@ -34,7 +34,7 @@ RSpec.feature 'Creating a vacancy' do
                                  leadership: leaderships.sample))
     end
 
-    scenario 'redirects to step 1, job specification', browserstack: true do
+    scenario 'redirects to step 1, job specification' do
       visit new_school_job_path
 
       expect(page.current_path).to eq(job_specification_school_job_path)
@@ -69,7 +69,7 @@ RSpec.feature 'Creating a vacancy' do
         end
       end
 
-      scenario 'redirects to step 2, candidate profile, when submitted successfully', browserstack: true do
+      scenario 'redirects to step 2, candidate profile, when submitted successfully' do
         visit new_school_job_path
 
         fill_in_job_specification_form_fields(vacancy)
@@ -116,7 +116,7 @@ RSpec.feature 'Creating a vacancy' do
         end
       end
 
-      scenario 'redirects to step 3, application_details profile, when submitted successfully', browserstack: true do
+      scenario 'redirects to step 3, application_details profile, when submitted successfully' do
         visit new_school_job_path
 
         fill_in_job_specification_form_fields(vacancy)
@@ -179,7 +179,7 @@ RSpec.feature 'Creating a vacancy' do
         expect(page).to have_current_path(school_job_path(vacancy.id))
       end
 
-      scenario 'lists all the vacancy details correctly', browserstack: true do
+      scenario 'lists all the vacancy details correctly' do
         vacancy = VacancyPresenter.new(create(:vacancy, :complete, :draft, school_id: school.id))
         visit school_job_review_path(vacancy.id)
 
@@ -189,7 +189,7 @@ RSpec.feature 'Creating a vacancy' do
       end
 
       context 'edit job_specification_details' do
-        scenario 'updates the vacancy details', browserstack: true do
+        scenario 'updates the vacancy details' do
           vacancy = create(:vacancy, :draft, :complete, school_id: school.id)
           visit school_job_review_path(vacancy.id)
           click_link_in_container_with_text('Job title')
@@ -240,7 +240,7 @@ RSpec.feature 'Creating a vacancy' do
       end
 
       context 'editing the candidate_specification_details' do
-        scenario 'updates the vacancy details', browserstack: true do
+        scenario 'updates the vacancy details' do
           vacancy = create(:vacancy, :draft, :complete, school_id: school.id)
           visit school_job_review_path(vacancy.id)
           click_link_in_container_with_text('Essential qualifications')
@@ -308,7 +308,7 @@ RSpec.feature 'Creating a vacancy' do
           expect(page).to have_content('a@valid.email')
         end
 
-        scenario 'updates the vacancy details', browserstack: true do
+        scenario 'updates the vacancy details' do
           vacancy = create(:vacancy, :draft, :complete, school_id: school.id)
           visit school_job_review_path(vacancy.id)
           click_link_in_container_with_text('Job contact email')
@@ -337,7 +337,7 @@ RSpec.feature 'Creating a vacancy' do
         end
       end
 
-      scenario 'redirects to the school vacancy page when published', browserstack: true do
+      scenario 'redirects to the school vacancy page when published' do
         vacancy = create(:vacancy, :draft, school_id: school.id)
         visit school_job_review_path(vacancy.id)
         click_on 'Confirm and submit job'

--- a/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature 'Creating a vacancy' do
     stub_hiring_staff_auth(urn: school.urn, session_id: session_id)
   end
 
-  scenario 'Visiting the school page' do
+  scenario 'Visiting the school page', browserstack: true do
     school = create(:school, name: 'Salisbury School')
     stub_hiring_staff_auth(urn: school.urn)
 
@@ -34,7 +34,7 @@ RSpec.feature 'Creating a vacancy' do
                                  leadership: leaderships.sample))
     end
 
-    scenario 'redirects to step 1, job specification' do
+    scenario 'redirects to step 1, job specification', browserstack: true do
       visit new_school_job_path
 
       expect(page.current_path).to eq(job_specification_school_job_path)
@@ -69,7 +69,7 @@ RSpec.feature 'Creating a vacancy' do
         end
       end
 
-      scenario 'redirects to step 2, candidate profile, when submitted succesfuly' do
+      scenario 'redirects to step 2, candidate profile, when submitted successfully', browserstack: true do
         visit new_school_job_path
 
         fill_in_job_specification_form_fields(vacancy)
@@ -116,7 +116,7 @@ RSpec.feature 'Creating a vacancy' do
         end
       end
 
-      scenario 'redirects to step 3, application_details profile, when submitted succesfuly' do
+      scenario 'redirects to step 3, application_details profile, when submitted successfully', browserstack: true do
         visit new_school_job_path
 
         fill_in_job_specification_form_fields(vacancy)
@@ -155,7 +155,7 @@ RSpec.feature 'Creating a vacancy' do
         end
       end
 
-      scenario 'redirects to the vacancy review page when submitted succesfuly' do
+      scenario 'redirects to the vacancy review page when submitted successfully', browserstack: true do
         visit new_school_job_path
 
         fill_in_job_specification_form_fields(vacancy)
@@ -179,7 +179,7 @@ RSpec.feature 'Creating a vacancy' do
         expect(page).to have_current_path(school_job_path(vacancy.id))
       end
 
-      scenario 'lists all the vacancy details correctly' do
+      scenario 'lists all the vacancy details correctly', browserstack: true do
         vacancy = VacancyPresenter.new(create(:vacancy, :complete, :draft, school_id: school.id))
         visit school_job_review_path(vacancy.id)
 
@@ -189,7 +189,7 @@ RSpec.feature 'Creating a vacancy' do
       end
 
       context 'edit job_specification_details' do
-        scenario 'updates the vacancy details' do
+        scenario 'updates the vacancy details', browserstack: true do
           vacancy = create(:vacancy, :draft, :complete, school_id: school.id)
           visit school_job_review_path(vacancy.id)
           click_link_in_container_with_text('Job title')
@@ -240,7 +240,7 @@ RSpec.feature 'Creating a vacancy' do
       end
 
       context 'editing the candidate_specification_details' do
-        scenario 'updates the vacancy details' do
+        scenario 'updates the vacancy details', browserstack: true do
           vacancy = create(:vacancy, :draft, :complete, school_id: school.id)
           visit school_job_review_path(vacancy.id)
           click_link_in_container_with_text('Essential qualifications')
@@ -308,7 +308,7 @@ RSpec.feature 'Creating a vacancy' do
           expect(page).to have_content('a@valid.email')
         end
 
-        scenario 'updates the vacancy details' do
+        scenario 'updates the vacancy details', browserstack: true do
           vacancy = create(:vacancy, :draft, :complete, school_id: school.id)
           visit school_job_review_path(vacancy.id)
           click_link_in_container_with_text('Job contact email')
@@ -337,7 +337,7 @@ RSpec.feature 'Creating a vacancy' do
         end
       end
 
-      scenario 'redirects to the school vacancy page when published' do
+      scenario 'redirects to the school vacancy page when published', browserstack: true do
         vacancy = create(:vacancy, :draft, school_id: school.id)
         visit school_job_review_path(vacancy.id)
         click_on 'Confirm and submit job'

--- a/spec/features/hiring_staff_can_see_their_vacancies_spec.rb
+++ b/spec/features/hiring_staff_can_see_their_vacancies_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Hiring staff can see their vacancies' do
-  scenario 'school with geolocation' do
+  scenario 'school with geolocation', browserstack: true do
     school = create(:school, northing: '1', easting: '2')
 
     stub_hiring_staff_auth(urn: school.urn)

--- a/spec/features/hiring_staff_can_sign_out_spec.rb
+++ b/spec/features/hiring_staff_can_sign_out_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 RSpec.feature 'Hiring staff can sign out' do
   let(:school) { create(:school) }
 
-  scenario 'as an authenticated user' do
+  scenario 'as an authenticated user', browserstack: true do
     stub_hiring_staff_auth(urn: school.urn)
 
     visit root_path

--- a/spec/features/hiring_staff_can_submit_vacancy_feedback_spec.rb
+++ b/spec/features/hiring_staff_can_submit_vacancy_feedback_spec.rb
@@ -42,10 +42,10 @@ RSpec.feature 'Vacancy feedback' do
         expect(page).to have_content('Rating can\'t be blank')
       end
 
-      scenario 'Can be successfully submitted for a published vacancy' do
+      scenario 'Can be successfully submitted for a published vacancy', browserstack: true do
         visit new_school_job_feedback_path(published_job.id)
 
-        choose 'Very satisfied'
+        choose 'Very satisfied', allow_label_click: true
         fill_in 'feedback_comment', with: 'Perfect!'
 
         click_on 'Submit feedback'

--- a/spec/features/hiring_staff_can_view_vacancies_spec.rb
+++ b/spec/features/hiring_staff_can_view_vacancies_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature 'School viewing vacancies' do
     expect(page).to have_content('You have no current jobs.')
   end
 
-  scenario 'A school can see a list of vacancies' do
+  scenario 'A school can see a list of vacancies', browserstack: true do
     vacancy1 = create(:vacancy, school: school)
     vacancy2 = create(:vacancy, school: school)
 

--- a/spec/features/hiring_staff_can_visit_the_public_listings_spec.rb
+++ b/spec/features/hiring_staff_can_visit_the_public_listings_spec.rb
@@ -14,44 +14,6 @@ RSpec.feature 'School viewing public listings' do
   let!(:school) { create(:school, urn: '110627') }
   let!(:user) { create(:user, oid: 'a-valid-oid') }
 
-  context 'when signed in with Azure' do
-    before(:each) do
-      OmniAuth.config.mock_auth[:default] = OmniAuth::AuthHash.new(
-        provider: 'default',
-        info: {
-          name: 'an-email@example.com',
-        },
-        extra: {
-          raw_info: {
-            id_token_claims: {
-              oid: 'a-valid-oid'
-            }
-          }
-        }
-      )
-      mock_response = double(code: '200', body: { user: { permissions: [{ school_urn: '110627' }] } }.to_json)
-      allow(TeacherVacancyAuthorisation::Permissions).to receive(:new)
-        .and_return(AuthHelpers::MockPermissions.new(mock_response))
-    end
-
-    scenario 'A signed in school should see a link back to their own dashboard when viewing public listings', browserstack: true do
-      visit root_path
-
-      click_on(I18n.t('nav.sign_in'))
-      choose(HiringStaff::IdentificationsController::AZURE_SIGN_IN_OPTIONS.first.to_radio.last, allow_label_click: true)
-      click_on(I18n.t('sign_in.link'))
-
-      expect(page).to have_content("Jobs at #{school.name}")
-      within('#proposition-links') { expect(page).to have_content(I18n.t('nav.school_page_link')) }
-
-      click_on(I18n.t('app.title'))
-      expect(page).to have_content(I18n.t('jobs.heading'))
-
-      click_on(I18n.t('nav.school_page_link'))
-      expect(page).to have_content("Jobs at #{school.name}")
-    end
-  end
-
   context 'when signed in with DfE Sign In' do
     before(:each) do
       OmniAuth.config.mock_auth[:dfe] = OmniAuth::AuthHash.new(
@@ -78,7 +40,8 @@ RSpec.feature 'School viewing public listings' do
       ENV['SIGN_IN_WITH_DFE'] = 'false'
     end
 
-    scenario 'A signed in school should see a link back to their own dashboard when viewing public listings', browserstack: true do
+    scenario 'A signed in school should see a link back to their own dashboard when viewing public listings',
+             browserstack: true do
       visit root_path
 
       click_on(I18n.t('nav.sign_in'))

--- a/spec/features/hiring_staff_can_visit_the_public_listings_spec.rb
+++ b/spec/features/hiring_staff_can_visit_the_public_listings_spec.rb
@@ -14,6 +14,44 @@ RSpec.feature 'School viewing public listings' do
   let!(:school) { create(:school, urn: '110627') }
   let!(:user) { create(:user, oid: 'a-valid-oid') }
 
+  context 'when signed in with Azure' do
+    before(:each) do
+      OmniAuth.config.mock_auth[:default] = OmniAuth::AuthHash.new(
+        provider: 'default',
+        info: {
+          name: 'an-email@example.com',
+        },
+        extra: {
+          raw_info: {
+            id_token_claims: {
+              oid: 'a-valid-oid'
+            }
+          }
+        }
+      )
+      mock_response = double(code: '200', body: { user: { permissions: [{ school_urn: '110627' }] } }.to_json)
+      allow(TeacherVacancyAuthorisation::Permissions).to receive(:new)
+        .and_return(AuthHelpers::MockPermissions.new(mock_response))
+    end
+
+    scenario 'A signed in school should see a link back to their own dashboard when viewing public listings', browserstack: true do
+      visit root_path
+
+      click_on(I18n.t('nav.sign_in'))
+      choose(HiringStaff::IdentificationsController::AZURE_SIGN_IN_OPTIONS.first.to_radio.last, allow_label_click: true)
+      click_on(I18n.t('sign_in.link'))
+
+      expect(page).to have_content("Jobs at #{school.name}")
+      within('#proposition-links') { expect(page).to have_content(I18n.t('nav.school_page_link')) }
+
+      click_on(I18n.t('app.title'))
+      expect(page).to have_content(I18n.t('jobs.heading'))
+
+      click_on(I18n.t('nav.school_page_link'))
+      expect(page).to have_content("Jobs at #{school.name}")
+    end
+  end
+
   context 'when signed in with DfE Sign In' do
     before(:each) do
       OmniAuth.config.mock_auth[:dfe] = OmniAuth::AuthHash.new(
@@ -40,11 +78,11 @@ RSpec.feature 'School viewing public listings' do
       ENV['SIGN_IN_WITH_DFE'] = 'false'
     end
 
-    scenario 'A signed in school should see a link back to their own dashboard when viewing public listings' do
+    scenario 'A signed in school should see a link back to their own dashboard when viewing public listings', browserstack: true do
       visit root_path
 
       click_on(I18n.t('nav.sign_in'))
-      choose(HiringStaff::IdentificationsController::DFE_SIGN_IN_OPTIONS.first.to_radio.last)
+      choose(HiringStaff::IdentificationsController::DFE_SIGN_IN_OPTIONS.first.to_radio.last, allow_label_click: true)
       click_on(I18n.t('sign_in.link'))
 
       expect(page).to have_content("Jobs at #{school.name}")

--- a/spec/features/job_seekers_can_apply_for_a_vacancy_spec.rb
+++ b/spec/features/job_seekers_can_apply_for_a_vacancy_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Job seekers can apply for a vacancy' do
-  scenario 'the application link is without protocol' do
+  scenario 'the application link is without protocol', browerstack: true do
     vacancy = create(:vacancy, :published, application_link: 'www.google.com')
 
     visit job_path(vacancy)

--- a/spec/features/job_seekers_can_filter_vacancies_spec.rb
+++ b/spec/features/job_seekers_can_filter_vacancies_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Filtering vacancies' do
-  scenario 'Filterable by keyword', elasticsearch: true do
+  scenario 'Filterable by keyword', elasticsearch: true, browserstack: true do
     headmaster = create(:vacancy, :published, job_title: 'Headmaster')
     languages_teacher = create(:vacancy, :published, job_title: 'Languages Teacher')
 

--- a/spec/features/job_seekers_can_search_vacancies_spec.rb
+++ b/spec/features/job_seekers_can_search_vacancies_spec.rb
@@ -3,21 +3,21 @@ require 'rails_helper'
 RSpec.feature 'Searching vacancies by keyword' do
   describe 'searchable fields' do
     context '#job_title' do
-      scenario 'exact match', elasticsearch: true do
+      scenario 'exact match', elasticsearch: true, browserstack: true do
         vacancy = create(:vacancy, job_title: 'Maths Teacher')
 
         Vacancy.__elasticsearch__.client.indices.flush
 
         visit jobs_path
 
-        expect(page.find('.vacancy:eq(1)')).to have_content(vacancy.job_title)
+        expect(page.find('.vacancy:nth-child(1)')).to have_content(vacancy.job_title)
 
         within '.filters-form' do
           fill_in 'keyword', with: vacancy.job_title
           page.find('.button[type=submit]').click
         end
 
-        expect(page.find('.vacancy:eq(1)')).to have_content(vacancy.job_title)
+        expect(page.find('.vacancy:nth-child(1)')).to have_content(vacancy.job_title)
       end
 
       scenario 'partial match', elasticsearch: true do

--- a/spec/features/job_seekers_can_see_a_map_spec.rb
+++ b/spec/features/job_seekers_can_see_a_map_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Viewing a vacancy' do
-  scenario 'should display a map when a school has geocoding' do
+  scenario 'should display a map when a school has geocoding', browserstack: true do
     school = create(:school,
                     easting: '537224',
                     northing: '177395',

--- a/spec/features/job_seekers_can_sort_vacancies_spec.rb
+++ b/spec/features/job_seekers_can_sort_vacancies_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Sorting vacancies' do
-  scenario 'Default is to be sorted by expiry date but can be sorted by published date', elasticsearch: true do
+  scenario 'Default is to be sorted by expiry date but can be sorted by published date', elasticsearch: true, browserstack: true do
     skip_vacancy_publish_on_validation
 
     first_vacancy = create(:vacancy, :published, expires_on: 7.days.from_now, publish_on: 4.days.ago)
@@ -11,20 +11,20 @@ RSpec.feature 'Sorting vacancies' do
     Vacancy.__elasticsearch__.client.indices.flush
     visit jobs_path
 
-    expect(page.find('.vacancy:eq(1)')).to have_content(third_vacancy.job_title)
-    expect(page.find('.vacancy:eq(2)')).to have_content(second_vacancy.job_title)
-    expect(page.find('.vacancy:eq(3)')).to have_content(first_vacancy.job_title)
+    expect(page.find('.vacancy:nth-child(1)')).to have_content(third_vacancy.job_title)
+    expect(page.find('.vacancy:nth-child(2)')).to have_content(second_vacancy.job_title)
+    expect(page.find('.vacancy:nth-child(3)')).to have_content(first_vacancy.job_title)
 
     click_link I18n.t('jobs.expires_on')
 
-    expect(page.find('.vacancy:eq(1)')).to have_content(first_vacancy.job_title)
-    expect(page.find('.vacancy:eq(2)')).to have_content(second_vacancy.job_title)
-    expect(page.find('.vacancy:eq(3)')).to have_content(third_vacancy.job_title)
+    expect(page.find('.vacancy:nth-child(1)')).to have_content(first_vacancy.job_title)
+    expect(page.find('.vacancy:nth-child(2)')).to have_content(second_vacancy.job_title)
+    expect(page.find('.vacancy:nth-child(3)')).to have_content(third_vacancy.job_title)
 
     click_link I18n.t('jobs.publish_on')
 
-    expect(page.find('.vacancy:eq(1)')).to have_content(first_vacancy.job_title)
-    expect(page.find('.vacancy:eq(2)')).to have_content(third_vacancy.job_title)
-    expect(page.find('.vacancy:eq(3)')).to have_content(second_vacancy.job_title)
+    expect(page.find('.vacancy:nth-child(1)')).to have_content(first_vacancy.job_title)
+    expect(page.find('.vacancy:nth-child(2)')).to have_content(third_vacancy.job_title)
+    expect(page.find('.vacancy:nth-child(3)')).to have_content(second_vacancy.job_title)
   end
 end

--- a/spec/features/job_seekers_can_sort_vacancies_spec.rb
+++ b/spec/features/job_seekers_can_sort_vacancies_spec.rb
@@ -1,7 +1,8 @@
 require 'rails_helper'
 
 RSpec.feature 'Sorting vacancies' do
-  scenario 'Default is to be sorted by expiry date but can be sorted by published date', elasticsearch: true, browserstack: true do
+  scenario 'Default is to be sorted by expiry date but can be sorted by published date',
+           elasticsearch: true, browserstack: true do
     skip_vacancy_publish_on_validation
 
     first_vacancy = create(:vacancy, :published, expires_on: 7.days.from_now, publish_on: 4.days.ago)

--- a/spec/features/job_seekers_can_view_a_vacancy_spec.rb
+++ b/spec/features/job_seekers_can_view_a_vacancy_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Viewing a single published vacancy' do
-  scenario 'Published vacancies are viewable' do
+  scenario 'Published vacancies are viewable', browserstack: true do
     published_vacancy = VacancyPresenter.new(create(:vacancy, :published))
 
     visit job_path(published_vacancy)

--- a/spec/features/job_seekers_can_view_vacancies_spec.rb
+++ b/spec/features/job_seekers_can_view_vacancies_spec.rb
@@ -25,7 +25,7 @@ RSpec.feature 'Viewing vacancies' do
     expect(page).to have_selector('.vacancy', count: Vacancy.default_per_page)
   end
 
-  scenario 'Only vacancies satisfying all publishing conditions are listed', elasticsearch: true do
+  scenario 'Only vacancies satisfying all publishing conditions are listed', elasticsearch: true, browserstack: true do
     valid_vacancy = create(:vacancy)
 
     expired = build(:vacancy, :expired)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ RSpec.configure do |config|
     '127.0.0.1', # Required for Capybara sessions
     'es', # Required for CI. Defined in ./buildspec.yml
     'pg', # Required for CI. Defined in ./buildspec.yml
+    /browserstack/,
   ]
   WebMock.disable_net_connect!(allow: allowed_http_requests)
 

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -7,7 +7,7 @@ module VacancyHelpers
     select vacancy.max_pay_scale.label, from: 'job_specification_form[max_pay_scale_id]'
     select vacancy.subject.name, from: 'job_specification_form[subject_id]'
     select vacancy.leadership.title, from: 'job_specification_form[leadership_id]'
-    check 'job_specification_form[flexible_working]' if vacancy.flexible_working
+    check 'job_specification_form[flexible_working]', visible: false if vacancy.flexible_working
     fill_in 'job_specification_form[minimum_salary]', with: vacancy.minimum_salary
     fill_in 'job_specification_form[benefits]', with: vacancy.benefits
     fill_in 'job_specification_form[weekly_hours]', with: vacancy.weekly_hours

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -2,6 +2,7 @@ module VacancyHelpers
   def fill_in_job_specification_form_fields(vacancy)
     fill_in 'job_specification_form[job_title]', with: vacancy.job_title
     fill_in 'job_specification_form[job_description]', with: vacancy.job_description
+    fill_in 'job_specification_form[benefits]', with: vacancy.benefits
     select vacancy.working_pattern, from: 'job_specification_form[working_pattern]'
     select vacancy.min_pay_scale.label, from: 'job_specification_form[min_pay_scale_id]'
     select vacancy.max_pay_scale.label, from: 'job_specification_form[max_pay_scale_id]'
@@ -9,7 +10,6 @@ module VacancyHelpers
     select vacancy.leadership.title, from: 'job_specification_form[leadership_id]'
     check 'job_specification_form[flexible_working]', visible: false if vacancy.flexible_working
     fill_in 'job_specification_form[minimum_salary]', with: vacancy.minimum_salary
-    fill_in 'job_specification_form[benefits]', with: vacancy.benefits
     fill_in 'job_specification_form[weekly_hours]', with: vacancy.weekly_hours
     fill_in 'job_specification_form[maximum_salary]', with: vacancy.maximum_salary
     fill_in 'job_specification_form[starts_on_dd]', with: vacancy.starts_on.day

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -8,7 +8,7 @@ module VacancyHelpers
     select vacancy.max_pay_scale.label, from: 'job_specification_form[max_pay_scale_id]'
     select vacancy.subject.name, from: 'job_specification_form[subject_id]'
     select vacancy.leadership.title, from: 'job_specification_form[leadership_id]'
-    check 'job_specification_form[flexible_working]', visible: false if vacancy.flexible_working
+    find('#flexible_working label').click if vacancy.flexible_working
     fill_in 'job_specification_form[minimum_salary]', with: vacancy.minimum_salary
     fill_in 'job_specification_form[weekly_hours]', with: vacancy.weekly_hours
     fill_in 'job_specification_form[maximum_salary]', with: vacancy.maximum_salary

--- a/testspec.yml
+++ b/testspec.yml
@@ -12,7 +12,7 @@ phases:
       - echo Testing the newly built Docker image...
       - docker run --name es -d -p 9200:9200 elasticsearch
       - docker run --name pg -d -p 5432:5432 postgres
-      - docker run --name test -d -e RAILS_ENV=test --link pg:pg --link es:es temp_image:test /bin/bash -c "tail -f /dev/null"
+      - docker run --name test -d -e RAILS_ENV=test -e BROWSERSTACK_USERNAME=${browserstack_username} -e BROWSERSTACK_ACCESS_KEY=${browserstack_access_key} --link pg:pg --link es:es temp_image:test /bin/bash -c "tail -f /dev/null"
       - docker exec test bundle install --with test --retry 3 --jobs 20
       - docker exec test /bin/bash -c "export DATABASE_URL='postgres://postgres@pg:5432/test?template=template0&pool=5&encoding=unicode' && export ELASTICSEARCH_URL='http://es:9200' && rake db:setup"
       - docker exec test /bin/bash -c "export DATABASE_URL='postgres://postgres@pg:5432/test?template=template0&pool=5&encoding=unicode' && export ELASTICSEARCH_URL='http://es:9200' && rake"


### PR DESCRIPTION
# Description

The is now ready for review. It allows us to test our happy path feature specs in five different browsers as part of our CI process. This will allow us to catch any browser incompatibilities as they happen.

# Things to consider

## Parallelisation 

I attempted to run the specs in parallel using the `parallel` gem however it threw a `ActiveRecord::RecordNotUnique` error. I guess because the tests attempted to use the same database and the same time and couldn't insert the same content.

By running the tests serially it takes about 15 minutes to run the tests in all the browsers.

## Internet Explorer 11 driver

The IE11 driver has many quirks, including:
- not being able to find checkboxes that are hidden (which is an issue for us because we're using GOV.UK styles that hide standard checkboxes)
- `page.html` has a strange issue where you can't see all the correct HTML on the page. I'm not sure what's going on here but the same test works in IE10 so I went with that instead.

## Edge driver

The Edge driver will fail to find an element if it's too far away from the element that is currently focused.

## Commit history

I decided to leave all the commits in the PR as it really helps describe the issues I ran in to trying to get this working, it might help people in the future.