### PR TITLE
Feature/342 changes to the sub navigation links

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -59,6 +59,7 @@
 @import 'components/flashes';
 @import 'components/links';
 @import 'components/share-url';
+@import 'components/navigation';
 @import 'ie';
 
 main#content {

--- a/app/assets/stylesheets/components/navigation.scss
+++ b/app/assets/stylesheets/components/navigation.scss
@@ -1,0 +1,58 @@
+.app-navigation {
+  $navigation-height: 53px;
+  background-color: $grey-4;
+  font-weight: bold;
+  margin-bottom: 2em;
+
+  @include clearfix;
+
+  &__list {
+    margin: 0;
+    padding: 0 0.5em;
+    list-style: none;
+    font-size: 0.85em;
+
+    @include media(tablet) {
+      float: right;
+      font-size: 1em;
+    }
+
+    & > li {
+      box-sizing: border-box;
+      height: $navigation-height;
+      float: left;
+      line-height: $navigation-height;
+      -moz-box-sizing: border-box;
+      -webkit-box-sizing: border-box;
+
+      &:hover {
+        border-bottom: 4px solid $light-blue;
+      }
+
+      &.active {
+        border-bottom: 4px solid $govuk-blue !important;
+
+        a:hover {
+          color: $link-colour;
+        }
+      }
+
+      a {
+        display: block;
+        padding: 0 0.5em;
+        color: $link-colour;
+        text-decoration: none;
+
+        &:visited {
+          color: $link-colour;
+        }
+
+        &:hover,
+        &:focus {
+          color: $link-hover-colour;
+          background-color: inherit;
+        }
+      }
+    }
+  }
+}

--- a/app/views/hiring_staff/identifications/new.html.haml
+++ b/app/views/hiring_staff/identifications/new.html.haml
@@ -4,7 +4,7 @@
 .grid-row
 
   .column-two-thirds
-    %h1.heading-large= t('sign_in.title')
+    %h1.heading-large.mt0= t('sign_in.title')
 
     %p.lede= t('sign_in.intro')
 

--- a/app/views/hiring_staff/schools/show.html.haml
+++ b/app/views/hiring_staff/schools/show.html.haml
@@ -2,7 +2,7 @@
 
 .school.grid-row
   .column-full
-    %h1.heading-large
+    %h1.heading-large.mt0
       = t('schools.jobs.index', school: @school.name)
     - if @multiple_schools
       = link_to t('sign_in.organisation.change'), new_azure_path

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -22,12 +22,15 @@
 
 - content_for :content do
   %main#content{ role: 'main', tabindex: -1 }
+
     .phase-banner
       %p
         %strong.phase-tag
           BETA
         %span
           This is a new service - #{link_to 'your feedback', 'https://www.surveymonkey.co.uk/r/FV5YF9Q'} will help us to improve it.
+
+    = render partial: 'shared/navigation'
 
     - flash.each do |name, msg|
       %div{class: "flash #{name}"}

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -16,18 +16,9 @@
 - content_for :proposition_header do
   .header-proposition
     .content
-      %a.js-header-toggle.menu{ href: '#proposition-links' }
-        = t('app.menu')
-
       %nav#proposition-menu
         %a#proposition-name{ href: '/' }
           = t('app.title')
-        %ul#proposition-links
-          - if authenticated?
-            %li= link_to t('nav.school_page_link'), school_path, class: active_link_class(school_path)
-            %li= link_to t('nav.sign_out'), sessions_path, method: :delete
-          - else
-            %li= link_to t('nav.sign_in'), new_identifications_path
 
 - content_for :content do
   %main#content{ role: 'main', tabindex: -1 }

--- a/app/views/shared/_navigation.haml
+++ b/app/views/shared/_navigation.haml
@@ -1,0 +1,8 @@
+%nav.app-navigation.govuk-clearfix
+  %ul.app-navigation__list
+    - if authenticated?
+      %li{class: active_link_class(school_path)}= link_to t('nav.school_page_link'), school_path, class: active_link_class(school_path)
+      %li{class: active_link_class(root_path)}= link_to t('nav.jobseekers_index_link'), root_path, class: active_link_class(root_path)
+      %li{class: active_link_class(sessions_path)}= link_to t('nav.sign_out'), sessions_path, method: :delete
+    - else
+      %li{class: active_link_class(new_identifications_path)}= link_to t('nav.sign_in'), new_identifications_path

