### PR TITLE
(feature) Allow hiring staff to select from multiple schools

### DIFF
--- a/app/controllers/hiring_staff/schools_controller.rb
+++ b/app/controllers/hiring_staff/schools_controller.rb
@@ -30,6 +30,6 @@ class HiringStaff::SchoolsController < HiringStaff::BaseController
   private
 
   def session_has_multiple_schools?
-    session.key?(:tva_permissions) && session[:tva_permissions].count > 1
+    session.key?(:multiple_schools) && session[:multiple_schools] == true
   end
 end

--- a/app/controllers/hiring_staff/schools_controller.rb
+++ b/app/controllers/hiring_staff/schools_controller.rb
@@ -1,6 +1,6 @@
 class HiringStaff::SchoolsController < HiringStaff::BaseController
   def show
-    @multiple_schools = session.key?(:tva_permissions)
+    @multiple_schools = session_has_multiple_schools?
     @school = SchoolPresenter.new(current_school)
     @vacancies = @school.vacancies.active
   end
@@ -25,5 +25,11 @@ class HiringStaff::SchoolsController < HiringStaff::BaseController
     else
       redirect_to edit_school_path(description: school.description)
     end
+  end
+
+  private
+
+  def session_has_multiple_schools?
+    session.key?(:tva_permissions) && session[:tva_permissions].count > 1
   end
 end

--- a/app/controllers/hiring_staff/sign_in/dfe/sessions_controller.rb
+++ b/app/controllers/hiring_staff/sign_in/dfe/sessions_controller.rb
@@ -24,7 +24,7 @@ class HiringStaff::SignIn::Dfe::SessionsController < HiringStaff::BaseController
   private
 
   def update_session(school_urn, permissions)
-    session.update(session_id: oid, urn: school_urn, tva_permissions: permissions.all_permissions)
+    session.update(session_id: oid, urn: school_urn, multiple_schools: permissions.many?)
     Auditor::Audit.new(current_school, 'dfe-sign-in.authorisation.success', current_session_id).log
   end
 

--- a/app/controllers/hiring_staff/sign_in/dfe/sessions_controller.rb
+++ b/app/controllers/hiring_staff/sign_in/dfe/sessions_controller.rb
@@ -14,7 +14,7 @@ class HiringStaff::SignIn::Dfe::SessionsController < HiringStaff::BaseController
 
     if permissions.all_permissions.any?
       school_urn = selected_school_urn || permissions.school_urn
-      update_session(school_urn)
+      update_session(school_urn, permissions.all_permissions)
       redirect_to school_path
     else
       Auditor::Audit.new(nil, 'dfe-sign-in.authorisation.failure', current_session_id).log_without_association
@@ -24,8 +24,8 @@ class HiringStaff::SignIn::Dfe::SessionsController < HiringStaff::BaseController
 
   private
 
-  def update_session(school_urn)
-    session.update(session_id: oid, urn: school_urn)
+  def update_session(school_urn, all_permissions)
+    session.update(session_id: oid, urn: school_urn, tva_permissions: all_permissions)
     Auditor::Audit.new(current_school, 'dfe-sign-in.authorisation.success', current_session_id).log
   end
 

--- a/app/controllers/hiring_staff/sign_in/dfe/sessions_controller.rb
+++ b/app/controllers/hiring_staff/sign_in/dfe/sessions_controller.rb
@@ -12,8 +12,9 @@ class HiringStaff::SignIn::Dfe::SessionsController < HiringStaff::BaseController
     permissions.authorise(identifier)
     Auditor::Audit.new(nil, 'dfe-sign-in.authentication.success', current_session_id).log_without_association
 
-    if permissions.school_urn.present?
-      update_session(permissions.school_urn)
+    if permissions.all_permissions.any?
+      school_urn = selected_school_urn || permissions.school_urn
+      update_session(school_urn)
       redirect_to school_path
     else
       Auditor::Audit.new(nil, 'dfe-sign-in.authorisation.failure', current_session_id).log_without_association
