### PR TITLE
[380] Rely on DSI organisations for authentication

### DIFF
--- a/app/services/teacher_vacancy_authorisation.rb
+++ b/app/services/teacher_vacancy_authorisation.rb
@@ -34,7 +34,6 @@ module TeacherVacancyAuthorisation
     end
 
     def authorised?
-      return user_permissions.any? if @school_urn.blank?
       user_permissions_for_school.any?
     end
 

--- a/app/views/hiring_staff/schools/show.html.haml
+++ b/app/views/hiring_staff/schools/show.html.haml
@@ -2,11 +2,11 @@
 
 .school.grid-row
   .column-full
-    - if @multiple_schools
-      .share-url
-        = 'We can see you are responsible for other schools, will be adding support for you to manage them all soon.'
     %h1.heading-large
       = t('schools.jobs.index', school: @school.name)
+    - if @multiple_schools
+      = link_to t('sign_in.organisation.change'), auth_dfe_callback_path
+      %br
       %br
 
 .grid-row

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180810104419) do
+ActiveRecord::Schema.define(version: 2018_08_10_104419) do
 
   # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
-  enable_extension "pgcrypto"
   enable_extension "fuzzystrmatch"
+  enable_extension "pgcrypto"
+  enable_extension "plpgsql"
 
   create_table "activities", force: :cascade do |t|
     t.uuid "trackable_id"

--- a/spec/features/hiring_staff_can_sign_in_with_dfe_spec.rb
+++ b/spec/features/hiring_staff_can_sign_in_with_dfe_spec.rb
@@ -109,6 +109,11 @@ RSpec.feature 'Hiring staff signing-in with DfE Sign In' do
         uid: 'an-unknown-oid',
         info: {
           email: 'another_email@example.com',
+        },
+        extra: {
+          raw_info: {
+            organisation: { urn: '110627' }
+          }
         }
       )
       mock_response = double(code: '200', body: { user: { permissions: [] } }.to_json)
@@ -199,20 +204,6 @@ RSpec.feature 'Hiring staff signing-in with DfE Sign In' do
       click_on(I18n.t('sign_in.link'))
     end
 
-    scenario 'it signs in the user successfully for school they have permission for' do
-      expect(page).to have_content("Jobs at #{school.name}")
-      within('#proposition-links') { expect(page).to have_content(I18n.t('nav.sign_out')) }
-      within('#proposition-links') { expect(page).to have_content(I18n.t('nav.school_page_link')) }
-    end
-
-    scenario 'adds entries in the audit log' do
-      activity = PublicActivity::Activity.last
-      expect(activity.key).to eq('dfe-sign-in.authorisation.success')
-      expect(activity.trackable.urn).to eq(school.urn)
-
-      authorisation = PublicActivity::Activity.last
-      expect(authorisation.key).to eq('dfe-sign-in.authorisation.success')
-      expect(authorisation.trackable.urn).to eq(school.urn)
-    end
+    it_behaves_like 'a failed sign in'
   end
 end

--- a/spec/features/hiring_staff_can_sign_in_with_dfe_spec.rb
+++ b/spec/features/hiring_staff_can_sign_in_with_dfe_spec.rb
@@ -100,6 +100,31 @@ RSpec.feature 'Hiring staff signing-in with DfE Sign In' do
       expect(page).to have_content("Jobs at #{school.name}")
       expect(current_path).to eql(school_path)
     end
+
+    context 'the user can switch between organisations' do
+      scenario 'allows the user to switch between organisations' do
+        expect(page).to have_content("Jobs at #{school.name}")
+
+        # Mock switching organisations on DfE Sign In
+        OmniAuth.config.mock_auth[:dfe] = OmniAuth::AuthHash.new(
+          provider: 'dfe',
+          uid: 'an-unknown-oid',
+          info: {
+            email: 'an-email@example.com',
+          },
+          extra: {
+            raw_info: {
+              organisation: { urn: '101010' }
+            }
+          }
+        )
+        expect(TeacherVacancyAuthorisation::Permissions).to receive(:new)
+          .and_return(mock_permissions)
+        click_on 'Change organisation'
+
+        expect(page).to have_content("Jobs at #{other_school.name}")
+      end
+    end
   end
 
   context 'with valid credentials but no permission' do

--- a/spec/features/hiring_staff_can_visit_the_public_listings_spec.rb
+++ b/spec/features/hiring_staff_can_visit_the_public_listings_spec.rb
@@ -21,6 +21,11 @@ RSpec.feature 'School viewing public listings' do
         uid: 'a-valid-oid',
         info: {
           email: 'an-email@example.com',
+        },
+        extra: {
+          raw_info: {
+            organisation: { urn: '110627' }
+          }
         }
       )
 

--- a/spec/services/teacher_vacancy_authorisation_spec.rb
+++ b/spec/services/teacher_vacancy_authorisation_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe 'TeacherVacancyAuthorisation::Permissions' do
 
       context 'no school urn is given' do
         let(:school_urn) { nil }
-        it { is_expected.to be true }
+        it { is_expected.to be false }
       end
 
       context 'school urn is given and matches a permission' do


### PR DESCRIPTION
This reverts our previous revert. This was done because of a bug in DfE Sign-in that wasn't going to be fixed in time for us to invite more users. The bug was that we couldn't attach organisations to users through the API, they were wiped as soon as the user activated their account.

To get around this issue we decided to add this code and to only support single school users for the time being, as they wouldn't have the need to switch organisations - the feature DSI was currently missing. Now we've tested DSI organisation attachments in production and it's now working as expected, so we can now reliably depend on users having 1 or more DSI organisations.

They can have their organisation removed from within DSI, the user would see a not authorised screen within our service and would need to be added back to the organisation before they can sign-in again.