### PR TITLE
[354] Allow search engines to index public listing pages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -66,6 +66,6 @@ class ApplicationController < ActionController::Base
   end
 
   def set_headers
-    response.set_header('X-Robots-Tag', 'none')
+    response.set_header('X-Robots-Tag', 'noindex, nofollow')
   end
 end

--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -85,4 +85,8 @@ class VacanciesController < ApplicationController
   def searched?
     params[:commit]&.eql?(I18n.t('buttons.apply_filters'))
   end
+
+  def set_headers
+    response.set_header('X-Robots-Tag', 'noarchive')
+  end
 end

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,0 @@
-# See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
-User-agent: *
-Disallow: /

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -93,9 +93,9 @@ RSpec.describe ApplicationController, type: :controller do
   end
 
   describe 'sets headers' do
-    it 'robots are asked not to follow' do
+    it 'robots are asked not to index or to follow' do
       get :check
-      expect(response.headers['X-Robots-Tag']).to eq('none')
+      expect(response.headers['X-Robots-Tag']).to eq('noindex, nofollow')
     end
   end
 end

--- a/spec/controllers/hiring_staff/vacancies_controller_spec.rb
+++ b/spec/controllers/hiring_staff/vacancies_controller_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
-RSpec.describe HiringStaff::SchoolsController, type: :controller do
+RSpec.describe HiringStaff::VacanciesController, type: :controller do
   describe 'sets headers' do
     it 'robots are asked not to index or to follow' do
-      get :show
+      get :new
       expect(response.headers['X-Robots-Tag']).to eq('noindex, nofollow')
     end
   end

--- a/spec/controllers/vacancies_controller_spec.rb
+++ b/spec/controllers/vacancies_controller_spec.rb
@@ -1,6 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe VacanciesController, type: :controller do
+  describe 'sets headers' do
+    it 'robots are asked to index but not to follow' do
+      get :index
+      expect(response.headers['X-Robots-Tag']).to eq('noarchive')
+    end
+  end
+
   describe '#index' do
     context 'when parameters include syntax' do
       it 'passes only safe values to VacancyFilters' do


### PR DESCRIPTION
* Switch from `none` to the equivalant `noindex, nofollow` as it’s more explicit and clear. None might mean, no robots tag. Details here: https://developers.google.com/search/reference/robots_meta_tag
* Continue to stop indexing all pages - including new ones - by default without us having to remember this in future
* Allow search engines to index pages but not to follow links on our home page and any public listing
* Remove robots.txt to allow the headers to be reliably respected per the advice of GDS: https://www.gov.uk/service-manual/technology/get-a-domain-name#telling-search-engines-not-to-index-pages

Now:

```
HTTP/1.1 200 OK
X-Frame-Options: SAMEORIGIN
X-XSS-Protection: 1; mode=block
X-Content-Type-Options: nosniff
X-Download-Options: noopen
X-Permitted-Cross-Domain-Policies: none
Referrer-Policy: strict-origin-when-cross-origin
X-Robots-Tag: noarchive, nofollow
Content-Type: text/html; charset=utf-8
ETag: W/"6a666fe6c90cefc9d81bddd8314e54d6"
Cache-Control: max-age=0, private, must-revalidate
Set-Cookie: _teachingjobs_session=f15f342fe672335b0229e23a368f52ab; path=/; expires=Wed, 22 Aug 2018 13:35:45 -0000; HttpOnly
X-Request-Id: 7870d19d-a305-4f12-9879-0b2ad64bbd42
X-Runtime: 1.303874
Transfer-Encoding: chunked
```