### PR TITLE
(feature) users can clear search parameters

### DIFF
--- a/app/assets/stylesheets/base/_utilities.scss
+++ b/app/assets/stylesheets/base/_utilities.scss
@@ -36,3 +36,11 @@
 .display-none {
   display: none;
 }
+
+.inline {
+  display: inline;
+}
+
+.nobreak {
+  white-space: nowrap;
+}

--- a/app/views/vacancies/index.html+phone.haml
+++ b/app/views/vacancies/index.html+phone.haml
@@ -5,9 +5,12 @@
 .grid-row
 
   .column-two-thirds
-    %p.heading-medium.mt0.mb1
-      %p.heading-medium.mt0= @vacancies.total_count_message
-      = link_to 'Refine your search?', '#filters'
+    %p.mb1
+      %span.heading-medium.mv0.inline= @vacancies.total_count_message
+      - if @vacancies.searched
+        %span.clear-search.nobreak= link_to t('jobs.filters.clear_filters'), root_path, class: 'govuk-link'
+      .nobreak
+        = link_to 'Refine your search?', '#filters'
     - if @vacancies.any?
       %div.sortable-links
         = t('jobs.sort_by')

--- a/app/views/vacancies/index.html.haml
+++ b/app/views/vacancies/index.html.haml
@@ -8,7 +8,10 @@
   .column-one-third
     = render 'filters'
   .column-two-thirds
-    %p.heading-medium.mt0= @vacancies.total_count_message
+    %p.mb1
+      %span.heading-medium.mv0.inline= @vacancies.total_count_message
+      - if @vacancies.searched
+        %span.clear-search.nobreak= link_to t('jobs.filters.clear_filters'), root_path, class: 'govuk-link'
     - if @vacancies.any?
       %div.sortable-links
         = t('jobs.sort_by')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -157,6 +157,7 @@ en:
       maximum_salary: 'Maximum salary'
       working_pattern: 'Working pattern'
       education_phase: 'Education phase'
+      clear_filters: 'Reset search'
   feedback:
     page_title: 'Feedback'
     heading: 'Give feedback'

--- a/spec/features/job_seekers_can_filter_vacancies_spec.rb
+++ b/spec/features/job_seekers_can_filter_vacancies_spec.rb
@@ -180,5 +180,24 @@ RSpec.feature 'Filtering vacancies' do
       expect(page).to have_content(higher_paid_vacancy.job_title)
       expect(page).to have_content(lower_paid_vacancy.job_title)
     end
+
+    scenario 'a user clears their search', elasticsearch: true do
+      create(:vacancy, :published, job_title: 'Physics Teacher')
+
+      Vacancy.__elasticsearch__.client.indices.flush
+      visit jobs_path
+
+      expect(page).not_to have_content(I18n.t('jobs.filters.clear_filters'))
+
+      within '.filters-form' do
+        fill_in 'keyword', with: 'Physics'
+        page.find('.button[type=submit]').click
+      end
+
+      expect(page).to have_content(I18n.t('jobs.filters.clear_filters'))
+
+      click_on I18n.t('jobs.filters.clear_filters')
+      expect(current_path).to eq root_path
+    end
   end
 end


### PR DESCRIPTION
> As a jobseeker  
I need to be able to get back to the way the search page was initially  
So I can start from an unfiltered list of results

**This commit adds a 'Clear search' link if search parameters are currently applied.**

before (desktop)
<img width="1002" alt="before desktop" src="https://user-images.githubusercontent.com/822507/44993260-d7c60e00-af91-11e8-8a55-c14383a5a8ab.png">

after (desktop)
<img width="1005" alt="after desktop" src="https://user-images.githubusercontent.com/822507/44993928-51f79200-af94-11e8-9517-fcf3590fbbf6.png">

before (mobile)
<img width="374" alt="before mobile" src="https://user-images.githubusercontent.com/822507/44993259-d7c60e00-af91-11e8-8102-19648a5dd37b.png">

after (mobile)
<img width="372" alt="after mobile" src="https://user-images.githubusercontent.com/822507/44993933-56bc4600-af94-11e8-87fe-a49f234f4915.png">



