### PR TITLE
Fix - prevent editing publication date of published job

### DIFF
--- a/app/controllers/hiring_staff/vacancies/application_details_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/application_details_controller.rb
@@ -31,6 +31,7 @@ class HiringStaff::Vacancies::ApplicationDetailsController < HiringStaff::Vacanc
   def update
     vacancy = school.vacancies.published.find(vacancy_id)
     @application_details_form = ApplicationDetailsForm.new(application_details_form)
+    @application_details_form.status = vacancy.status
     @application_details_form.id = vacancy.id
 
     if @application_details_form.valid?

--- a/app/controllers/hiring_staff/vacancies/application_details_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/application_details_controller.rb
@@ -24,6 +24,8 @@ class HiringStaff::Vacancies::ApplicationDetailsController < HiringStaff::Vacanc
 
     @school = school
     @application_details_form = ApplicationDetailsForm.new(vacancy_attributes)
+    vacancy ||= school.vacancies.find(@application_details_form.id)
+    @application_details_form.original_publish_on = vacancy.publish_on
     @application_details_form.valid?
   end
 
@@ -33,6 +35,7 @@ class HiringStaff::Vacancies::ApplicationDetailsController < HiringStaff::Vacanc
     @application_details_form = ApplicationDetailsForm.new(application_details_form)
     @application_details_form.status = vacancy.status
     @application_details_form.id = vacancy.id
+    @application_details_form.original_publish_on = vacancy.publish_on
 
     if @application_details_form.valid?
       reset_session_vacancy!

--- a/app/form_models/application_details_form.rb
+++ b/app/form_models/application_details_form.rb
@@ -3,5 +3,15 @@ class ApplicationDetailsForm < VacancyForm
            :publish_on_dd, :publish_on_mm, :publish_on_yyyy,
            :published?, :status, to: :vacancy
 
+  attr_accessor :original_publish_on
+
   include VacancyApplicationDetailValidations
+
+  def disable_editing_publish_on?
+    published? && vacancy.reload.publish_on.past?
+  end
+
+  def publish_on_change?
+    original_publish_on.present? ? !publish_on.eql?(original_publish_on) : false
+  end
 end

--- a/app/form_models/application_details_form.rb
+++ b/app/form_models/application_details_form.rb
@@ -1,6 +1,7 @@
 class ApplicationDetailsForm < VacancyForm
   delegate :expires_on_dd, :expires_on_mm, :expires_on_yyyy,
-           :publish_on_dd, :publish_on_mm, :publish_on_yyyy, to: :vacancy
+           :publish_on_dd, :publish_on_mm, :publish_on_yyyy,
+           :published?, :status, to: :vacancy
 
   include VacancyApplicationDetailValidations
 end

--- a/app/models/concerns/vacancy_application_detail_validations.rb
+++ b/app/models/concerns/vacancy_application_detail_validations.rb
@@ -12,11 +12,15 @@ module VacancyApplicationDetailValidations
   end
 
   def validity_of_publish_on
-    errors.add(:publish_on, publish_on_before_today_error) if !published? && publish_on_after_today?
+    errors.add(:publish_on, publish_on_before_today_error) if publish_on_in_past? && publish_on_check?
   end
 
   def validity_of_expires_on
     errors.add(:expires_on, expires_on_before_publish_on_error) if expiry_date_less_than_publish_date?
+  end
+
+  def publish_on_check?
+    published? && publish_on_change? || !published?
   end
 
   private
@@ -25,7 +29,7 @@ module VacancyApplicationDetailValidations
     expires_on && publish_on && expires_on < publish_on
   end
 
-  def publish_on_after_today?
+  def publish_on_in_past?
     publish_on && publish_on < Time.zone.today
   end
 

--- a/app/models/concerns/vacancy_application_detail_validations.rb
+++ b/app/models/concerns/vacancy_application_detail_validations.rb
@@ -4,14 +4,15 @@ module VacancyApplicationDetailValidations
   included do
     validates :contact_email, format: { with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i },
                               if: proc { |a| a.contact_email.present? }
-    validates :application_link, :contact_email, :publish_on, :expires_on, presence: true
+    validates :application_link, :contact_email, :expires_on, presence: true
     validates :application_link, url: true, if: proc { |v| v.application_link.present? }
 
+    validates :publish_on, presence: true, if: proc { |v| !v.published? }
     validate :validity_of_publish_on, :validity_of_expires_on
   end
 
   def validity_of_publish_on
-    errors.add(:publish_on, publish_on_before_today_error) if publish_on_after_today?
+    errors.add(:publish_on, publish_on_before_today_error) if !published? && publish_on_after_today?
   end
 
   def validity_of_expires_on

