### PR TITLE
(fix): Don’t raise CSRF exception on session#destroy

### DIFF
--- a/app/controllers/hiring_staff/sessions_controller.rb
+++ b/app/controllers/hiring_staff/sessions_controller.rb
@@ -1,4 +1,6 @@
 class HiringStaff::SessionsController < HiringStaff::BaseController
+  protect_from_forgery with: :null_session, only: %i[destroy]
+
   skip_before_action :check_session, only: %i[destroy]
   skip_before_action :check_terms_and_conditions, only: %i[destroy]
 


### PR DESCRIPTION
* Users who sign out but click back in their browser and sign out again will currently have a ActionController::InvalidAuthenticityToken error thrown. We want this end point to always succeed regardless of session state (this includes expired sessions) and as there is nothing sensitive being done by the destroy action apart from removing the session anyway. If an old sign-out link is clicked, don’t throw a CSRF exception (which is default by ApplicationController) but allow it to be treated as null for the duration of the request.

Before:
```
1. they are on a logged in page with the 'Sign out' link
2. they click 'sign out' (and are signed out)
3. they click the browsers back button
4. they can see the 'sign out' link again
5. clicking that gets a 422 (ActionController::InvalidAuthenticityToken)
```

After:
```
1. they are on a logged in page with the 'Sign out' link
2. they click 'sign out' (and are signed out)
3. they click the browsers back button
4. they can see the 'sign out' link again
5. they see the home page as a signed out user
```