### PR TITLE
(fix): Containers are marked as unhealthy after an another 30 seconds

### DIFF
--- a/terraform/modules/core/core.tf
+++ b/terraform/modules/core/core.tf
@@ -233,7 +233,7 @@ resource "aws_alb_target_group" "alb_target_group" {
 
   health_check {
     healthy_threshold   = "5"
-    unhealthy_threshold = "2"
+    unhealthy_threshold = "3"
     interval            = "30"
     matcher             = "200"
     path                = "${var.load_balancer_check_path}"


### PR DESCRIPTION
* Increase from 60 seconds to 90 seconds, before marking containers as unhelathy and stopping the deployments
* At 2 intervals of 30 seconds, a container had 60 seconds to start up successfully. Containers or the docker-entrypoint can perform longer running tasks like migrations or loading files from third parties. Now that we are noticing that containers are taking ever so slightly longer to start we need to give them a bit more time to succeed.