@@ -38,5 +39,9 @@ class HiringStaff::SignIn::Dfe::SessionsController < HiringStaff::BaseController
 
   def identifier
     auth_hash['info']['email']
+  end
+
+  def selected_school_urn
+    auth_hash.dig('extra', 'raw_info', 'organisation', 'urn')
   end
 end

--- a/app/services/teacher_vacancy_authorisation.rb
+++ b/app/services/teacher_vacancy_authorisation.rb
@@ -34,7 +34,6 @@ module TeacherVacancyAuthorisation
     end
 
     def authorised?
-      return user_permissions.any? if @school_urn.blank?
       user_permissions_for_school.any?
     end
 

--- a/app/services/teacher_vacancy_authorisation.rb
+++ b/app/services/teacher_vacancy_authorisation.rb
@@ -11,9 +11,10 @@ module TeacherVacancyAuthorisation
                    'Content-Type' => 'application/json' }
     end
 
-    def authorise(user_token)
+    def authorise(user_token, school_urn = nil)
       request = Net::HTTP::Get.new("/users/#{user_token}", headers)
       @response = http.request(request)
+      @school_urn = school_urn
 
       user_permissions
     end
@@ -23,11 +24,18 @@ module TeacherVacancyAuthorisation
     end
 
     def school_urn
-      user_permissions.any? ? user_permissions.first['school_urn'] : nil
+      return nil unless user_permissions.any?
+      return user_permissions_for_school.first['school_urn'] if @school_urn.present?
+      user_permissions.first['school_urn']
     end
 
     def many?
       user_permissions && user_permissions.count > 1
+    end
+
+    def authorised?
+      return user_permissions.any? if @school_urn.blank?
+      user_permissions_for_school.any?
     end
 
     private
@@ -38,6 +46,10 @@ module TeacherVacancyAuthorisation
 
     def user_permissions
       @user_permissions ||= parsed_response.present? ? parsed_response['user']['permissions'] : []
+    end
+
+    def user_permissions_for_school
+      user_permissions.select { |permission| permission['school_urn'] == @school_urn }
     end
   end
 end

--- a/app/views/hiring_staff/schools/show.html.haml
+++ b/app/views/hiring_staff/schools/show.html.haml
@@ -5,7 +5,7 @@
     %h1.heading-large
       = t('schools.jobs.index', school: @school.name)
     - if @multiple_schools
-      = link_to t('sign_in.organisation.change'), new_azure_path
+      = link_to t('sign_in.organisation.change'), auth_dfe_callback_path
       %br
       %br
 

--- a/spec/features/hiring_staff_can_sign_in_with_azure_spec.rb
+++ b/spec/features/hiring_staff_can_sign_in_with_azure_spec.rb
@@ -129,29 +129,6 @@ RSpec.feature 'Hiring staff signing-in with Azure' do
       expect(activities[2].key).to eq('azure.authorisation.success')
       expect(activities[2].trackable.urn).to eq(other_school.urn)
     end
-
-    context 'allows the user to switch between organisation' do
-      before(:each) do
-        click_on 'Change organisation'
-
-        expect(page).to have_content('Select your organisation')
-        choose school.name
-        click_on 'Continue'
-      end
-
-      scenario 'allows the user to switch between orgnisations and logs audit events' do
-        expect(page).to have_content("Jobs at #{school.name}")
-      end
-
-      scenario 'adds entries to the audit log' do
-        activities = PublicActivity::Activity.all
-
-        expect(activities[3].key).to eq('azure.authentication.success')
-        expect(activities[4].key).to eq('azure.authorisation.select_school')
-        expect(activities[5].key).to eq('azure.authorisation.success')
-        expect(activities[5].trackable.urn).to eq(school.urn)
-      end
-    end
   end
 
   context 'with valid credentials that do not match a school' do

