### PR TITLE
[412] New containers that start in production never attempt to crea…

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,24 +1,31 @@
 #!/bin/bash
 set -e
 
-echo "Starting docker entrypoint…"
+echo "ENTRYPOINT: Starting docker entrypoint…"
 
 setup_database()
 {
-  echo "Checking database setup is up-to-date…"
+  echo "ENTRYPOINT: Checking database setup is up to date…"
   # Rails will throw an error if no database exists"
   #   PG::ConnectionBad: FATAL:  database "tvs_development" does not exist
   if rake db:migrate:status &> /dev/null; then
-    echo "Database found, running db:migrate…"
+    echo "ENTRYPOINT: Database found, running db:migrate…"
     rake db:migrate
   else
-    echo "No database found, running db:create db:schema:load…"
-    rake db:create db:schema:load
+    echo "ENTRYPOINT: No database found…"
+
+    if [ "$RAILS_ENV" == "production" ]; then
+      echo "ENTRYPOINT: Environment is production, doing nothing."
+    else
+      echo "ENTRYPOINT: Environment is in non-production, attempting to automatically create the database…"
+      echo "ENTRYPOINT: Running db:create db:schema:load…"
+      rake db:create db:schema:load
+    fi
   fi
-  echo "Finished database setup"
+  echo "ENTRYPOINT: Finished database setup."
 }
 
-if [ -z ${DATABASE_URL+x} ]; then echo "Skipping database setup"; else setup_database; fi
+if [ -z ${DATABASE_URL+x} ]; then echo "ENTRYPOINT: Skipping database setup due to missing DATABASE_URL"; else setup_database; fi
 
-echo "Finished docker entrypoint."
+echo "ENTRYPOINT: Finished docker entrypoint."
 exec "$@"


### PR DESCRIPTION
…te the database again

* We have recently had an issue where the staging database was wiped at 2am on a saturday. We are confident that there was nobody on the team doing anything at that time. We do know that staging was stuck in an cycle of deployment, where new containers were failing health checks (still an unknown diagnosis on this). This caused new containers to be restarted repeatedly, the only code running during that is docker-entrypoint.sh and the applications’s load and initialisers. This file the only code that looks to go near the database, even though it should be safe to run as `rake db:create` is idempotent and will not cause destructive actions if it can find the database.
* The only plausible explanation of this is that there was a network problem with AWS RDS during this time (perhaps caused by lots of repeat connections?) and the database was connected to but the database information was not found correctly by rake.
* The only other automatic things running at the 3 scheduled rake tasks but I’ve confirmed that none were running between 2:25 and 2:27 when the database disappeared. None of them look to perform destructive actions.
* To enable us to benefit from automatic provisioning of databases in development and on all new environments that are spun up, we’re going to keep this code but ensure it’s never run in production. This should/would only ever need to be run for the first setup of production anyway, so a fair cost for a developer to do it, or to later create a rake task to be run through AWS to do it.

RDS connections during this window:

<img width="891" alt="screen shot 2018-08-29 at 15 17 24" src="https://user-images.githubusercontent.com/912473/44846397-2436e400-ac48-11e8-9b3c-f3509468b579.png">
