### PR TITLE
[310] Users that reset their DFE Sign-in password can recover from t…

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -2,6 +2,14 @@ class ErrorsController < ApplicationController
   skip_before_action :verify_authenticity_token,
                      only: %i[not_found unprocessable_entity internal_server_error]
 
+  def unauthorised
+    respond_to do |format|
+      format.html { render status: 401 }
+      format.json { render json: { error: 'Not authorised' }, status: 401 }
+      format.all { render status: 401, body: nil }
+    end
+  end
+
   def not_found
     respond_to do |format|
       format.html { render status: 404 }

--- a/app/controllers/hiring_staff/sign_in/dfe/sessions_controller.rb
+++ b/app/controllers/hiring_staff/sign_in/dfe/sessions_controller.rb
@@ -36,7 +36,7 @@ class HiringStaff::SignIn::Dfe::SessionsController < HiringStaff::BaseController
     auth_hash['uid']
   end
 
-  private def identifier
+  def identifier
     auth_hash['info']['email']
   end
 end

--- a/app/views/errors/unauthorised.html.haml
+++ b/app/views/errors/unauthorised.html.haml
@@ -1,0 +1,4 @@
+- content_for :page_title_prefix, t('error_pages.unauthorised')
+
+%h1.heading-xlarge=t('error_pages.unauthorised')
+%p You can email #{mail_to t('help.email')} if the problem persists.

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,42 +1,49 @@
-class OmniAuth::Strategies::Dfe < OmniAuth::Strategies::OpenIDConnect
-  # rubocop:disable Metrics/AbcSize
-  # rubocop:disable Metrics/CyclomaticComplexity
-  # rubocop:disable Metrics/PerceivedComplexity
-  # rubocop:disable Metrics/LineLength
-  # rubocop:disable Style/GuardClause
-  # Please refer to this commit to read why this has been copied from:https://github.com/m0n9oose/omniauth_openid_connect/blob/master/lib/omniauth/strategies/openid_connect.rb
-  def callback_phase
-    logger.info('Override callback phase…')
-    error = request.params['error_reason'] || request.params['error']
-    if error
-      raise CallbackError.new(request.params['error'], request.params['error_description'] || request.params['error_reason'], request.params['error_uri'])
-    elsif request['QUERY_STRING'].blank?
-      return Rack::Response.new(['Oops there was a problem. Please visit this URL to continue: https://teaching-jobs.service.gov.uk/identifications/new'], 200)
-    elsif request.params['state'].to_s.empty? || request.params['state'] != stored_state
-      return Rack::Response.new(['401 Unauthorized'], 401).finish
-    elsif !request.params['code']
-      return fail!(:missing_code, OmniAuth::OpenIDConnect::MissingCodeError.new(request.params['error']))
-    else
-      options.issuer = issuer if options.issuer.blank?
-      discover! if options.discovery
-      client.redirect_uri = redirect_uri
-      client.authorization_code = authorization_code
-      access_token
-      super
+module OmniAuth
+  module Strategies
+    class OpenIDConnect
+      # rubocop:disable Metrics/AbcSize
+      # rubocop:disable Metrics/CyclomaticComplexity
+      # rubocop:disable Metrics/PerceivedComplexity
+      # rubocop:disable Metrics/LineLength
+      # rubocop:disable Style/GuardClause
+      # Please refer to this commit to read why this has been copied from: https://github.com/m0n9oose/omniauth_openid_connect/blob/master/lib/omniauth/strategies/openid_connect.rb
+      def callback_phase
+        error = request.params['error_reason'] || request.params['error']
+        if error
+          raise CallbackError.new(request.params['error'], request.params['error_description'] || request.params['error_reason'], request.params['error_uri'])
+        elsif request.params.blank?
+          redirects = { '/auth/dfe/callback' => '/dfe/sessions/new' }
+          req = Rack::Request.new(env)
+          return redirect(redirects[req.path]) if redirects.include?(req.path)
+        elsif request.params['state'].to_s.empty? || request.params['state'] != stored_state
+          return Rack::Response.new(['401 Unauthorized'], 401).finish
+        elsif !request.params['code']
+          return fail!(:missing_code, OmniAuth::OpenIDConnect::MissingCodeError.new(request.params['error']))
+        else
+          options.issuer = issuer if options.issuer.blank?
+          discover! if options.discovery
+          client.redirect_uri = redirect_uri
+          client.authorization_code = authorization_code
+          access_token
+          super
+        end
+      rescue CallbackError => e
+        fail!(:invalid_credentials, e)
+      rescue ::Timeout::Error, ::Errno::ETIMEDOUT => e
+        fail!(:timeout, e)
+      rescue ::SocketError => e
+        fail!(:failed_to_connect, e)
+      end
+      # rubocop:enable Metrics/AbcSize
+      # rubocop:enable Metrics/CyclomaticComplexity
+      # rubocop:enable Metrics/PerceivedComplexity
+      # rubocop:enable Metrics/LineLength
+      # rubocop:enable Style/GuardClause
     end
