### PR TITLE
[397] Auto expire docker images older than 60 days

### DIFF
--- a/terraform/modules/ecs/ecs.tf
+++ b/terraform/modules/ecs/ecs.tf
@@ -5,6 +5,30 @@ resource "aws_ecr_repository" "default" {
   name = "${var.project_name}-${var.environment}"
 }
 
+resource "aws_ecr_lifecycle_policy" "autoexpire" {
+  repository = "${aws_ecr_repository.default.name}"
+
+  policy = <<EOF
+{
+    "rules": [
+        {
+            "rulePriority": 10,
+            "description": "Expire images older than 60 days",
+            "selection": {
+                "tagStatus": "any",
+                "countType": "sinceImagePushed",
+                "countUnit": "days",
+                "countNumber": 60
+            },
+            "action": {
+                "type": "expire"
+            }
+        }
+    ]
+}
+EOF
+}
+
 /*====
 ECS cluster
 ======*/


### PR DESCRIPTION
https://www.terraform.io/docs/providers/aws/r/ecr_lifecycle_policy.html
* You can test this by running a terraform plan OR a dry run inside the AWS console itself: https://eu-west-2.console.aws.amazon.com/ecs/home?region=eu-west-2#/repositories/tvs2-staging#lifecyclePreview