### PR TITLE
(fix) deleting job confirmation appears twice

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,7 +11,6 @@
 // about supported directives.
 //
 //= require jquery
-//= require jquery_ujs
 //= require rails-ujs
 //= require turbolinks
 //= require_tree .


### PR DESCRIPTION
- `jquery_ujs` was included to support IE8; we’re no longer compelled to do so, therefore we can remove it