-  rescue CallbackError => e
-    fail!(:invalid_credentials, e)
-  rescue ::Timeout::Error, ::Errno::ETIMEDOUT => e
-    fail!(:timeout, e)
-  rescue ::SocketError => e
-    fail!(:failed_to_connect, e)
   end
-  # rubocop:enable Metrics/AbcSize
-  # rubocop:enable Metrics/CyclomaticComplexity
-  # rubocop:enable Metrics/PerceivedComplexity
-  # rubocop:enable Metrics/LineLength
-  # rubocop:enable Style/GuardClause
 end
+
+class OmniAuth::Strategies::Dfe < OmniAuth::Strategies::OpenIDConnect; end
 
 Rails.application.config.middleware.use OmniAuth::Builder do
   dfe_sign_in_issuer_uri    = URI(ENV.fetch('DFE_SIGN_IN_ISSUER', 'example'))

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -16,7 +16,7 @@ module OmniAuth
           req = Rack::Request.new(env)
           return redirect(redirects[req.path]) if redirects.include?(req.path)
         elsif request.params['state'].to_s.empty? || request.params['state'] != stored_state
-          return Rack::Response.new(['401 Unauthorized'], 401).finish
+          return redirect('/401')
         elsif !request.params['code']
           return fail!(:missing_code, OmniAuth::OpenIDConnect::MissingCodeError.new(request.params['error']))
         else

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -236,6 +236,7 @@ en:
       already_submitted: Feedback for this job listing has already been submitted
 
   error_pages:
+    unauthorised: We were unable to authorise your request.
     unprocessable_entity: We're unable to process your request.
     not_found: Page not found.
     server_error: Something went wrong at our end.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,6 +64,7 @@ Rails.application.routes.draw do
     end
   end
 
+  match '/401', to: 'errors#unauthorised', via: :all
   match '/404', to: 'errors#not_found', via: :all
   match '/422', to: 'errors#unprocessable_entity', via: :all
   match '/500', to: 'errors#internal_server_error', via: :all

--- a/spec/features/hiring_staff_can_sign_in_with_azure_spec.rb
+++ b/spec/features/hiring_staff_can_sign_in_with_azure_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature 'Hiring staff signing-in with Azure' do
 
   after(:each) do
     OmniAuth.config.mock_auth[:default] = nil
+    OmniAuth.config.test_mode = false
   end
 
   let!(:school) { create(:school, urn: '110627') }

--- a/spec/features/hiring_staff_can_sign_in_with_dfe_spec.rb
+++ b/spec/features/hiring_staff_can_sign_in_with_dfe_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 RSpec.feature 'Hiring staff signing-in with DfE Sign In' do
-  before do
+  before(:each) do
     OmniAuth.config.test_mode = true
     ENV['SIGN_IN_WITH_DFE'] = 'true'
   end
