### PR TITLE
Fix/aws ip ranges does not stop boot

### DIFF
--- a/lib/modules/aws_ip_ranges.rb
+++ b/lib/modules/aws_ip_ranges.rb
@@ -6,8 +6,13 @@ module AWSIpRanges
     uri = URI(PATH)
 
     begin
-      response = Net::HTTP.get(uri)
-      return parse_json_for_ips(response)
+      http_connection = Net::HTTP.new(uri.host, uri.port)
+      http_connection.read_timeout = 10
+      http_connection.open_timeout = 5
+      http_connection.use_ssl = true
+      response = http_connection.start { |http| http.get(uri.path) }
+
+      return parse_json_for_ips(response.body)
     rescue Timeout::Error, Errno::EINVAL, Errno::ECONNRESET, EOFError,
            Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError, Net::ProtocolError => error
       Rails.logger.warn("Unable to setup Rack Proxies to acquire the correct remote_ip: #{error.class}")

--- a/lib/modules/aws_ip_ranges.rb
+++ b/lib/modules/aws_ip_ranges.rb
@@ -21,5 +21,8 @@ module AWSIpRanges
       record['region'] == 'GLOBAL' && record['service'] == 'CLOUDFRONT'
     end
     cloudfront_ip_blocks.map { |cloudfront_ip| cloudfront_ip['ip_prefix'] }
+  rescue JSON::ParserError
+    Rails.logger.warn('Unable parse AWS Ip Range response to setup Rack Proxies')
+    []
   end
 end

--- a/spec/fixtures/bad_aws_ip_ranges.xml
+++ b/spec/fixtures/bad_aws_ip_ranges.xml
@@ -1,0 +1,13 @@
+HTTP/1.1 403 Forbidden
+Content-Type: application/xml
+Transfer-Encoding: chunked
+Connection: keep-alive
+Date: Thu, 30 Aug 2018 15:20:48 GMT
+Server: AmazonS3
+Age: 156
+X-Cache: Error from cloudfront
+Via: 1.1 dd12e7e803f596deb3908675a4e017be.cloudfront.net (CloudFront)
+X-Amz-Cf-Id: vFrd7pLiJmoGL4dUDJsvu41YR13_X_yQHymK5MlBHd3jdHQPlj153Q==
+
+<?xml version="1.0" encoding="UTF-8"?>
+<Error><Code>AccessDenied</Code><Message>Access Denied</Message><RequestId>41561330E5F1240B</RequestId><HostId>yQ4BdRISh5XUnE9nPKxrv7n5GF7W6nx8Ey6sgvtPjIkmb2MH/VCgHARQA1Mykmw/xir4xu6jrV8=</HostId></Error>%

--- a/spec/lib/modules/aws_ip_ranges_spec.rb
+++ b/spec/lib/modules/aws_ip_ranges_spec.rb
@@ -43,14 +43,29 @@ RSpec.describe AWSIpRanges do
       expect(AWSIpRanges.cloudfront_ips).to eql(expected_result)
     end
 
+    it 'configures a short timeout' do
+      http_connection_double = instance_double(Net::HTTP)
+      allow(Net::HTTP).to receive(:new).and_return(http_connection_double)
+
+      expect(http_connection_double).to receive(:read_timeout=).with(10)
+      expect(http_connection_double).to receive(:open_timeout=).with(5)
+      expect(http_connection_double).to receive(:use_ssl=).with(true)
+
+      # Check same object is the one used for the request
+      successful_response = instance_double(Net::HTTPOK, body: '')
+      expect(http_connection_double).to receive(:start).and_return(successful_response)
+
+      AWSIpRanges.cloudfront_ips
+    end
+
     context 'when there was any connectivity issue' do
       it 'returns an empty array' do
-        allow(Net::HTTP).to receive(:get).and_raise(Timeout::Error.new('error'))
+        allow_any_instance_of(Net::HTTP).to receive(:start).and_raise(Timeout::Error.new('error'))
         expect(AWSIpRanges.cloudfront_ips).to eql([])
       end
 
       it 'logs a warning' do
-        allow(Net::HTTP).to receive(:get).and_raise(Timeout::Error.new('error'))
+        allow_any_instance_of(Net::HTTP).to receive(:start).and_raise(Timeout::Error.new('error'))
         expect(Rails.logger)
           .to receive(:warn)
           .with('Unable to setup Rack Proxies to acquire the correct remote_ip: Timeout::Error')
@@ -70,7 +85,7 @@ RSpec.describe AWSIpRanges do
       ].each do |error|
         context "when #{error} is raised" do
           it 'returns an empty array' do
-            allow(Net::HTTP).to receive(:get).and_raise(error.new('error'))
+            allow_any_instance_of(Net::HTTP).to receive(:start).and_raise(error.new('error'))
             expect(AWSIpRanges.cloudfront_ips).to eql([])
           end
         end

--- a/spec/lib/modules/aws_ip_ranges_spec.rb
+++ b/spec/lib/modules/aws_ip_ranges_spec.rb
@@ -65,7 +65,8 @@ RSpec.describe AWSIpRanges do
         EOFError,
         Net::HTTPBadResponse,
         Net::HTTPHeaderSyntaxError,
-        Net::ProtocolError
+        Net::ProtocolError,
+        Net::OpenTimeout
       ].each do |error|
         context "when #{error} is raised" do
           it 'returns an empty array' do

--- a/spec/lib/modules/aws_ip_ranges_spec.rb
+++ b/spec/lib/modules/aws_ip_ranges_spec.rb
@@ -75,5 +75,25 @@ RSpec.describe AWSIpRanges do
         end
       end
     end
+
+    context 'when the response was 403 and not JSON' do
+      before(:each) do
+        aws_ip_ranges = File.read(Rails.root.join('spec', 'fixtures', 'bad_aws_ip_ranges.xml'))
+
+        stub_request(:get, AWSIpRanges::PATH)
+          .to_return(body: aws_ip_ranges, status: 403)
+      end
+
+      it 'returns an empty array' do
+        expect(AWSIpRanges.cloudfront_ips).to eql([])
+      end
+
+      it 'logs a warning' do
+        expect(Rails.logger)
+          .to receive(:warn)
+          .with('Unable parse AWS Ip Range response to setup Rack Proxies')
+        AWSIpRanges.cloudfront_ips
+      end
+    end
   end
 end


### PR DESCRIPTION
* Add timeout for AWS IP ranges to improve the chances our containers can boot successfully
* Handle the case where AWS give us a 403 and some XML instead of JSON