### PR TITLE
Chore/340 validated changes to mobile layouts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,8 @@ gem 'public_activity'
 gem 'high_voltage', '~> 3.1'
 gem 'google_drive', require: false
 
+gem 'browser'
+
 group :test, :development, :staging do
   gem 'faker'
   gem 'factory_bot_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,7 @@ GEM
     bindata (2.4.3)
     bindex (0.5.0)
     breasal (0.0.1)
+    browser (2.5.3)
     builder (3.2.3)
     byebug (9.1.0)
     capybara (2.15.1)
@@ -480,6 +481,7 @@ DEPENDENCIES
   activerecord-session_store
   addressable
   breasal (~> 0.0.1)
+  browser
   byebug
   capybara (~> 2.13)
   coffee-rails

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,7 @@ class ApplicationController < ActionController::Base
 
   before_action :check_staging_auth, except: :check
   before_action :set_headers
+  before_action :detect_device_format
 
   include AuthenticationConcerns
   include Ip
@@ -30,6 +31,10 @@ class ApplicationController < ActionController::Base
 
   def authenticate?
     Rails.env.staging?
+  end
+
+  def detect_device_format
+    request.variant = :phone if browser.device.mobile?
   end
 
   private def http_user

--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -1,6 +1,4 @@
 class VacanciesController < ApplicationController
-  # include VariantConcerns
-
   helper_method :location,
                 :keyword,
                 :minimum_salary,

--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -1,4 +1,6 @@
 class VacanciesController < ApplicationController
+  # include VariantConcerns
+
   helper_method :location,
                 :keyword,
                 :minimum_salary,

--- a/app/views/vacancies/_school_details.html.haml
+++ b/app/views/vacancies/_school_details.html.haml
@@ -1,0 +1,16 @@
+%dl.school--details
+  %dt= t('schools.address')
+  %dd= @vacancy.school.full_address
+
+  - if @vacancy.school.phase.present?
+    %dt= t('schools.phase')
+    %dd= @vacancy.school.phase.titleize
+
+  - if @vacancy.school.school_type.present?
+    %dt= t('schools.type')
+    %dd= @vacancy.school.school_type.label
+
+  - if @vacancy.school.url.present?
+    %dt= t('schools.website')
+    %dd
+      = link_to("#{@vacancy.school.name} website (opens in a new window)", @vacancy.school.url, class: 'wordwrap', target: '_blank')

--- a/app/views/vacancies/_show.html+phone.haml
+++ b/app/views/vacancies/_show.html+phone.haml
@@ -18,22 +18,7 @@
       = @vacancy.school.name
     %p= @vacancy.school.description
 
-    %dl.school--details
-      %dt= t('schools.address')
-      %dd= @vacancy.school.full_address
-
-      - if @vacancy.school.phase.present?
-        %dt= t('schools.phase')
-        %dd= @vacancy.school.phase&.titleize
-
-      - if @vacancy.school.school_type.present?
-        %dt= t('schools.type')
-        %dd= @vacancy.school.school_type.label
-
-      - if @vacancy.school.url.present?
-        %dt= t('schools.website')
-        %dd
-          = link_to("#{@vacancy.school.name} website (opens in a new window)", @vacancy.school.url, class: 'wordwrap', target: '_blank')
+    = render partial: 'school_details'
 
     - if @vacancy.school.geolocation
       #map_zoom{style: 'height: 200px; margin-bottom: 20px;'}

--- a/app/views/vacancies/_show.html+phone.haml
+++ b/app/views/vacancies/_show.html+phone.haml
@@ -13,14 +13,6 @@
       %span.heading-secondary
         = @vacancy.location
 
-    - if @vacancy.school.geolocation
-      #map_zoom{style: 'height: 200px; margin-bottom: 20px;'}
-      = render partial: '/vacancies/school', formats: [:js], locals: { name: @vacancy.school.name,
-                                                            lat: @vacancy.school_geolocation.x,
-                                                            lng: @vacancy.school_geolocation.y }
-
-      %script{async: true, defer: true, src: "https://maps.googleapis.com/maps/api/js?key=#{ENV['GOOGLE_MAPS_API_KEY']}&callback=initMap"}
-
     %h2.heading-medium
       = t('schools.about')
       = @vacancy.school.name
@@ -42,6 +34,14 @@
         %dt= t('schools.website')
         %dd
           = link_to("#{@vacancy.school.name} website (opens in a new window)", @vacancy.school.url, class: 'wordwrap', target: '_blank')
+
+    - if @vacancy.school.geolocation
+      #map_zoom{style: 'height: 200px; margin-bottom: 20px;'}
+      = render partial: '/vacancies/school', formats: [:js], locals: { name: @vacancy.school.name,
+                                                            lat: @vacancy.school_geolocation.x,
+                                                            lng: @vacancy.school_geolocation.y }
+
+      %script{async: true, defer: true, src: "https://maps.googleapis.com/maps/api/js?key=#{ENV['GOOGLE_MAPS_API_KEY']}&callback=initMap"}
 
     %h2.mt1.heading-medium= t('jobs.key_info')
 

