### PR TITLE
(feature) Redirect signed in users from the identifications page

### DIFF
--- a/app/controllers/hiring_staff/identifications_controller.rb
+++ b/app/controllers/hiring_staff/identifications_controller.rb
@@ -5,6 +5,8 @@ class HiringStaff::IdentificationsController < HiringStaff::BaseController
   skip_before_action :check_session, only: %i[new create]
   skip_before_action :verify_authenticity_token, only: [:create]
 
+  before_action :redirect_signed_in_users
+
   def new; end
 
   def create
@@ -17,5 +19,9 @@ class HiringStaff::IdentificationsController < HiringStaff::BaseController
 
   def choice
     params.require('identifications').permit('name')['name']
+  end
+
+  def redirect_signed_in_users
+    return redirect_to school_path if session.key?(:urn)
   end
 end

--- a/spec/features/hiring_staff_can_sign_in_with_dfe_spec.rb
+++ b/spec/features/hiring_staff_can_sign_in_with_dfe_spec.rb
@@ -51,6 +51,12 @@ RSpec.feature 'Hiring staff signing-in with DfE Sign In' do
       within('#proposition-links') { expect(page).to have_content(I18n.t('nav.school_page_link')) }
     end
 
+    scenario 'it redirects the sign in page to the school page' do
+      visit new_identifications_path
+      expect(page).to have_content("Jobs at #{school.name}")
+      expect(current_path).to eql(school_path)
+    end
+
     scenario 'adds entries in the audit log' do
       activity = PublicActivity::Activity.last
       expect(activity.key).to eq('dfe-sign-in.authorisation.success')


### PR DESCRIPTION
It's possible for already signed in users to come back to our service via a bookmark or direct link. If they are signed in we should redirect them to the schools page instead of showing them the sign in page again needlessly.