### PR TITLE
[fix] ensure `expires_on` is always after `publish_on`

### DIFF
--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -65,6 +65,7 @@ FactoryBot.define do
 
     trait :published do
       status { :published }
+      expires_on { Faker::Time.between(Time.zone.today + 10.days, Time.zone.today + 20.days) }
     end
 
     trait :published_slugged do


### PR DESCRIPTION
- resolves staging CI failure