--- a/spec/features/hiring_staff_can_sign_in_with_dfe_spec.rb
+++ b/spec/features/hiring_staff_can_sign_in_with_dfe_spec.rb
@@ -175,20 +175,17 @@ RSpec.feature 'Hiring staff signing-in with DfE Sign In' do
       click_on(I18n.t('sign_in.link'))
     end
 
-    scenario 'it signs in the user successfully for the selected school' do
-      expect(page).to have_content("Jobs at #{school.name}")
-      within('#proposition-links') { expect(page).to have_content(I18n.t('nav.sign_out')) }
-      within('#proposition-links') { expect(page).to have_content(I18n.t('nav.school_page_link')) }
+    scenario 'it does not sign-in the user' do
+      expect(page).to have_content(I18n.t('static_pages.not_authorised.title'))
+      within('#proposition-links') { expect(page).not_to have_content(I18n.t('nav.school_page_link')) }
     end
 
     scenario 'adds entries in the audit log' do
-      activity = PublicActivity::Activity.last
-      expect(activity.key).to eq('dfe-sign-in.authorisation.success')
-      expect(activity.trackable.urn).to eq(school.urn)
+      authentication = PublicActivity::Activity.first
+      expect(authentication.key).to eq('dfe-sign-in.authentication.success')
 
       authorisation = PublicActivity::Activity.last
-      expect(authorisation.key).to eq('dfe-sign-in.authorisation.success')
-      expect(authorisation.trackable.urn).to eq(school.urn)
+      expect(authorisation.key).to eq('dfe-sign-in.authorisation.failure')
     end
   end
 

--- a/spec/features/hiring_staff_can_sign_in_with_dfe_spec.rb
+++ b/spec/features/hiring_staff_can_sign_in_with_dfe_spec.rb
@@ -13,6 +13,7 @@ RSpec.feature 'Hiring staff signing-in with DfE Sign In' do
   end
 
   let!(:school) { create(:school, urn: '110627') }
+  let!(:other_school) { create(:school, urn: '101010') }
 
   context 'with valid credentials that do match a school' do
     before(:each) do
@@ -28,27 +29,34 @@ RSpec.feature 'Hiring staff signing-in with DfE Sign In' do
           }
         }
       )
-
-      mock_response = double(code: '200', body: {
-        user:
-        {
-          permissions:
-          [
-            {
-              user_token: 'an-email@example.com',
-              school_urn: '110627'
-            }
-          ]
-        }
-      }.to_json)
-
       expect(TeacherVacancyAuthorisation::Permissions).to receive(:new)
-        .and_return(AuthHelpers::MockPermissions.new(mock_response))
+        .and_return(mock_permissions)
       visit root_path
       click_on(I18n.t('nav.sign_in'))
       choose(HiringStaff::IdentificationsController::DFE_SIGN_IN_OPTIONS.first.to_radio.last)
       click_on(I18n.t('sign_in.link'))
     end
+
+    let(:mock_response) do
+      double(code: '200', body: {
+        user:
+          {
+            permissions:
+              [
+                {
+                  user_token: 'an-email@example.com',
+                  school_urn: '110627'
+                },
+                {
+                  user_token: 'an-email@example.com',
+                  school_urn: '101010'
+                }
+              ]
+          }
+      }.to_json)
+    end
+
+    let(:mock_permissions) { AuthHelpers::MockPermissions.new(mock_response) }
 
     scenario 'it signs in the user successfully' do
       expect(page).to have_content("Jobs at #{school.name}")
@@ -70,6 +78,31 @@ RSpec.feature 'Hiring staff signing-in with DfE Sign In' do
       authorisation = PublicActivity::Activity.last
       expect(authorisation.key).to eq('dfe-sign-in.authorisation.success')
       expect(authorisation.trackable.urn).to eq(school.urn)
