### PR TITLE
[394] Log anonymised email address for users who weren’t authorised

### DIFF
--- a/app/controllers/hiring_staff/sign_in/dfe/sessions_controller.rb
+++ b/app/controllers/hiring_staff/sign_in/dfe/sessions_controller.rb
@@ -18,6 +18,7 @@ class HiringStaff::SignIn::Dfe::SessionsController < HiringStaff::BaseController
       redirect_to school_path
     else
       Auditor::Audit.new(nil, 'dfe-sign-in.authorisation.failure', current_session_id).log_without_association
+      logger.warn("Unauthenticated user for identifier: #{identifier.gsub(/(.)./, '\1*')}")
       redirect_to page_path('user-not-authorised')
     end
   end

--- a/app/controllers/hiring_staff/sign_in/dfe/sessions_controller.rb
+++ b/app/controllers/hiring_staff/sign_in/dfe/sessions_controller.rb
@@ -18,7 +18,7 @@ class HiringStaff::SignIn::Dfe::SessionsController < HiringStaff::BaseController
       redirect_to school_path
     else
       Auditor::Audit.new(nil, 'dfe-sign-in.authorisation.failure', current_session_id).log_without_association
-      logger.warn("Unauthenticated user for identifier: #{identifier.gsub(/(.)./, '\1*')}")
+      log_debug_information
       redirect_to page_path('user-not-authorised')
     end
   end
@@ -44,5 +44,10 @@ class HiringStaff::SignIn::Dfe::SessionsController < HiringStaff::BaseController
 
   def selected_school_urn
     auth_hash.dig('extra', 'raw_info', 'organisation', 'urn')
+  end
+
+  def log_debug_information
+    anonymised_email = identifier.gsub(/(.)./, '\1*')
+    logger.warn("Unauthenticated user for identifier: #{anonymised_email}, school_urn: #{selected_school_urn}")
   end
 end

--- a/spec/features/hiring_staff_can_sign_in_with_dfe_spec.rb
+++ b/spec/features/hiring_staff_can_sign_in_with_dfe_spec.rb
@@ -48,7 +48,7 @@ RSpec.shared_examples 'a failed sign in' do |options|
     anonymised_email = options[:email].gsub(/(.)./, '\1*')
     expect_any_instance_of(ActiveSupport::Logger)
       .to receive(:warn)
-      .with("Unauthenticated user for identifier: #{anonymised_email}")
+      .with("Unauthenticated user for identifier: #{anonymised_email}, school_urn: #{options[:school_urn]}")
 
     visit root_path
 
@@ -178,7 +178,7 @@ RSpec.feature 'Hiring staff signing-in with DfE Sign In' do
         .and_return(AuthHelpers::MockPermissions.new(mock_authorisation_response))
     end
 
-    it_behaves_like 'a failed sign in', email: 'another_email@example.com'
+    it_behaves_like 'a failed sign in', email: 'another_email@example.com', school_urn: '110627'
   end
 
   context 'with valid credentials and no organisation in DfE Sign In but existing permissions' do
@@ -213,6 +213,6 @@ RSpec.feature 'Hiring staff signing-in with DfE Sign In' do
         .and_return(AuthHelpers::MockPermissions.new(mock_authorisation_response))
     end
 
-    it_behaves_like 'a failed sign in', email: 'an-email@example.com'
+    it_behaves_like 'a failed sign in', email: 'an-email@example.com', school_urn: nil
   end
 end


### PR DESCRIPTION
* This will be helpful during the early stages of inviting new users in gaining confidence in the process to know whether it is sensible to invite more users. We want to know that for all users that see the not-authorised page, it is because they have been invited to DSI by another service and are truly not allowed access yet, as opposed to a bug in our invitation process.
* We don't want or need the full personal email addresses that are coming back from DfE Sign-in to be sent to Papertrail as I think we can get away with checking every other character against the list we've invited before looking up in DfE Sign-in and our authorisation tool to debug.

<img width="612" alt="screen shot 2018-08-24 at 12 03 31" src="https://user-images.githubusercontent.com/912473/44581486-c44ac400-a795-11e8-9aec-85894e29657b.png">