@@ -9,6 +9,7 @@ RSpec.feature 'Hiring staff signing-in with DfE Sign In' do
     OmniAuth.config.mock_auth[:default] = nil
     OmniAuth.config.mock_auth[:dfe] = nil
     ENV['SIGN_IN_WITH_DFE'] = 'false'
+    OmniAuth.config.test_mode = false
   end
 
   let!(:school) { create(:school, urn: '110627') }

--- a/spec/features/hiring_staff_can_sign_in_with_dfe_spec.rb
+++ b/spec/features/hiring_staff_can_sign_in_with_dfe_spec.rb
@@ -7,6 +7,7 @@ RSpec.feature 'Hiring staff signing-in with DfE Sign In' do
 
   after(:each) do
     OmniAuth.config.mock_auth[:default] = nil
+    OmniAuth.config.mock_auth[:dfe] = nil
     ENV['SIGN_IN_WITH_DFE'] = 'false'
   end
 

--- a/spec/features/hiring_staff_can_visit_the_public_listings_spec.rb
+++ b/spec/features/hiring_staff_can_visit_the_public_listings_spec.rb
@@ -7,6 +7,7 @@ RSpec.feature 'School viewing public listings' do
 
   after(:each) do
     OmniAuth.config.mock_auth[:default] = nil
+    OmniAuth.config.mock_auth[:dfe] = nil
   end
 
   let!(:school) { create(:school, urn: '110627') }

--- a/spec/requests/dfe_sign_in_spec.rb
+++ b/spec/requests/dfe_sign_in_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe 'DfE Sign-in' do
     context 'when that payload is unauthorised' do
       it 'redirects the user to the not authorised page' do
         params = {
-          'code' => 'a-long-secret',
-          'session_state' => '123.456'
+          'code': 'a-long-secret',
+          'session_state': '123.456'
         }
 
         get '/auth/dfe/callback', params: params

--- a/spec/requests/dfe_sign_in_spec.rb
+++ b/spec/requests/dfe_sign_in_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe 'DfE Sign-in' do
+  before(:each) do
+    ensure_omniauth_has_not_been_mocked_in_another_test
+  end
+
+  context 'when DfE Sign-in respond with an OIDC payload for authentication purposes' do
+    context 'when that payload is unauthorised' do
+      it 'redirects the user to the not authorised page' do
+        params = {
+          'code' => 'a-long-secret',
+          'session_state' => '123.456'
+        }
+
+        get '/auth/dfe/callback', params: params
+
+        expect(response.status).to eq(302)
+        expect(response.body).to eq('Redirecting to /401...')
+      end
+    end
+  end
+
+  context 'when a user is linked back to our service with a redirect' do
+    it 'routes the request back to the new sign-in page' do
+      request = get '/auth/dfe/callback'
+      expect(request).to redirect_to(new_dfe_path)
+    end
+  end
+
+  def ensure_omniauth_has_not_been_mocked_in_another_test
+    OmniAuth.config.mock_auth[:default] = nil
+    OmniAuth.config.mock_auth[:dfe] = nil
+  end
+end


### PR DESCRIPTION
…he error

* DfE Sign-in will always redirect users to our redirect_uri that’s used for normal authentication requests: auth/dfe/callback.
* This is not currently configurable in their service and they advise us to handle multiple types of request on the same endpoint.
* This was a problem because OmniAuth was identifying this request as unauthorised because our service was not the origin, no nonce was created and stored (I think). This then is intercepted in Rack in the Omniauth wrapper of our callback endpoint so we have to look inside our omniauth strategy to handle this behaviour and stop it rendering a white page with “Not authorised”.
* This change is the quickest thing I can think of doing that will allow users to recover from this error when they reset their password. Giving us more time to identify a better solution.
* Both types of requests are GET so I cannot distinguish on that but as QUERY_STRING is populated with params like `code` as part of an OIDC request, I can check for their absence
