### PR TITLE
[336] Enable generic sign-in option for testing

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,11 @@
 inherit_from: .rubocop_todo.yml
+Rails/UnknownEnv:
+  Environments:
+    - production
+    - development
+    - test
+    - staging
+    
 AllCops:
     TargetRubyVersion: 2.4
     Exclude:

--- a/app/controllers/hiring_staff/identifications_controller.rb
+++ b/app/controllers/hiring_staff/identifications_controller.rb
@@ -10,8 +10,8 @@ class HiringStaff::IdentificationsController < HiringStaff::BaseController
   def new; end
 
   def create
-    sign_in_path = new_azure_path
-    sign_in_path = new_dfe_path if DFE_SIGN_IN_OPTIONS.map(&:name).include?(choice)
+    sign_in_path = new_dfe_path
+    sign_in_path = new_azure_path if AZURE_SIGN_IN_OPTIONS.map(&:name).include?(choice)
 
     logger.debug("Hiring staff identified as from the #{choice} district during sign in.")
     redirect_to sign_in_path

--- a/app/helpers/identifications_helper.rb
+++ b/app/helpers/identifications_helper.rb
@@ -1,6 +1,18 @@
 module IdentificationsHelper
   DFE_SIGN_IN_OPTIONS = [
-    OpenStruct.new(name: 'other', to_radio: ['other', 'Other'])
+    OpenStruct.new(
+      name: I18n.t('sign_in.option.milton_keynes').downcase,
+      to_radio: [I18n.t('sign_in.milton_keynes.other').downcase, I18n.t('sign_in.milton_keynes.other')]
+    )
+  ].freeze
+
+  # For the temporary purposes of usability testing for hiring staff that belong
+  # to a school we've not yet rolled out to.
+  STAGING_DFE_SIGN_IN_OPTIONS = [
+    OpenStruct.new(
+      name: I18n.t('sign_in.option.other').downcase,
+      to_radio: [I18n.t('sign_in.option.other').downcase, I18n.t('sign_in.option.other')]
+    )
   ].freeze
 
   AZURE_SIGN_IN_OPTIONS = [
@@ -12,6 +24,7 @@ module IdentificationsHelper
     @identification_options ||= begin
       opts = AZURE_SIGN_IN_OPTIONS.map(&:to_radio)
       opts += DFE_SIGN_IN_OPTIONS.map(&:to_radio) unless Rails.env.production?
+      opts += STAGING_DFE_SIGN_IN_OPTIONS.map(&:to_radio) if Rails.env.staging?
       opts
     end
   end

--- a/app/helpers/identifications_helper.rb
+++ b/app/helpers/identifications_helper.rb
@@ -1,6 +1,6 @@
 module IdentificationsHelper
   DFE_SIGN_IN_OPTIONS = [
-    OpenStruct.new(name: 'milton_keynes', to_radio: ['milton_keynes', 'Milton Keynes'])
+    OpenStruct.new(name: 'other', to_radio: ['other', 'Other'])
   ].freeze
 
   AZURE_SIGN_IN_OPTIONS = [

--- a/app/helpers/identifications_helper.rb
+++ b/app/helpers/identifications_helper.rb
@@ -2,7 +2,7 @@ module IdentificationsHelper
   DFE_SIGN_IN_OPTIONS = [
     OpenStruct.new(
       name: I18n.t('sign_in.option.milton_keynes').downcase,
-      to_radio: [I18n.t('sign_in.milton_keynes.other').downcase, I18n.t('sign_in.milton_keynes.other')]
+      to_radio: [I18n.t('sign_in.option.milton_keynes').downcase, I18n.t('sign_in.option.milton_keynes')]
     )
   ].freeze
 
@@ -16,8 +16,14 @@ module IdentificationsHelper
   ].freeze
 
   AZURE_SIGN_IN_OPTIONS = [
-    OpenStruct.new(name: 'cambridgeshire', to_radio: ['cambridgeshire', 'Cambridgeshire']),
-    OpenStruct.new(name: 'the_north_east', to_radio: ['the_north_east', 'The North East'])
+    OpenStruct.new(
+      name: I18n.t('sign_in.option.cambridgeshire').downcase,
+      to_radio: [I18n.t('sign_in.option.cambridgeshire').downcase, I18n.t('sign_in.option.cambridgeshire')]
+    ),
+    OpenStruct.new(
+      name: I18n.t('sign_in.option.the_north_east').downcase.tr('_', ' '),
+      to_radio: ['the_north_east', 'The North East']
+    )
   ].freeze
 
   def identification_options

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,6 +25,9 @@ en:
       title: 'Select your organisation'
       legend: 'You are associated with more than one organisation, please select the one you wish to sign-in with.'
       change: 'Change organisation'
+    option:
+      other: 'Other'
+      milton_keynes: 'Milton Keynes'
   identification:
     find_school_information: Find your schools official area
   jobs:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,6 +28,8 @@ en:
     option:
       other: 'Other'
       milton_keynes: 'Milton Keynes'
+      cambridgeshire: 'Cambridgeshire'
+      the_north_east: 'The North East'
   identification:
     find_school_information: Find your schools official area
   jobs:

--- a/spec/features/hiring_staff_can_sign_in_with_dfe_spec.rb
+++ b/spec/features/hiring_staff_can_sign_in_with_dfe_spec.rb
@@ -122,6 +122,24 @@ RSpec.feature 'Hiring staff signing-in with DfE Sign In' do
         expect(page).to have_content("Jobs at #{other_school.name}")
       end
     end
+
+    context 'when usability testing is carried out in staging' do
+      before(:each) do
+        stub_global_auth(return_value: false)
+        allow(Rails).to receive(:env)
+          .and_return(ActiveSupport::StringInquirer.new('staging'))
+      end
+
+      it 'allows the user to select the "other" option for signing in with DfE Sign-in', elasticsearch: true do
+        visit root_path
+
+        click_on(I18n.t('nav.sign_in'))
+        choose(I18n.t('sign_in.option.other'))
+        click_on(I18n.t('sign_in.link'))
+
+        expect(page).to have_content("Jobs at #{school.name}")
+      end
+    end
   end
 
   context 'with valid credentials but no permission' do

--- a/spec/features/hiring_staff_can_sign_in_with_dfe_spec.rb
+++ b/spec/features/hiring_staff_can_sign_in_with_dfe_spec.rb
@@ -36,13 +36,11 @@ end
 RSpec.feature 'Hiring staff signing-in with DfE Sign In' do
   before(:each) do
     OmniAuth.config.test_mode = true
-    ENV['SIGN_IN_WITH_DFE'] = 'true'
   end
 
   after(:each) do
     OmniAuth.config.mock_auth[:default] = nil
     OmniAuth.config.mock_auth[:dfe] = nil
-    ENV['SIGN_IN_WITH_DFE'] = 'false'
     OmniAuth.config.test_mode = false
   end
 

--- a/spec/features/hiring_staff_can_sign_in_with_dfe_spec.rb
+++ b/spec/features/hiring_staff_can_sign_in_with_dfe_spec.rb
@@ -122,24 +122,6 @@ RSpec.feature 'Hiring staff signing-in with DfE Sign In' do
         expect(page).to have_content("Jobs at #{other_school.name}")
       end
     end
-
-    context 'when usability testing is carried out in staging' do
-      before(:each) do
-        stub_global_auth(return_value: false)
-        allow(Rails).to receive(:env)
-          .and_return(ActiveSupport::StringInquirer.new('staging'))
-      end
-
-      it 'allows the user to select the "other" option for signing in with DfE Sign-in', elasticsearch: true do
-        visit root_path
-
-        click_on(I18n.t('nav.sign_in'))
-        choose(I18n.t('sign_in.option.other'))
-        click_on(I18n.t('sign_in.link'))
-
-        expect(page).to have_content("Jobs at #{school.name}")
-      end
-    end
   end
 
   context 'with valid credentials but no permission' do

--- a/spec/features/hiring_staff_can_visit_the_public_listings_spec.rb
+++ b/spec/features/hiring_staff_can_visit_the_public_listings_spec.rb
@@ -69,12 +69,6 @@ RSpec.feature 'School viewing public listings' do
       mock_response = double(code: '200', body: { user: { permissions: [{ school_urn: '110627' }] } }.to_json)
       allow(TeacherVacancyAuthorisation::Permissions).to receive(:new)
         .and_return(AuthHelpers::MockPermissions.new(mock_response))
-
-      ENV['SIGN_IN_WITH_DFE'] = 'true'
-    end
-
-    after(:each) do
-      ENV['SIGN_IN_WITH_DFE'] = 'false'
     end
 
     scenario 'A signed in school should see a link back to their own dashboard when viewing public listings' do


### PR DESCRIPTION
* This should only need to life as long as we need to present sign-in options to users but it's still needed in usability testing sessions as the testers school will likely not be in the same regions we have rolled out to, at least to begin with.
* Refactor existing options using locale
* Switched the logic of the guard clause around sign-in redirection. Instead of Azure it will always try to go to DfE Sign-in unless one of the Azure areas. This makes support of 'Other' very easy and clear as well as aligning with the longer term strategy of moving away from Azure.