### PR TITLE
(fix): Test no longer fails because of extra white space

### DIFF
--- a/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
@@ -364,7 +364,7 @@ RSpec.feature 'Creating a vacancy' do
         visit school_job_review_path(vacancy.id)
         click_on 'Confirm and submit job'
 
-        expect(page).to have_content("Your job listing will be posted on #{vacancy.publish_on}.")
+        expect(page).to have_content("Your job listing will be posted on #{format_date(vacancy.publish_on)}.")
         visit school_job_path(vacancy.id)
         expect(page).to have_content("Date posted #{format_date(vacancy.publish_on)}")
       end


### PR DESCRIPTION
* This was fixed 2 lines below when it failed there before, but it has only now failed a test on CI on this line, I believe the same fix will work here: https://eu-west-2.console.aws.amazon.com/codebuild/home?region=eu-west-2#/builds/tvs2-staging-codebuild:bc9ca28c-e031-49c2-bd29-0f3f1c94ce7d/view/new