### PR TITLE
(chore) ‘apply filters’ becomes ‘(refine) search’

### DIFF
--- a/app/presenters/vacancies_presenter.rb
+++ b/app/presenters/vacancies_presenter.rb
@@ -21,6 +21,14 @@ class VacanciesPresenter < BasePresenter
     end
   end
 
+  def apply_filters_button_text
+    if @searched == true
+      I18n.t('buttons.apply_filters_if_criteria')
+    else
+      I18n.t('buttons.apply_filters')
+    end
+  end
+
   private
 
   def total_count

--- a/app/views/vacancies/_filters.html.haml
+++ b/app/views/vacancies/_filters.html.haml
@@ -28,4 +28,4 @@
     = hidden_field_tag :sort_column, sort_column
     = hidden_field_tag :sort_order, sort_order
 
-    = submit_tag t('buttons.apply_filters'), class: 'button'
+    = submit_tag @vacancies.apply_filters_button_text, class: 'button'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -215,7 +215,8 @@ en:
     please_accept: 'Please accept the terms and conditions'
     label: 'I agree to all of the Terms and Conditions of the Teaching Jobs service.'
   buttons:
-    apply_filters: 'Apply filters'
+    apply_filters: 'Search'
+    apply_filters_if_criteria: 'Refine search'
     save_and_continue: 'Save and continue'
     accept_and_continue: 'Accept and continue'
     update_job: 'Update job'

--- a/spec/features/job_seekers_can_view_vacancies_spec.rb
+++ b/spec/features/job_seekers_can_view_vacancies_spec.rb
@@ -125,6 +125,21 @@ RSpec.feature 'Viewing vacancies' do
     expect(page).not_to have_content(I18n.t('jobs.no_jobs'))
   end
 
+  scenario 'The search button text changes from \'Search\' to \'Refine search\' when the filters are applied' do
+    Vacancy.__elasticsearch__.client.indices.flush
+    visit jobs_path
+
+    within '.filters-form' do
+      fill_in 'keyword', with: 'English'
+      expect(find('.button').value).to eq('Search')
+      click_on I18n.t('buttons.apply_filters')
+    end
+
+    within '.filters-form' do
+      expect(find('.button').value).to eq(I18n.t('buttons.apply_filters_if_criteria'))
+    end
+  end
+
   context 'when the vacancy is part_time' do
     scenario 'Shows the weekly hours if there are weekly_hours' do
       vacancy = create(:vacancy, working_pattern: :part_time, weekly_hours: '5')


### PR DESCRIPTION
Some testing has revealed the button text "Apply filters" can be confusing.

We've changed it to 'Search' for the initial state, and 'Refine search' when a search has already been performed.

**Before**
![before](https://user-images.githubusercontent.com/822507/44531053-bb9bb480-a6e7-11e8-96b1-3d6e68ea0138.png)

**After (no search applied)**
![after no search](https://user-images.githubusercontent.com/822507/44531059-c0606880-a6e7-11e8-9078-446c52eab986.png)

**After (with search applied)**
![after with search](https://user-images.githubusercontent.com/822507/44531071-c6eee000-a6e7-11e8-9af1-f7a705317a63.png)