--- a/app/views/vacancies/_show.html+phone.haml
+++ b/app/views/vacancies/_show.html+phone.haml
@@ -1,0 +1,123 @@
+- content_for :page_title_prefix do
+  #{@vacancy.job_title} — #{@vacancy.school_name}
+
+.vacancy.grid-row
+  - if @vacancy.expired?
+    .column-full
+      .banner-warning
+        = t('jobs.expired')
+
+  .column-one-third
+    %h1.heading-large
+      = @vacancy.job_title
+      %span.heading-secondary
+        = @vacancy.location
+
+    - if @vacancy.school.geolocation
+      #map_zoom{style: 'height: 200px; margin-bottom: 20px;'}
+      = render partial: '/vacancies/school', formats: [:js], locals: { name: @vacancy.school.name,
+                                                            lat: @vacancy.school_geolocation.x,
+                                                            lng: @vacancy.school_geolocation.y }
+
+      %script{async: true, defer: true, src: "https://maps.googleapis.com/maps/api/js?key=#{ENV['GOOGLE_MAPS_API_KEY']}&callback=initMap"}
+
+    %h2.heading-medium
+      = t('schools.about')
+      = @vacancy.school.name
+    %p= @vacancy.school.description
+
+    %dl.school--details
+      %dt= t('schools.address')
+      %dd= @vacancy.school.full_address
+
+      - if @vacancy.school.phase.present?
+        %dt= t('schools.phase')
+        %dd= @vacancy.school.phase&.titleize
+
+      - if @vacancy.school.school_type.present?
+        %dt= t('schools.type')
+        %dd= @vacancy.school.school_type.label
+
+      - if @vacancy.school.url.present?
+        %dt= t('schools.website')
+        %dd
+          = link_to("#{@vacancy.school.name} website (opens in a new window)", @vacancy.school.url, class: 'wordwrap', target: '_blank')
+
+    %h2.mt1.heading-medium= t('jobs.key_info')
+
+    %table.check-your-answers.cya-questions-short
+      %tbody
+        %tr
+          %td.cya-question= t('jobs.salary')
+          %td.cya-answer= @vacancy.salary_range
+        %tr
+          %td.cya-question= t('jobs.working_pattern')
+          %td.cya-answer= @vacancy.working_pattern
+        - if @vacancy.part_time? && @vacancy.weekly_hours
+          %tr
+            %td.cya-question= t('jobs.weekly_hours')
+            %td.cya-answer= @vacancy.weekly_hours
+        - if @vacancy.flexible_working?
+          %tr
+            %td.cya-question= t('jobs.flexible_working')
+            %td.cya-answer= @vacancy.flexible_working
+        - if @vacancy.starts_on.present?
+          %tr
+            %td.cya-question= t('jobs.starts_on')
+            %td.cya-answer= format_date(@vacancy.starts_on)
+        - if @vacancy.ends_on.present?
+          %tr
+            %td.cya-question= t('jobs.ends_on')
+            %td.cya-answer= format_date(@vacancy.ends_on)
+        %tr
+          %td.cya-question= t('jobs.publish_on')
+          %td.cya-answer= format_date(@vacancy.publish_on)
+        %tr
+          %td.cya-question= t('jobs.expires_on')
+          %td.cya-answer= format_date(@vacancy.expires_on)
+        - if @vacancy.main_subject.present?
+          %tr
+            %td.cya-question= t('jobs.main_subject')
+            %td.cya-answer= @vacancy.main_subject
+
+        - if @vacancy.pay_scale_range.present?
+          %tr
+            %td.cya-question= t('jobs.pay_scale_range')
+            %td.cya-answer= @vacancy.pay_scale_range
+
+        - if @vacancy.leadership.present?
+          %tr
+            %td.cya-question= t('jobs.leadership_level')
+            %td.cya-answer= @vacancy.leadership.title
+
+        - if @vacancy.contact_email.present?
+          %tr
+            %td.cya-question= t('jobs.contact_email')
+            %td.cya-answer.wordwrap= mail_to @vacancy.contact_email, @vacancy.contact_email, subject: t('jobs.contact_email_subject', job: @vacancy.job_title), body: t('jobs.contact_email_body', url: url_for(only_path: false))
+
+
+    %h2.heading-medium= t('jobs.description')
+    %p= @vacancy.job_description
+
+    - if @vacancy.education?
+      %h2.heading-medium= t('jobs.education')
+      %p= @vacancy.education
+
+    - if @vacancy.qualifications?
+      %h2.heading-medium= t('jobs.qualifications')
+      %p= @vacancy.qualifications
+
+    - if @vacancy.experience?
+      %h2.heading-medium= t('jobs.experience')
+      %p= @vacancy.experience
+
+    - if @vacancy.benefits?
+      %h2.heading-medium= t('jobs.benefits')
+      %p= @vacancy.benefits
+
+    %aside.vacancy--metadata
+      - if @vacancy.application_link.present?
+        %p.font-xsmall=t('jobs.aria_labels.apply_link')
+        = link_to t('jobs.apply'), new_job_interest_path(@vacancy.id), target: '_blank', class: 'button vacancy-apply-link', 'aria-label': t('jobs.aria_labels.apply_link')
+
+= render partial: 'shared/beta_banner'

