### PR TITLE
(feature) adds a mobile-specific feature test

### DIFF
--- a/spec/features/job_seekers_can_view_vacancies_spec.rb
+++ b/spec/features/job_seekers_can_view_vacancies_spec.rb
@@ -156,4 +156,19 @@ RSpec.feature 'Viewing vacancies' do
       expect(page).not_to have_content(I18n.t('jobs.weekly_hours'))
     end
   end
+
+  context 'when the user is not on mobile' do
+    scenario 'they should not see the \'refine your search\' link' do
+      visit jobs_path
+      expect(page).not_to have_content('Refine your search')
+    end
+  end
+
+  context 'when the user is on mobile' do
+    scenario 'they should see the \'refine your search\' link' do
+      page.driver.header('User-Agent', USER_AGENTS['MOBILE_CHROME'])
+      visit jobs_path
+      expect(page).to have_content('Refine your search')
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -15,6 +15,8 @@ Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
 ActiveRecord::Migration.maintain_test_schema!
 
+USER_AGENTS = user_agents ||= YAML.load_file(Browser.root.join("test/ua.yml")).freeze
+
 RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!


### PR DESCRIPTION
[Using `Capybara.page.driver.header` we can manipulate the request header](https://github.com/teampoltergeist/poltergeist#manipulating-request-headers) and pass it a user agent string that will trigger the action pack variants for our mobile views.

This way, we can test for elements of UI that differ in mobile and desktop.

We’ve added a constant `USER_AGENTS` to `specs/rails_helper.rb` that extracts the user agent strings that come packaged up with the gem.