--- a/app/views/vacancies/index.html.haml
+++ b/app/views/vacancies/index.html.haml
@@ -1,7 +1,5 @@
 - content_for :page_title_prefix, t('jobs.heading')
 
-= render partial: 'shared/beta_banner'
-
 %h1.heading-xlarge
   = t('jobs.heading')
 .grid-row
@@ -28,3 +26,5 @@
           %p= sentence
 
 = paginate @vacancies
+
+= render partial: 'shared/beta_banner'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,9 +12,10 @@ en:
     title: 'Teaching Jobs'
     menu: 'Menu'
   nav:
-    sign_in: 'List a teaching job at your school'
+    sign_in: 'Sign in to list a job'
     sign_out: 'Sign out'
     school_page_link: 'My jobs'
+    jobseekers_index_link: 'All jobs'
   sign_in:
     title: 'Sign in to Teaching Jobs'
     intro: 'While the service is in development it lists teaching jobs in select areas, currently Cambridgeshire, the North East and Milton Keynes. In order for you to sign into the service we need to know which area your school is in. '

--- a/spec/features/hiring_staff_can_sign_in_with_azure_spec.rb
+++ b/spec/features/hiring_staff_can_sign_in_with_azure_spec.rb
@@ -50,9 +50,9 @@ RSpec.feature 'Hiring staff signing-in with Azure' do
 
     scenario 'signs-in the user successfully' do
       expect(page).to have_content("Jobs at #{school.name}")
-      within('#proposition-links') { expect(page).to have_content(I18n.t('nav.sign_out')) }
-      within('#proposition-links') { expect(page).to have_content(I18n.t('nav.school_page_link')) }
-      within('#proposition-links') { expect(page).to have_selector('a.active', text: 'My jobs') }
+      within('.app-navigation') { expect(page).to have_content(I18n.t('nav.sign_out')) }
+      within('.app-navigation') { expect(page).to have_content(I18n.t('nav.school_page_link')) }
+      within('.app-navigation') { expect(page).to have_selector('a.active', text: 'My jobs') }
     end
 
     scenario 'adds entries in the audit log' do
@@ -116,9 +116,9 @@ RSpec.feature 'Hiring staff signing-in with Azure' do
 
     scenario 'offer the ability to select which school to sign-in with' do
       expect(page).to have_content("Jobs at #{other_school.name}")
-      within('#proposition-links') { expect(page).to have_content(I18n.t('nav.sign_out')) }
-      within('#proposition-links') { expect(page).to have_content(I18n.t('nav.school_page_link')) }
-      within('#proposition-links') { expect(page).to have_selector('a.active', text: 'My jobs') }
+      within('.app-navigation') { expect(page).to have_content(I18n.t('nav.sign_out')) }
+      within('.app-navigation') { expect(page).to have_content(I18n.t('nav.school_page_link')) }
+      within('.app-navigation') { expect(page).to have_selector('a.active', text: 'My jobs') }
     end
 
     scenario 'adds entries in the audit log' do
@@ -182,7 +182,7 @@ RSpec.feature 'Hiring staff signing-in with Azure' do
 
     scenario 'it does not sign-in the user' do
       expect(page).to have_content(I18n.t('static_pages.not_authorised.title'))
-      within('#proposition-links') { expect(page).not_to have_content(I18n.t('nav.school_page_link')) }
+      within('.app-navigation') { expect(page).not_to have_content(I18n.t('nav.school_page_link')) }
     end
 
     scenario 'adds entries in the audit log' do

--- a/spec/features/hiring_staff_can_sign_in_with_dfe_spec.rb
+++ b/spec/features/hiring_staff_can_sign_in_with_dfe_spec.rb
@@ -47,8 +47,8 @@ RSpec.feature 'Hiring staff signing-in with DfE Sign In' do
 
     scenario 'it signs in the user successfully' do
       expect(page).to have_content("Jobs at #{school.name}")