--- a/app/views/hiring_staff/vacancies/application_details/edit.html.haml
+++ b/app/views/hiring_staff/vacancies/application_details/edit.html.haml
@@ -22,7 +22,7 @@
                 wrapper_html: {id: 'application_link'},
                 required: true
 
-      - if @application_details_form.published?
+      - if @application_details_form.disable_editing_publish_on?
         #publish_on
           %label.form-label-bold= t('jobs.publication_date')
           = format_date @application_details_form.publish_on

--- a/app/views/hiring_staff/vacancies/application_details/edit.html.haml
+++ b/app/views/hiring_staff/vacancies/application_details/edit.html.haml
@@ -22,12 +22,18 @@
                 wrapper_html: {id: 'application_link'},
                 required: true
 
-      %div.form-group#publish_on
-        = f.gov_uk_date_field :publish_on,
-          legend_text: t('jobs.publication_date'),
-          legend_class: 'form-label-bold',
-          form_hint_text: t('jobs.form_hints.publication_date',
-                          date: l(Date.today, format: :hinttext))
+      - if @application_details_form.published?
+        #publish_on
+          %label.form-label-bold= t('jobs.publication_date')
+          = format_date @application_details_form.publish_on
+        %br
+      - else
+        %div.form-group#publish_on
+          = f.gov_uk_date_field :publish_on,
+            legend_text: t('jobs.publication_date'),
+            legend_class: 'form-label-bold',
+            form_hint_text: t('jobs.form_hints.publication_date',
+                            date: l(Date.today, format: :hinttext))
 
       %div.form-group#deadline
         = f.gov_uk_date_field :expires_on,

--- a/app/views/hiring_staff/vacancies/edit.html.haml
+++ b/app/views/hiring_staff/vacancies/edit.html.haml
@@ -175,8 +175,8 @@
             = t('jobs.publication_date')
           %td.cya-answer
             = format_date @vacancy.publish_on
-          - unless @vacancy.published?
-            %td.cya-change
+          %td.cya-change
+            - unless @vacancy.published? && @vacancy.publish_on.past?
               = link_to t('buttons.change'), edit_school_job_application_details_path(@vacancy.id, anchor: 'publish_on'), 'aria-label': t('jobs.aria_labels.change_date_role_will_be_listed')
         %tr
           %td.cya-question

--- a/app/views/hiring_staff/vacancies/edit.html.haml
+++ b/app/views/hiring_staff/vacancies/edit.html.haml
@@ -175,8 +175,9 @@
             = t('jobs.publication_date')
           %td.cya-answer
             = format_date @vacancy.publish_on
-          %td.cya-change
-            = link_to t('buttons.change'), edit_school_job_application_details_path(@vacancy.id, anchor: 'publish_on'), 'aria-label': t('jobs.aria_labels.change_date_role_will_be_listed')
+          - unless @vacancy.published?
+            %td.cya-change
+              = link_to t('buttons.change'), edit_school_job_application_details_path(@vacancy.id, anchor: 'publish_on'), 'aria-label': t('jobs.aria_labels.change_date_role_will_be_listed')
         %tr
           %td.cya-question
             = t('jobs.deadline_date')

--- a/spec/features/hiring_staff_can_edit_a_published_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_edit_a_published_vacancy_spec.rb
@@ -169,6 +169,25 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
         verify_all_vacancy_details(vacancy)
       end
 
+      context 'if the job post has already been published' do
+        scenario 'renders the publication date as text and does not allow editing' do
+          vacancy = create(:vacancy, :published, school: school)
+          vacancy = VacancyPresenter.new(vacancy)
+          visit edit_school_job_path(vacancy.id)
+
+          click_header_link(I18n.t('jobs.application_details'))
+          expect(page).to have_content('Date role will be listed')
+          expect(page).to have_content(format_date(vacancy.publish_on))
+          expect(page).not_to have_css('#application_details_form_publish_on_dd')
+
+          fill_in 'application_details_form[application_link]', with: vacancy.application_link
+          click_on 'Update job'
+
+          expect(page).to have_content(I18n.t('messages.jobs.updated'))
+          verify_all_vacancy_details(vacancy)
+        end
+      end
+
       scenario 'tracks the vacancy update' do
         vacancy = create(:vacancy, :published, school: school)
         application_link = vacancy.application_link

--- a/spec/features/hiring_staff_can_edit_a_published_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_edit_a_published_vacancy_spec.rb
@@ -170,21 +170,46 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
       end
 
       context 'if the job post has already been published' do
-        scenario 'renders the publication date as text and does not allow editing' do
-          vacancy = create(:vacancy, :published, school: school)
-          vacancy = VacancyPresenter.new(vacancy)
-          visit edit_school_job_path(vacancy.id)
+        context 'and the publication date is in the past' do
+          scenario 'renders the publication date as text and does not allow editing' do
+            vacancy = build(:vacancy, :published, slug: 'test-slug', publish_on: 1.day.ago, school: school)
+            vacancy.save(validate: false)
+            vacancy = VacancyPresenter.new(vacancy)
+            visit edit_school_job_path(vacancy.id)
 