--- a/app/views/vacancies/_show.html.haml
+++ b/app/views/vacancies/_show.html.haml
@@ -39,22 +39,7 @@
 
     %p= @vacancy.school.description
 
-    %dl.school--details
-      %dt= t('schools.address')
-      %dd= @vacancy.school.full_address
-
-      - if @vacancy.school.phase.present?
-        %dt= t('schools.phase')
-        %dd= @vacancy.school.phase.titleize
-
-      - if @vacancy.school.school_type.present?
-        %dt= t('schools.type')
-        %dd= @vacancy.school.school_type.label
-
-      - if @vacancy.school.url.present?
-        %dt= t('schools.website')
-        %dd
-          = link_to("#{@vacancy.school.name} website (opens in a new window)", @vacancy.school.url, class: 'wordwrap', target: '_blank')
+    = render partial: 'school_details'
 
     - if @vacancy.school.geolocation
       %div#map_zoom

--- a/app/views/vacancies/index.html+phone.haml
+++ b/app/views/vacancies/index.html+phone.haml
@@ -6,7 +6,7 @@
 
   .column-two-thirds
     %p.heading-medium.mt0.mb1
-      = @vacancies.total_count
+      %p.heading-medium.mt0= @vacancies.total_count_message
       = link_to 'Refine your search?', '#filters'
     - if @vacancies.any?
       %div.sortable-links

--- a/app/views/vacancies/index.html+phone.haml
+++ b/app/views/vacancies/index.html+phone.haml
@@ -1,0 +1,26 @@
+- content_for :page_title_prefix, t('jobs.heading')
+
+%h1.heading-xlarge
+  = t('jobs.heading')
+.grid-row
+
+  .column-two-thirds
+    %p.heading-medium.mt0.mb1
+      = @vacancies.total_count
+      = link_to 'Refine your search?', '#filters'
+    - if @vacancies.any?
+      %div.sortable-links
+        = t('jobs.sort_by')
+        = link_to_sort_by t('jobs.expires_on'), column: 'expires_on', order: 'asc', sort: @sort
+        = link_to_sort_by t('jobs.publish_on'), column: 'publish_on', order: 'desc', sort: @sort
+
+      %ul.vacancies
+        - @vacancies.each do |vacancy|
+          = render partial: 'vacancy', locals: { vacancy: vacancy }
+
+  .column-one-third#filters
+    = render 'filters'
+
+= paginate @vacancies
+
+= render partial: 'shared/beta_banner'

--- a/app/views/vacancies/show.html.haml
+++ b/app/views/vacancies/show.html.haml
@@ -1,4 +1,3 @@
-= render partial: 'shared/beta_banner'
 = render partial: 'vacancies/breadcrumb'
 = render partial: 'vacancies/show'
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,6 +30,7 @@ en:
   jobs:
     heading: 'Find a job in teaching'
     sort_by: 'Sort by:'
+    key_info: 'Key information'
     salary: 'Salary'
     publish_on: 'Date posted'
     expires_on: 'Closing date'


### PR DESCRIPTION
This PR implements (some of) the changes made to try and improve the experience for job seekers on mobile:

- jobseekers' index page: adding the ' _n_ results' and 'refine search' anchor link UI at the top of the results page, and moving the filters to the very bottom
- job show page: apply listing layout changes as previously deployed to testing, except place the map below the about school info (rather than above)

Browser detection is performed using the [Browser gem.](https://github.com/fnando/browser) Different views are served to mobile devices using [Rails' ActionPack Variants.](https://richonrails.com/articles/action-pack-variants-in-rails-4-1)

## before - list view
<img src="https://user-images.githubusercontent.com/822507/43714277-5b84cda0-9974-11e8-8519-87a928b2ba92.png" width=150/>

## after - list view
<img src="https://user-images.githubusercontent.com/822507/43714294-67689df4-9974-11e8-8c6a-8c45a4936ae6.png" width=150/>

## before - job view
<img src="https://user-images.githubusercontent.com/822507/43714283-600e0b16-9974-11e8-93d4-e7ab004281a0.png" width=150/>

## after - job view
<img src="https://user-images.githubusercontent.com/822507/43714298-6c348078-9974-11e8-951a-d20ce8cbc7fa.png" width=150/>
