### PR TITLE
Revert "(feature) Require school urn from DfE Sign In to log in succe…

### DIFF
--- a/app/services/teacher_vacancy_authorisation.rb
+++ b/app/services/teacher_vacancy_authorisation.rb
@@ -34,6 +34,7 @@ module TeacherVacancyAuthorisation
     end
 
     def authorised?
+      return user_permissions.any? if @school_urn.blank?
       user_permissions_for_school.any?
     end
 

--- a/app/views/hiring_staff/schools/show.html.haml
+++ b/app/views/hiring_staff/schools/show.html.haml
@@ -2,11 +2,11 @@
 
 .school.grid-row
   .column-full
+    - if @multiple_schools
+      .share-url
+        = 'We can see you are responsible for other schools, will be adding support for you to manage them all soon.'
     %h1.heading-large
       = t('schools.jobs.index', school: @school.name)
-    - if @multiple_schools
-      = link_to t('sign_in.organisation.change'), auth_dfe_callback_path
-      %br
       %br
 
 .grid-row

--- a/spec/features/hiring_staff_can_sign_in_with_dfe_spec.rb
+++ b/spec/features/hiring_staff_can_sign_in_with_dfe_spec.rb
@@ -133,11 +133,6 @@ RSpec.feature 'Hiring staff signing-in with DfE Sign In' do
         uid: 'an-unknown-oid',
         info: {
           email: 'another_email@example.com',
-        },
-        extra: {
-          raw_info: {
-            organisation: { urn: '110627' }
-          }
         }
       )
       mock_response = double(code: '200', body: { user: { permissions: [] } }.to_json)
@@ -228,6 +223,20 @@ RSpec.feature 'Hiring staff signing-in with DfE Sign In' do
       click_on(I18n.t('sign_in.link'))
     end
 
-    it_behaves_like 'a failed sign in'
+    scenario 'it signs in the user successfully for school they have permission for' do
+      expect(page).to have_content("Jobs at #{school.name}")
+      within('#proposition-links') { expect(page).to have_content(I18n.t('nav.sign_out')) }
+      within('#proposition-links') { expect(page).to have_content(I18n.t('nav.school_page_link')) }
+    end
+
+    scenario 'adds entries in the audit log' do
+      activity = PublicActivity::Activity.last
+      expect(activity.key).to eq('dfe-sign-in.authorisation.success')
+      expect(activity.trackable.urn).to eq(school.urn)
+
+      authorisation = PublicActivity::Activity.last
+      expect(authorisation.key).to eq('dfe-sign-in.authorisation.success')
+      expect(authorisation.trackable.urn).to eq(school.urn)
+    end
   end
 end

--- a/spec/features/hiring_staff_can_sign_in_with_dfe_spec.rb
+++ b/spec/features/hiring_staff_can_sign_in_with_dfe_spec.rb
@@ -99,31 +99,6 @@ RSpec.feature 'Hiring staff signing-in with DfE Sign In' do
       expect(page).to have_content("Jobs at #{school.name}")
       expect(current_path).to eql(school_path)
     end
-
-    context 'the user can switch between organisations' do
-      scenario 'allows the user to switch between organisations' do
-        expect(page).to have_content("Jobs at #{school.name}")
-
-        # Mock switching organisations on DfE Sign In
-        OmniAuth.config.mock_auth[:dfe] = OmniAuth::AuthHash.new(
-          provider: 'dfe',
-          uid: 'an-unknown-oid',
-          info: {
-            email: 'an-email@example.com',
-          },
-          extra: {
-            raw_info: {
-              organisation: { urn: '101010' }
-            }
-          }
-        )
-        expect(TeacherVacancyAuthorisation::Permissions).to receive(:new)
-          .and_return(mock_permissions)
-        click_on 'Change organisation'
-
-        expect(page).to have_content("Jobs at #{other_school.name}")
-      end
-    end
   end
 
   context 'with valid credentials but no permission' do

--- a/spec/features/hiring_staff_can_visit_the_public_listings_spec.rb
+++ b/spec/features/hiring_staff_can_visit_the_public_listings_spec.rb
@@ -58,11 +58,6 @@ RSpec.feature 'School viewing public listings' do
         uid: 'a-valid-oid',
         info: {
           email: 'an-email@example.com',
-        },
-        extra: {
-          raw_info: {
-            organisation: { urn: '110627' }
-          }
         }
       )
 

--- a/spec/services/teacher_vacancy_authorisation_spec.rb
+++ b/spec/services/teacher_vacancy_authorisation_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe 'TeacherVacancyAuthorisation::Permissions' do
 
       context 'no school urn is given' do
         let(:school_urn) { nil }
-        it { is_expected.to be false }
+        it { is_expected.to be true }
       end
 
       context 'school urn is given and matches a permission' do


### PR DESCRIPTION
…ssfully"

This reverts commit 6d93fab152e2f87210f9d7f3eababa859a1201b9.

* As we have at the last minute found we cannot depend on the organisations being associated as reliably as we first thought we need to have a fall back option after all until a fix can be made.
* This is not ideal because if no org is returned by DSI it will choose the first school_urn from the permissions list we hold. This will work okay for single user schools but not for MATs. We are going to work around this by not inviting any new MATs until a fix is in.
* We were still showing the 'Choose organisation' link which wouldn't have worked so I replaced it with a temporary message explaining that while we can see they have multiple, we're adding support for them to switch soon. To do this I reused the `.share-url` class as it has the styles needed for this message. I chose not to refactor this style for reuse as I plan for this pull request to be reverted in the whole soon.

![screen shot 2018-08-09 at 12 02 00](https://user-images.githubusercontent.com/912473/43895079-0ef09000-9bcc-11e8-87e0-a94678bdd526.png)
