### PR TITLE
(wip) add a meta description tag

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,4 +1,5 @@
 - content_for :head do
+  %meta{name: 'description', content: 'The free service for schools in England to list teaching roles and for jobseekers to find them.'}/
   = render partial: 'shared/gtag'
   = stylesheet_link_tag 'application', media: 'all'
   = javascript_include_tag 'application'


### PR DESCRIPTION
- adds a general description of the service to a `<meta name='description'>` tag

<img width="1041" alt="screen shot 2018-09-11 at 15 16 23" src="https://user-images.githubusercontent.com/822507/45366081-e043c780-b5d5-11e8-90a7-02f923ff5c75.png">