+    end
+
+    context 'the user can switch between organisations' do
+      scenario 'allows the user to switch between organisations' do
+        expect(page).to have_content("Jobs at #{school.name}")
+
+        # Mock switching organisations on DfE Sign In
+        OmniAuth.config.mock_auth[:dfe] = OmniAuth::AuthHash.new(
+          provider: 'dfe',
+          uid: 'an-unknown-oid',
+          info: {
+            email: 'an-email@example.com',
+          },
+          extra: {
+            raw_info: {
+              organisation: { urn: '101010' }
+            }
+          }
+        )
+        expect(TeacherVacancyAuthorisation::Permissions).to receive(:new)
+          .and_return(mock_permissions)
+        click_on 'Change organisation'
+
+        expect(page).to have_content("Jobs at #{other_school.name}")
+      end
     end
   end
 

--- a/spec/features/hiring_staff_can_sign_in_with_dfe_spec.rb
+++ b/spec/features/hiring_staff_can_sign_in_with_dfe_spec.rb
@@ -113,6 +113,11 @@ RSpec.feature 'Hiring staff signing-in with DfE Sign In' do
         uid: 'an-unknown-oid',
         info: {
           email: 'another_email@example.com',
+        },
+        extra: {
+          raw_info: {
+            organisation: { urn: '110627' }
+          }
         }
       )
       mock_response = double(code: '200', body: { user: { permissions: [] } }.to_json)
@@ -225,20 +230,17 @@ RSpec.feature 'Hiring staff signing-in with DfE Sign In' do
       click_on(I18n.t('sign_in.link'))
     end
 
-    scenario 'it signs in the user successfully for school they have permission for' do
-      expect(page).to have_content("Jobs at #{school.name}")
-      within('#proposition-links') { expect(page).to have_content(I18n.t('nav.sign_out')) }
-      within('#proposition-links') { expect(page).to have_content(I18n.t('nav.school_page_link')) }
+    scenario 'it does not sign-in the user' do
+      expect(page).to have_content(I18n.t('static_pages.not_authorised.title'))
+      within('#proposition-links') { expect(page).not_to have_content(I18n.t('nav.school_page_link')) }
     end
 
     scenario 'adds entries in the audit log' do
-      activity = PublicActivity::Activity.last
-      expect(activity.key).to eq('dfe-sign-in.authorisation.success')
-      expect(activity.trackable.urn).to eq(school.urn)
+      authentication = PublicActivity::Activity.first
+      expect(authentication.key).to eq('dfe-sign-in.authentication.success')
 
       authorisation = PublicActivity::Activity.last
-      expect(authorisation.key).to eq('dfe-sign-in.authorisation.success')
-      expect(authorisation.trackable.urn).to eq(school.urn)
+      expect(authorisation.key).to eq('dfe-sign-in.authorisation.failure')
     end
   end
 end

--- a/spec/features/hiring_staff_can_sign_in_with_dfe_spec.rb
+++ b/spec/features/hiring_staff_can_sign_in_with_dfe_spec.rb
@@ -21,6 +21,11 @@ RSpec.feature 'Hiring staff signing-in with DfE Sign In' do
         uid: 'an-unknown-oid',
         info: {
           email: 'an-email@example.com',
+        },
+        extra: {
+          raw_info: {
+            organisation: { urn: '110627' }
+          }
         }
       )
 
@@ -68,7 +73,7 @@ RSpec.feature 'Hiring staff signing-in with DfE Sign In' do
     end
   end
 
