### PR TITLE
Feature/376 a more obvious link to the search landing page

### DIFF
--- a/app/views/vacancies/_back_link.html.haml
+++ b/app/views/vacancies/_back_link.html.haml
@@ -1,0 +1,3 @@
+.grid-row
+  .column-full
+    = link_to 'Back', root_path, class: 'link-back'

--- a/app/views/vacancies/_breadcrumb.html.haml
+++ b/app/views/vacancies/_breadcrumb.html.haml
@@ -1,8 +1,0 @@
-.grid-row
-  .column-full
-    .breadcrumbs
-      %ol.no-style
-        %li
-          = link_to I18n.t('jobs.heading'), root_path
-        %li{'aria-current' => 'page'}
-          = @vacancy.job_title

--- a/app/views/vacancies/show.html.haml
+++ b/app/views/vacancies/show.html.haml
@@ -1,4 +1,4 @@
-= render partial: 'vacancies/breadcrumb'
+= render partial: 'vacancies/back_link'
 = render partial: 'vacancies/show'
 
 %script.jobref{type: 'application/ld+json'}


### PR DESCRIPTION
Testing revealed that some jobseekers were having difficulty navigating back from a single job view to the list view.

We’ve replaced the breadcrumb (which was only ever one level deep) with a GOV UK ‘back’ link pattern.

**Before**
<img width="1004" alt="before" src="https://user-images.githubusercontent.com/822507/44462004-f1b73680-a60a-11e8-9d1b-75f378974b93.png">

**After**
<img width="995" alt="after" src="https://user-images.githubusercontent.com/822507/44462008-f67bea80-a60a-11e8-9211-47b64e4e38d2.png">
