### PR TITLE
[407] refine salary validation

### DIFF
--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -47,6 +47,6 @@ module VacanciesHelper
   end
 
   def pay_scale_options
-    @pay_scale_options ||= PayScale.current
+    @pay_scale_options ||= PayScale.all
   end
 end

--- a/app/models/concerns/vacancy_job_specification_validations.rb
+++ b/app/models/concerns/vacancy_job_specification_validations.rb
@@ -7,7 +7,7 @@ module VacancyJobSpecificationValidations
     validates :job_title, length: { minimum: 4, maximum: 100 }, if: :job_title?
     validates :job_description, length: { minimum: 10, maximum: 50_000 }, if: :job_description?
 
-    validates :minimum_salary, salary: { presence: true, minimum_value: true }
+    validates :minimum_salary, salary: { presence: true, minimum_value: false }
     validates :maximum_salary, salary: { presence: false }, if: :minimum_valid_and_maximum_salary_present?
     validate :maximum_salary_greater_than_minimum, if: :minimum_and_maximum_salary_present_and_valid?
     validates :working_pattern, presence: true

--- a/app/models/pay_scale.rb
+++ b/app/models/pay_scale.rb
@@ -2,9 +2,4 @@ class PayScale < ApplicationRecord
   has_many :vacancies
 
   default_scope { order(:index) }
-  scope :current, (-> { where('expires_at >= ?', Time.zone.today).where('starts_at <= ?', Time.zone.today) })
-
-  def self.minimum_payscale_salary
-    PayScale.current.minimum(:salary).to_i
-  end
 end

--- a/app/validators/salary_validator.rb
+++ b/app/validators/salary_validator.rb
@@ -5,7 +5,7 @@ class SalaryValidator < ActiveModel::EachValidator
   rescue_from ArgumentError, with: :invalid_format_message
 
   SALARY_FORMAT = /^\d+\.{0,1}\d{2}{0,1}$/
-  MIN_SALARY_ALLOWED = PayScale.minimum_payscale_salary.freeze
+  MIN_SALARY_ALLOWED = 0
   MAX_SALARY_ALLOWED = 200000
 
   def validate_each(record, attribute, value)

--- a/spec/form_models/job_specification_form_spec.rb
+++ b/spec/form_models/job_specification_form_spec.rb
@@ -8,23 +8,6 @@ RSpec.describe JobSpecificationForm, type: :model do
     it { should validate_presence_of(:minimum_salary) }
     it { should validate_presence_of(:working_pattern) }
 
-    describe '#minimum_salary' do
-      describe '#minimum_salary_at_least_minimum_payscale' do
-        let(:job_specification) do
-          JobSpecificationForm.new(job_title: 'job title',
-                                   job_description: 'description', working_pattern: :full_time,
-                                   minimum_salary: 20, maximum_salary: 200)
-        end
-
-        it 'the minimum salary should be at least equal to the minimum payscale value' do
-          stub_const("#{SalaryValidator}::MIN_SALARY_ALLOWED", '3000')
-          expect(job_specification.valid?). to be false
-          expect(job_specification.errors.messages[:minimum_salary][0])
-            . to eq('must be at least £3000')
-        end
-      end
-    end
-
     describe '#maximum_salary' do
       let(:job_specification) do
         JobSpecificationForm.new(job_title: 'job title',

--- a/spec/models/pay_scale_spec.rb
+++ b/spec/models/pay_scale_spec.rb
@@ -12,47 +12,5 @@ RSpec.describe PayScale, type: :model do
         expect(PayScale.all.last).to eq(last)
       end
     end
-
-    describe '#current' do
-      it 'also orders by index' do
-        last = create(:pay_scale, index: 30)
-        first = create(:pay_scale, index: 1)
-
-        expect(PayScale.current.first).to eq(first)
-        expect(PayScale.current.last).to eq(last)
-      end
-
-      it 'includes pay scales that are current' do
-        current = create(:pay_scale, starts_at: Time.zone.today - 2.days, expires_at: Time.zone.today + 2.days)
-        expect(PayScale.current).to include(current)
-      end
-
-      it 'doesn’t include pay scales that haven’t started' do
-        not_started = create(:pay_scale, starts_at: Time.zone.today + 2.days)
-        expect(PayScale.current).not_to include(not_started)
-      end
-
-      it 'doesn’t include pay scales that have expired' do
-        expired = create(:pay_scale, expires_at: Time.zone.today - 2.days)
-        expect(PayScale.current).not_to include(expired)
-      end
-    end
-  end
-
-  describe '#minimum_payscale_salary' do
-    it 'returns the lowest current pay scale salary' do
-      Timecop.freeze(Time.zone.today) do
-        minimum = create(:pay_scale,
-                         salary: 1000, starts_at: Time.zone.today - 2.days, expires_at: Time.zone.today + 2.days)
-        create(:pay_scale, salary: 2000, starts_at: Time.zone.today - 2.days, expires_at: Time.zone.today + 2.days)
-        future_minimum = create(:pay_scale, salary: 5000, starts_at: Time.zone.today + 2.months)
-        create(:pay_scale, salary: 6000, starts_at: Time.zone.today + 2.months)
-
-        expect(PayScale.minimum_payscale_salary).to be minimum.salary
-
-        Timecop.travel(Time.zone.today + 3.months)
-        expect(PayScale.minimum_payscale_salary).to be future_minimum.salary
-      end
-    end
   end
 end

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -113,6 +113,14 @@ RSpec.describe Vacancy, type: :model do
     end
 
     context '#minimum_salary and #maximum_salary combined validations' do
+      it 'present minimum_salary and no maximum_salary' do
+        job = build(:vacancy, minimum_salary: '20', maximum_salary: nil)
+
+        expect(job.valid?).to be true
+        expect(job.errors.messages[:minimum_salary]).to be_empty
+        expect(job.errors.messages[:maximum_salary]).to be_empty
+      end
+
       it 'no minimum_salary and no maximum_salary set' do
         job = build(:vacancy, minimum_salary: nil, maximum_salary: nil)
 
@@ -163,16 +171,6 @@ RSpec.describe Vacancy, type: :model do
         expect(job.errors.messages[:minimum_salary]).to be_empty
         expect(job.errors.messages[:maximum_salary])
           .to eq(['must be entered in one of the following formats: 25000 or 25000.00'])
-      end
-
-      it 'less than allowed minimum_salary and no maximum_salary' do
-        stub_const("#{SalaryValidator}::MIN_SALARY_ALLOWED", '3000')
-        job = build(:vacancy, minimum_salary: '20', maximum_salary: nil)
-
-        expect(job.valid?).to be false
-        expect(job.errors.messages[:minimum_salary])
-          .to eq(['must be at least £3000'])
-        expect(job.errors.messages[:maximum_salary]).to be_empty
       end
 
       it 'valid minimum_salary and greater than allowed maximum_salary' do


### PR DESCRIPTION
- disables minimum salary validation
- set minimum allowed value to 0 until UR decides appropriate validation value
- remove `#current` scope from PayScales
- ~adds unique index to `code` to ensure no duplicate entries can be added~ https://eu-west-2.console.aws.amazon.com/codebuild/home?region=eu-west-2#/builds/tvs2-pull-requests:31ef8be7-fd10-422f-b114-4e3169ce1d71/view/new