-  context 'with valid credentials that do not match a school' do
+  context 'with valid credentials but no permission' do
     before(:each) do
       OmniAuth.config.mock_auth[:dfe] = OmniAuth::AuthHash.new(
         provider: 'dfe',
@@ -98,6 +103,112 @@ RSpec.feature 'Hiring staff signing-in with DfE Sign In' do
 
       authorisation = PublicActivity::Activity.last
       expect(authorisation.key).to eq('dfe-sign-in.authorisation.failure')
+    end
+  end
+
+  context 'with valid credentials but the existing permissions don’t match the selected school' do
+    before(:each) do
+      OmniAuth.config.mock_auth[:dfe] = OmniAuth::AuthHash.new(
+        provider: 'dfe',
+        uid: 'an-unknown-oid',
+        info: {
+          email: 'an-email@example.com',
+        },
+        extra: {
+          raw_info: {
+            organisation: { urn: '110627' }
+          }
+        }
+      )
+
+      mock_response = double(code: '200', body: {
+        user:
+          {
+            permissions:
+              [
+                {
+                  user_token: 'an-email@example.com',
+                  school_urn: '109871'
+                }
+              ]
+          }
+      }.to_json)
+
+      expect(TeacherVacancyAuthorisation::Permissions).to receive(:new)
+        .and_return(AuthHelpers::MockPermissions.new(mock_response))
+      visit root_path
+      click_on(I18n.t('nav.sign_in'))
+      choose(HiringStaff::IdentificationsController::DFE_SIGN_IN_OPTIONS.first.to_radio.last)
+      click_on(I18n.t('sign_in.link'))
+    end
+
+    scenario 'it signs in the user successfully for the selected school' do
+      expect(page).to have_content("Jobs at #{school.name}")
+      within('#proposition-links') { expect(page).to have_content(I18n.t('nav.sign_out')) }
+      within('#proposition-links') { expect(page).to have_content(I18n.t('nav.school_page_link')) }
+    end
+
+    scenario 'adds entries in the audit log' do
+      activity = PublicActivity::Activity.last
+      expect(activity.key).to eq('dfe-sign-in.authorisation.success')
+      expect(activity.trackable.urn).to eq(school.urn)
+
+      authorisation = PublicActivity::Activity.last
+      expect(authorisation.key).to eq('dfe-sign-in.authorisation.success')
+      expect(authorisation.trackable.urn).to eq(school.urn)
+    end
+  end
+
+  context 'with valid credentials and no organisation in DfE Sign In but existing permissions' do
+    before(:each) do
+      OmniAuth.config.mock_auth[:dfe] = OmniAuth::AuthHash.new(
+        provider: 'dfe',
+        uid: 'an-unknown-oid',
+        info: {
+          email: 'an-email@example.com',
+        },
+        extra: {
+          raw_info: {
+            organisation: {}
+          }
+        }
+      )
+
+      mock_response = double(code: '200', body: {
+        user:
+          {
+            permissions:
+              [
+                {
+                  user_token: 'an-email@example.com',
+                  school_urn: '110627'
+                }
+              ]
+          }
+      }.to_json)
+
+      expect(TeacherVacancyAuthorisation::Permissions).to receive(:new)
+        .and_return(AuthHelpers::MockPermissions.new(mock_response))
+      visit root_path
+      click_on(I18n.t('nav.sign_in'))
+      choose(HiringStaff::IdentificationsController::DFE_SIGN_IN_OPTIONS.first.to_radio.last)
+      click_on(I18n.t('sign_in.link'))
+    end
+
+    scenario 'it signs in the user successfully for school they have permission for' do
+      expect(page).to have_content("Jobs at #{school.name}")
+      within('#proposition-links') { expect(page).to have_content(I18n.t('nav.sign_out')) }
+      within('#proposition-links') { expect(page).to have_content(I18n.t('nav.school_page_link')) }
+    end
+
+    scenario 'adds entries in the audit log' do
+      activity = PublicActivity::Activity.last
+      expect(activity.key).to eq('dfe-sign-in.authorisation.success')
+      expect(activity.trackable.urn).to eq(school.urn)
+
+      authorisation = PublicActivity::Activity.last
+      expect(authorisation.key).to eq('dfe-sign-in.authorisation.success')
+      expect(authorisation.trackable.urn).to eq(school.urn)
     end
   end
 end

--- a/spec/features/hiring_staff_can_visit_the_public_listings_spec.rb
+++ b/spec/features/hiring_staff_can_visit_the_public_listings_spec.rb
@@ -58,6 +58,11 @@ RSpec.feature 'School viewing public listings' do
         uid: 'a-valid-oid',
         info: {
           email: 'an-email@example.com',
+        },
+        extra: {
+          raw_info: {
+            organisation: { urn: '110627' }
+          }
         }
       )
 

