### PR TITLE
(feature): Location hint text doesn’t describe what it supports

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -151,7 +151,7 @@ en:
     filters:
       title: 'Search job listings'
       location: 'Location'
-      location_hint: 'Town, postcode or region'
+      location_hint: 'Postcode'
       keyword: 'Keyword'
       keyword_hint: 'Role or subject, for example'
       minimum_salary: 'Minimum salary'


### PR DESCRIPTION
* As searching by Region and Town (while possible) has introduced some usability concerns. When used with the radius, Google works from a central pin drop outwards by that distance. A user who searches ‘Cambridge’ with the mandatory radius may easily miss job listings that appear throughout the rest of the Cambridge area, as they are not perfect circles. This less of a problem with small towns but is a problem for regions and large towns like London that span greater areas.
* Until we have more time to approach this functionality so that it can work out the total geo area we will remove any user expectation of it working. If they still use something other than postcode (2/5) of our recent searches didn't, then this functionality may still be able to help them.

In this example where the stars are job listings, only 1 school would appear in first search (red: radius 1 mile) and 3 would appear in the second search (orange: 5 mile). The last listing, outside of orange would never be discovered.
![congressdistricts2011](https://user-images.githubusercontent.com/912473/43716233-53687e94-997b-11e8-8b4a-29567326ebe8.jpg)


Before:
<img width="305" alt="screen shot 2018-08-06 at 13 13 05" src="https://user-images.githubusercontent.com/912473/43716051-87784d14-997a-11e8-9f65-4ac0d54d1806.png">


After:
<img width="303" alt="screen shot 2018-08-06 at 13 12 14" src="https://user-images.githubusercontent.com/912473/43716049-861b8382-997a-11e8-8cf9-40cee2fd9821.png">