-          click_header_link(I18n.t('jobs.application_details'))
-          expect(page).to have_content('Date role will be listed')
-          expect(page).to have_content(format_date(vacancy.publish_on))
-          expect(page).not_to have_css('#application_details_form_publish_on_dd')
+            click_header_link(I18n.t('jobs.application_details'))
+            expect(page).to have_content('Date role will be listed')
+            expect(page).to have_content(format_date(vacancy.publish_on))
+            expect(page).not_to have_css('#application_details_form_publish_on_dd')
 
-          fill_in 'application_details_form[application_link]', with: vacancy.application_link
-          click_on 'Update job'
+            fill_in 'application_details_form[application_link]', with: vacancy.application_link
+            click_on 'Update job'
 
-          expect(page).to have_content(I18n.t('messages.jobs.updated'))
-          verify_all_vacancy_details(vacancy)
+            expect(page).to have_content(I18n.t('messages.jobs.updated'))
+            verify_all_vacancy_details(vacancy)
+          end
+        end
+
+        context 'and the publication date is in the future' do
+          scenario 'renders the publication date as text and allows editing' do
+            vacancy = create(:vacancy, :published, publish_on: Time.zone.now + 3.days, school: school)
+            vacancy = VacancyPresenter.new(vacancy)
+            visit edit_school_job_path(vacancy.id)
+            click_link_in_container_with_text(I18n.t('jobs.publication_date'))
+
+            expect(page).to have_content('Date role will be listed')
+            expect(page).to have_css('#application_details_form_publish_on_dd')
+
+            fill_in 'application_details_form[publish_on_dd]', with: (Time.zone.today + 2.days).day
+            fill_in 'application_details_form[publish_on_mm]', with: (Time.zone.today + 2.days).month
+            fill_in 'application_details_form[publish_on_yyyy]', with: (Time.zone.today + 2.days).year
+            click_on 'Update job'
+
+            expect(page).to have_content(I18n.t('messages.jobs.updated'))
+
+            vacancy.publish_on = Time.zone.today + 2.days
+            verify_all_vacancy_details(vacancy)
+          end
         end
       end
 

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe Vacancy, type: :model do
     context 'a record saved with job spec and candidate spec details, ' \
       'and empty contact_email' do
 
-      subject { build(:vacancy) }
+      subject { build(:vacancy, status: :draft) }
       before { subject.contact_email = '' }
 
       it 'should validate presence of contact email' do

--- a/spec/support/capybara_helper.rb
+++ b/spec/support/capybara_helper.rb
@@ -3,6 +3,10 @@ module CapybaraHelper
     find(:xpath, "//tr[td[contains(text(), '#{text}')]]").find('td.cya-change a').click
   end
 
+  def click_header_link(text)
+    find(:xpath, "//th[h2[contains(text(), '#{text}')]]").find('a', text: 'Change').click
+  end
+
   def within_row_for(element: 'label', text:, &block)
     element = page.find(element, text: text).find(:xpath, '..')
     within(element, &block)


### PR DESCRIPTION
**`publish_on`: disable validation check for already published jobs and enable editing and validation for jobs with a `published` status and a future publication date**

## A job that has already been published
**`status: published` and `publish_on.past?`**

- Remove `change` button of publication date
<img width="756" alt="edit-view-of-published-with-past-publish-on" src="https://user-images.githubusercontent.com/159200/44595016-b90c8e00-a7bf-11e8-8d1c-9ef901df6b10.png">

- Display text instead of date field
<img width="1107" alt="edit-published-with-past-publish-on" src="https://user-images.githubusercontent.com/159200/44595024-be69d880-a7bf-11e8-89eb-444b5a63063f.png">

## A job that is ready to be published
**`status: published` and `publish_on.future?`**

- The `change` button is still available
<img width="837" alt="edit-view-of-published-with-future-publish-on" src="https://user-images.githubusercontent.com/159200/44595068-e5280f00-a7bf-11e8-9b6b-3bdc53c1a142.png">

- The publication date can be edited
<img width="856" alt="screen shot 2018-08-24 at 17 10 42" src="https://user-images.githubusercontent.com/159200/44595424-c413ee00-a7c0-11e8-9fd9-874259d3ec93.png">

- Validation enforced - `publish_on` can not be set in the past
<img width="1088" alt="unable-to-set-past-publish-on-on-published" src="https://user-images.githubusercontent.com/159200/44595090-f4a75800-a7bf-11e8-94cb-d0dd2e89dd4d.png">