--- a/spec/services/teacher_vacancy_authorisation_spec.rb
+++ b/spec/services/teacher_vacancy_authorisation_spec.rb
@@ -55,6 +55,17 @@ RSpec.describe 'TeacherVacancyAuthorisation::Permissions' do
       service.authorise('sample-token')
       expect(service.school_urn).to eq('12345')
     end
+
+    it 'returns the requested school_urn if given' do
+      response = { user: { permissions: [{ school_urn: '12345' }, { school_urn: '77777' }] } }.to_json
+      mock_http = double(:http, request: double(:reponse, code: '200', body: response))
+      expect(mock_http).to receive(:use_ssl=).with(true)
+      expect(Net::HTTP::Get).to receive(:new).with('/users/sample-token', headers).and_return(request)
+      expect(Net::HTTP).to receive(:new).with('localhost', 1357).and_return(mock_http)
+
+      service.authorise('sample-token', '77777')
+      expect(service.school_urn).to eq('77777')
+    end
   end
 
   describe '#many?' do
@@ -80,6 +91,45 @@ RSpec.describe 'TeacherVacancyAuthorisation::Permissions' do
 
       service.authorise('sample-token')
       expect(service.many?).to eq(false)
+    end
+  end
+
+  describe '#authorised?' do
+    subject(:authorised?) { service.authorised? }
+    let(:response) { { user: { permissions: permissions } }.to_json }
+    let(:mock_http) { double(:http, request: double(:reponse, code: '200', body: response)) }
+
+    before do
+      allow(Net::HTTP::Get).to receive(:new).with('/users/sample-token', headers).and_return(request)
+      allow(Net::HTTP).to receive(:new).with('localhost', 1357).and_return(mock_http)
+      allow(mock_http).to receive(:use_ssl=).with(true)
+
+      service.authorise('sample-token', school_urn)
+    end
+
+    context 'user has some permissions' do
+      let(:permissions) { [{ school_urn: '12345' }] }
+
+      context 'no school urn is given' do
+        let(:school_urn) { nil }
+        it { is_expected.to be true }
+      end
+
+      context 'school urn is given and matches a permission' do
+        let(:school_urn) { '12345' }
+        it { is_expected.to be true }
+      end
+
+      context 'school urn is given and doesn’t match permissions' do
+        let(:school_urn) { '99999' }
+        it { is_expected.to be false }
+      end
+    end
+
+    context 'user has no permissions' do
+      let(:permissions) { [] }
+      let(:school_urn) { nil }
+      it { is_expected.to be false }
     end
   end
 end

--- a/spec/services/teacher_vacancy_authorisation_spec.rb
+++ b/spec/services/teacher_vacancy_authorisation_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe 'TeacherVacancyAuthorisation::Permissions' do
 
       context 'no school urn is given' do
         let(:school_urn) { nil }
-        it { is_expected.to be true }
+        it { is_expected.to be false }
       end
 
       context 'school urn is given and matches a permission' do

--- a/spec/support/auth_helpers.rb
+++ b/spec/support/auth_helpers.rb
@@ -4,7 +4,9 @@ module AuthHelpers
       @response = response
     end
 
-    def authorise(identifier); end
+    def authorise(_identifier, school_urn = nil)
+      @school_urn = school_urn
+    end
   end
 
   def stub_global_auth(return_value: true)


### PR DESCRIPTION
# User need

As a DfE sign user who is invited to use Teaching Jobs I need to be able to manage all the schools (organisations) I represent, so that I can publish job listings for my school/s 

# Description

This PR allows for a few different sign in cases:

- A user with multiple DfE Sign In organisations and permission in TVA selects the school they want to manage and we sign them in to that school
- A user with one DfE Sign In organisation and permission in TVA signs in to the school they are associated with from DfE Sign In
- A user with no DfE Sign In organisations and permission in TA signs in the the school they are associated with in TVA 