### PR TITLE
(fix): Terraform deployments never attempt tp update the task definition

### DIFF
--- a/terraform/modules/ecs/ecs.tf
+++ b/terraform/modules/ecs/ecs.tf
@@ -56,6 +56,10 @@ resource "aws_ecs_service" "web" {
   }
 
   depends_on = ["aws_iam_role.ecs_role"]
+
+  lifecycle {
+    ignore_changes = ["task_definition", "desired_count"]
+  }
 }
 
 resource "aws_ecs_service" "logspout" {


### PR DESCRIPTION
* When running on task 363, a terraform deploy wants to revert the task definition to a verion no longer there. I don't know why 353 is no longer in the list of tasks.
* How is Terraform calculating 353 as the valid version, why not 352? Our web container definition file has an image hard coded as `latest`, while code pipeline deploys will always make task definitions with a docker image that includes the correct git commit SHA eg `commit-2a3d145864e17f847cc26d5e60a03b21d0ea565d`, perhaps Terraform deployments have been creating new task definitions with the `:latest` tag. When it notices new task definitions since the last `latest` once, it tries to revert back to that one.
* It looks like changes to task definitions by code pipeline are reconciled with by Terraform during a terraform deploy. Terraform notices a change since it’s last deployment and tries to ‘correct’ the task. Code pipeline _should_ be the only responsible component for deploying new task definitions, Terraform shouldn’t change our version to a previous one. To ensure this `ignore_changes` is used to ignore upstream changes:

Change proposed by Terraform:
```
~ module.ecs.aws_ecs_service.web
     task_definition:                           "arn:aws:ecs:eu-west-2:530003481352:task-definition/tvs2_staging_web:363" => "arn:aws:ecs:eu-west-2:530003481352:task-definition/tvs2_staging_web:353"
```

Allowing it to continue results in:

```
     Error: Error applying plan:

     1 error(s) occurred:

     * module.ecs.aws_ecs_service.web: 1 error(s) occurred:

     * aws_ecs_service.web: ClientException: TaskDefinition is inactive
             status code: 400, request id: e65316ac-af66-11e8-a6e4-dd4b90d569bf
```

After this fix, there is no proposed change and all other Terraform changes are applied successfully.