### PR TITLE
[419] extend audit points

### DIFF
--- a/app/controllers/hiring_staff/terms_and_conditions_controller.rb
+++ b/app/controllers/hiring_staff/terms_and_conditions_controller.rb
@@ -9,6 +9,7 @@ class HiringStaff::TermsAndConditionsController < HiringStaff::BaseController
     @terms_and_conditions_form = TermsAndConditionsForm.new(terms_params)
     if @terms_and_conditions_form.valid?
       current_user.update(accepted_terms_at: Time.zone.now)
+      Auditor::Audit.new(current_user, 'user.terms_and_conditions.accept', current_session_id).log
       redirect_to school_path
     else
       render :show

--- a/app/controllers/hiring_staff/vacancies/feedback_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/feedback_controller.rb
@@ -16,6 +16,8 @@ class HiringStaff::Vacancies::FeedbackController < HiringStaff::Vacancies::Appli
                                 comment: feedback_params[:comment])
 
     return render 'new' unless @feedback.save
+
+    Auditor::Audit.new(vacancy, 'vacancy.feedback.create', current_session_id).log
     redirect_to school_path, notice: I18n.t('messages.feedback.submitted')
   end
 

--- a/app/controllers/interests_controller.rb
+++ b/app/controllers/interests_controller.rb
@@ -1,6 +1,7 @@
 class InterestsController < ApplicationController
   def new
     vacancy = Vacancy.find(vacancy_id)
+    Auditor::Audit.new(vacancy, 'vacancy.get_more_information', nil).log
     redirect_to(vacancy.application_link)
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  include Auditor::Model
+
   def accepted_terms_and_conditions?
     accepted_terms_at.present?
   end

--- a/spec/features/hiring_staff_can_submit_vacancy_feedback_spec.rb
+++ b/spec/features/hiring_staff_can_submit_vacancy_feedback_spec.rb
@@ -51,6 +51,20 @@ RSpec.feature 'Vacancy feedback' do
         click_on 'Submit feedback'
         expect(page).to have_content('Your feedback has been successfully submitted')
       end
+
+      scenario 'logs an audit activity' do
+        visit new_school_job_feedback_path(published_job.id)
+
+        choose 'Very satisfied'
+        fill_in 'feedback_comment', with: 'Perfect!'
+
+        click_on 'Submit feedback'
+        expect(page).to have_content('Your feedback has been successfully submitted')
+
+        activity = published_job.activities.last
+        expect(activity.key).to eq('vacancy.feedback.create')
+        expect(activity.session_id).to eq(session_id)
+      end
     end
   end
 end

--- a/spec/features/job_seekers_can_apply_for_a_vacancy_spec.rb
+++ b/spec/features/job_seekers_can_apply_for_a_vacancy_spec.rb
@@ -3,9 +3,19 @@ require 'rails_helper'
 RSpec.feature 'Job seekers can apply for a vacancy' do
   scenario 'the application link is without protocol' do
     vacancy = create(:vacancy, :published, application_link: 'www.google.com')
-
     visit job_path(vacancy)
 
     expect(page).to have_link(I18n.t('jobs.apply', href: 'http://www.google.com'))
+  end
+
+  scenario 'an activity is logged successfuly' do
+    vacancy = create(:vacancy, :published, application_link: 'www.google.com')
+    visit job_path(vacancy)
+
+    click_on 'Get more information'
+
+    activity = vacancy.activities.last
+    expect(activity.key).to eq('vacancy.get_more_information')
+    expect(activity.session_id).to eq(nil)
   end
 end


### PR DESCRIPTION
Extend auditor to track
- clicks to the `Get more information` button
- Acceptance of terms and conditions
- Feedback creation