-      within('#proposition-links') { expect(page).to have_content(I18n.t('nav.sign_out')) }
-      within('#proposition-links') { expect(page).to have_content(I18n.t('nav.school_page_link')) }
+      within('.app-navigation') { expect(page).to have_content(I18n.t('nav.sign_out')) }
+      within('.app-navigation') { expect(page).to have_content(I18n.t('nav.school_page_link')) }
     end
 
     scenario 'it redirects the sign in page to the school page' do
@@ -89,7 +89,7 @@ RSpec.feature 'Hiring staff signing-in with DfE Sign In' do
 
     scenario 'it does not sign-in the user' do
       expect(page).to have_content(I18n.t('static_pages.not_authorised.title'))
-      within('#proposition-links') { expect(page).not_to have_content(I18n.t('nav.school_page_link')) }
+      within('.app-navigation') { expect(page).not_to have_content(I18n.t('nav.school_page_link')) }
     end
 
     scenario 'adds entries in the audit log' do

--- a/spec/features/hiring_staff_can_sign_out_spec.rb
+++ b/spec/features/hiring_staff_can_sign_out_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature 'Hiring staff can sign out' do
 
     click_on(I18n.t('nav.sign_out'))
 
-    within('#proposition-links') { expect(page).to have_content(I18n.t('nav.sign_in')) }
+    within('.app-navigation') { expect(page).to have_content(I18n.t('nav.sign_in')) }
     expect(page).to have_content(I18n.t('messages.access.signed_out'))
   end
 end

--- a/spec/features/hiring_staff_can_visit_the_public_listings_spec.rb
+++ b/spec/features/hiring_staff_can_visit_the_public_listings_spec.rb
@@ -41,7 +41,7 @@ RSpec.feature 'School viewing public listings' do
       click_on(I18n.t('sign_in.link'))
 
       expect(page).to have_content("Jobs at #{school.name}")
-      within('#proposition-links') { expect(page).to have_content(I18n.t('nav.school_page_link')) }
+      within('.app-navigation') { expect(page).to have_content(I18n.t('nav.school_page_link')) }
 
       click_on(I18n.t('app.title'))
       expect(page).to have_content(I18n.t('jobs.heading'))
@@ -80,7 +80,7 @@ RSpec.feature 'School viewing public listings' do
       click_on(I18n.t('sign_in.link'))
 
       expect(page).to have_content("Jobs at #{school.name}")
-      within('#proposition-links') { expect(page).to have_content(I18n.t('nav.school_page_link')) }
+      within('.app-navigation') { expect(page).to have_content(I18n.t('nav.school_page_link')) }
 
       click_on(I18n.t('app.title'))
       expect(page).to have_content(I18n.t('jobs.heading'))


### PR DESCRIPTION
**User need:**
> So that I know where to start the journey of listing a vacancy without getting confused
I want to be taken to the start of the journey instead of having to work it out

As a result of a "how might we?" session, we decided to test out another way of displaying navigation other than the off-the-shelf GOV UK proposition links, which haven't performed well in testing.

With no subnav pattern in the [GOV UK Design System](https://design-system.service.gov.uk/) (DS), I asked on the x-gov Slack, where it was suggested I adopt the subnav patterm from the DS website itself. 

This PR takes a trimmed-down version of that code; just enough to validate the design pattern. The mobile version of the DS nav uses some JS that we don't have as a dependency, and I'd be loathe to add it unless we need it. 

Also noteworthy: as we're using GOV UK Elements, not Frontend, I had to tweak a bunch of class names. 

#### before - unauthorised
![before - unauthorised](https://user-images.githubusercontent.com/822507/43781345-968480a4-9a54-11e8-8be2-6c5f9af1334f.png)

#### after - unauthorised
![after - unauthorised](https://user-images.githubusercontent.com/822507/43781350-99762114-9a54-11e8-91c2-14631ddd94b7.png)

#### before - authorised
![before - authorised](https://user-images.githubusercontent.com/822507/43781353-9c83a2a0-9a54-11e8-9c92-b40f0f2d38d3.png)

#### after - authorised
![after - authorised](https://user-images.githubusercontent.com/822507/43781356-9efe1c04-9a54-11e8-913a-8c1e05f284c0.png)
