### PR TITLE
(fix) ensure OmniAuth test mode is disabled …

### DIFF
--- a/spec/features/hiring_staff_can_visit_the_public_listings_spec.rb
+++ b/spec/features/hiring_staff_can_visit_the_public_listings_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature 'School viewing public listings' do
   end
 
   after(:each) do
+    OmniAuth.config.test_mode = false
     OmniAuth.config.mock_auth[:default] = nil
     OmniAuth.config.mock_auth[:dfe] = nil
   end

--- a/spec/requests/dfe_sign_in_spec.rb
+++ b/spec/requests/dfe_sign_in_spec.rb
@@ -1,10 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'DfE Sign-in' do
-  before(:each) do
-    ensure_omniauth_has_not_been_mocked_in_another_test
-  end
-
+RSpec.describe 'DfE Sign-in', type: :request do
   context 'when DfE Sign-in respond with an OIDC payload for authentication purposes' do
     context 'when that payload is unauthorised' do
       it 'redirects the user to the not authorised page' do
@@ -13,7 +9,7 @@ RSpec.describe 'DfE Sign-in' do
           'session_state': '123.456'
         }
 
-        get '/auth/dfe/callback', params: params
+        get auth_dfe_callback_path, params: params
 
         expect(response.status).to eq(302)
         expect(response.body).to eq('Redirecting to /401...')
@@ -23,13 +19,8 @@ RSpec.describe 'DfE Sign-in' do
 
   context 'when a user is linked back to our service with a redirect' do
     it 'routes the request back to the new sign-in page' do
-      request = get '/auth/dfe/callback'
+      request = get auth_dfe_callback_path
       expect(request).to redirect_to(new_dfe_path)
     end
-  end
-
-  def ensure_omniauth_has_not_been_mocked_in_another_test
-    OmniAuth.config.mock_auth[:default] = nil
-    OmniAuth.config.mock_auth[:dfe] = nil
   end
 end


### PR DESCRIPTION
after any features that enable it
- use rails route helpers in request spec
- remove redundant before(:each) block from request spec