### PR TITLE
[417] better filtering options for nqts

### DIFF
--- a/app/assets/stylesheets/components/filter_vacancies.scss
+++ b/app/assets/stylesheets/components/filter_vacancies.scss
@@ -18,4 +18,12 @@
   @media screen and (max-width: $small-screen) {
     margin-bottom: $gutter;
   }
+
+// filters form white checkbox on grey background
+.filters-form .multiple-choice {
+  background: $white;
+  label {
+    background: $panel-colour;
+  }
+}
 }

--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -5,6 +5,7 @@ class VacanciesController < ApplicationController
                 :maximum_salary,
                 :working_pattern,
                 :phase,
+                :newly_qualified_teacher,
                 :radius,
                 :sort_column,
                 :sort_order
@@ -35,7 +36,7 @@ class VacanciesController < ApplicationController
   def search_params
     params.permit(:keyword, :location, :radius,
                   :minimum_salary, :maximum_salary, :phase,
-                  :phase, :working_pattern).to_hash
+                  :phase, :working_pattern, :newly_qualified_teacher).to_hash
   end
 
   def id
@@ -68,6 +69,10 @@ class VacanciesController < ApplicationController
 
   def phase
     params[:phase]
+  end
+
+  def newly_qualified_teacher
+    params[:newly_qualified_teacher]
   end
 
   def radius

--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -49,4 +49,11 @@ module VacanciesHelper
   def pay_scale_options
     @pay_scale_options ||= PayScale.all
   end
+
+  def nqts_options
+    {
+      'Suitable': true,
+      'Not suitable': false
+    }
+  end
 end

--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -49,11 +49,4 @@ module VacanciesHelper
   def pay_scale_options
     @pay_scale_options ||= PayScale.all
   end
-
-  def nqts_options
-    {
-      'Suitable': true,
-      'Not suitable': false
-    }
-  end
 end

--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -49,4 +49,8 @@ module VacanciesHelper
   def pay_scale_options
     @pay_scale_options ||= PayScale.all
   end
+
+  def nqt_suitable_checked?(newly_qualified_teacher)
+    newly_qualified_teacher == 'true'
+  end
 end

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -40,6 +40,7 @@ class Vacancy < ApplicationRecord
     indexes :minimum_salary, type: :integer
     indexes :maximum_salary, type: :integer
     indexes :coordinates, type: :geo_point, ignore_malformed: true
+    indexes :newly_qualified_teacher, type: :keyword
   end
 
   extend FriendlyId

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -40,7 +40,7 @@ class Vacancy < ApplicationRecord
     indexes :minimum_salary, type: :integer
     indexes :maximum_salary, type: :integer
     indexes :coordinates, type: :geo_point, ignore_malformed: true
-    indexes :newly_qualified_teacher, type: :keyword
+    indexes :newly_qualified_teacher, type: :boolean
   end
 
   extend FriendlyId

--- a/app/services/vacancy_filters.rb
+++ b/app/services/vacancy_filters.rb
@@ -10,9 +10,9 @@ class VacancyFilters
     @keyword = args[:keyword]
     @minimum_salary = args[:minimum_salary]
     @maximum_salary = args[:maximum_salary]
+    @newly_qualified_teacher = args[:newly_qualified_teacher]
     @working_pattern = extract_working_pattern(args)
     @phase = School.phases.include?(args[:phase]) ? args[:phase] : nil
-    @newly_qualified_teacher = args[:newly_qualified_teacher]
   end
 
   def to_hash

--- a/app/services/vacancy_filters.rb
+++ b/app/services/vacancy_filters.rb
@@ -1,5 +1,6 @@
 class VacancyFilters
-  attr_reader :location, :radius, :keyword, :minimum_salary, :maximum_salary, :working_pattern, :phase
+  attr_reader :location, :radius, :keyword, :minimum_salary, :maximum_salary, :working_pattern, :phase,
+              :newly_qualified_teacher
 
   def initialize(args)
     args = ActiveSupport::HashWithIndifferentAccess.new(args)
@@ -11,6 +12,7 @@ class VacancyFilters
     @maximum_salary = args[:maximum_salary]
     @working_pattern = extract_working_pattern(args)
     @phase = School.phases.include?(args[:phase]) ? args[:phase] : nil
+    @newly_qualified_teacher = args[:newly_qualified_teacher]
   end
 
   def to_hash
@@ -22,6 +24,7 @@ class VacancyFilters
       maximum_salary: maximum_salary,
       working_pattern: working_pattern,
       phase: phase,
+      newly_qualified_teacher: newly_qualified_teacher,
     }
   end
 

--- a/app/services/vacancy_search_builder.rb
+++ b/app/services/vacancy_search_builder.rb
@@ -126,8 +126,8 @@ class VacancySearchBuilder
     {
       bool: {
         filter: {
-          terms: {
-            newly_qualified_teacher: [@newly_qualified_teacher.to_s],
+          term: {
+            newly_qualified_teacher: @newly_qualified_teacher.to_s,
           },
         },
       },

--- a/app/services/vacancy_search_builder.rb
+++ b/app/services/vacancy_search_builder.rb
@@ -2,10 +2,12 @@ require 'geocoding'
 class VacancySearchBuilder
   MIN_ALLOWED_RADIUS = 1
 
+  # rubocop:disable Metrics/AbcSize
   def initialize(filters:, sort:, expired: false, status: :published)
     @keyword = filters.keyword.to_s.strip
     @working_pattern = filters.working_pattern
     @phase = filters.phase
+    @newly_qualified_teacher = filters.newly_qualified_teacher
     @minimum_salary = filters.minimum_salary
     @maximum_salary = filters.maximum_salary
     @sort = sort
@@ -16,6 +18,7 @@ class VacancySearchBuilder
     @geocoded_location = Geocoding.new(filters.location).coordinates
     @radius = filters.radius.to_i.positive? ? filters.radius.to_i : MIN_ALLOWED_RADIUS
   end
+  # rubocop:enable Metrics/AbcSize
 
   def call
     { search_query: search_query, search_sort: sort_query }
@@ -37,6 +40,7 @@ class VacancySearchBuilder
     [
       keyword_query,
       phase_query,
+      newly_qualified_teacher_query,
       working_pattern_query,
       salary_query,
       expired_query,
@@ -111,6 +115,19 @@ class VacancySearchBuilder
         filter: {
           terms: {
             working_pattern: [@working_pattern.to_s],
+          },
+        },
+      },
+    }
+  end
+
+  def newly_qualified_teacher_query
+    return if @newly_qualified_teacher.blank?
+    {
+      bool: {
+        filter: {
+          terms: {
+            newly_qualified_teacher: [@newly_qualified_teacher.to_s],
           },
         },
       },

--- a/app/views/hiring_staff/vacancies/job_specification/new.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/new.html.haml
@@ -86,7 +86,7 @@
                 hint: t('jobs.form_hints.newly_qualified_teacher'),
                 wrapper: :inline_checkbox,
                 wrapper_html: { id: 'newly_qualified_teacher' },
-                input_html: { 'aria-label': t('jobs.aria_labels.newly_qualified_teacher')}
+                input_html: { 'aria-label': t('jobs.aria_labels.newly_qualified_teacher') }
       = f.input :flexible_working, as: :boolean,
                 hint: t('jobs.form_hints.flexible_working'),
                 wrapper: :inline_checkbox,

--- a/app/views/vacancies/_filters.html.haml
+++ b/app/views/vacancies/_filters.html.haml
@@ -25,7 +25,6 @@
       = label_tag 'phase', t('jobs.filters.education_phase'), class: 'form-label'
       = select_tag 'phase', options_for_select(school_phase_options, phase), class: 'form-control form-control-block', include_blank: 'Any'
     .form-group
-      %span.form-label= t('jobs.filters.newly_qualified_teacher')
       .multiple-choice
         = check_box_tag :newly_qualified_teacher, 'true', nqt_suitable_checked?(newly_qualified_teacher)
         = label_tag 'newly_qualified_teacher', t('jobs.filters.nqt_suitable'), class: 'form-label'

--- a/app/views/vacancies/_filters.html.haml
+++ b/app/views/vacancies/_filters.html.haml
@@ -25,8 +25,10 @@
       = label_tag 'phase', t('jobs.filters.education_phase'), class: 'form-label'
       = select_tag 'phase', options_for_select(school_phase_options, phase), class: 'form-control form-control-block', include_blank: 'Any'
     .form-group
-      = label_tag 'newly_qualified_teacher', t('jobs.filters.newly_qualified_teacher'), class: 'form-label'
-      = select_tag 'newly_qualified_teacher', options_for_select(nqts_options, newly_qualified_teacher), class: 'form-control form-control-block'
+      %span.form-label= t('jobs.filters.newly_qualified_teacher')
+      .multiple-choice
+        = check_box '', :newly_qualified_teacher, {}, 'true', ''
+        = label_tag 'newly_qualified_teacher', t('jobs.filters.nqt_suitable'), class: 'form-label'
 
     = hidden_field_tag :sort_column, sort_column
     = hidden_field_tag :sort_order, sort_order

--- a/app/views/vacancies/_filters.html.haml
+++ b/app/views/vacancies/_filters.html.haml
@@ -27,7 +27,7 @@
     .form-group
       %span.form-label= t('jobs.filters.newly_qualified_teacher')
       .multiple-choice
-        = check_box '', :newly_qualified_teacher, {}, 'true', ''
+        = check_box_tag :newly_qualified_teacher, 'true', nqt_suitable_checked?(newly_qualified_teacher)
         = label_tag 'newly_qualified_teacher', t('jobs.filters.nqt_suitable'), class: 'form-label'
 
     = hidden_field_tag :sort_column, sort_column

--- a/app/views/vacancies/_filters.html.haml
+++ b/app/views/vacancies/_filters.html.haml
@@ -24,6 +24,9 @@
     .form-group
       = label_tag 'phase', t('jobs.filters.education_phase'), class: 'form-label'
       = select_tag 'phase', options_for_select(school_phase_options, phase), class: 'form-control form-control-block', include_blank: 'Any'
+    .form-group
+      = label_tag 'newly_qualified_teacher', t('jobs.filters.newly_qualified_teacher'), class: 'form-label'
+      = select_tag 'newly_qualified_teacher', options_for_select(nqts_options, newly_qualified_teacher), class: 'form-control form-control-block'
 
     = hidden_field_tag :sort_column, sort_column
     = hidden_field_tag :sort_order, sort_order

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -165,7 +165,7 @@ en:
       working_pattern: 'Working pattern'
       education_phase: 'Education phase'
       newly_qualified_teacher: 'Newly qualified teacher'
-      nqt_suitable: 'NQT Suitable'
+      nqt_suitable: 'Suitable for NQTs'
       clear_filters: 'Reset search'
   feedback:
     page_title: 'Feedback'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -165,6 +165,7 @@ en:
       working_pattern: 'Working pattern'
       education_phase: 'Education phase'
       newly_qualified_teacher: 'Newly qualified teacher'
+      nqt_suitable: 'NQT Suitable'
       clear_filters: 'Reset search'
   feedback:
     page_title: 'Feedback'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -164,7 +164,6 @@ en:
       maximum_salary: 'Maximum salary'
       working_pattern: 'Working pattern'
       education_phase: 'Education phase'
-      newly_qualified_teacher: 'Newly qualified teacher'
       nqt_suitable: 'Suitable for NQTs'
       clear_filters: 'Reset search'
   feedback:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -164,6 +164,7 @@ en:
       maximum_salary: 'Maximum salary'
       working_pattern: 'Working pattern'
       education_phase: 'Education phase'
+      newly_qualified_teacher: 'Newly qualified teacher'
       clear_filters: 'Reset search'
   feedback:
     page_title: 'Feedback'

--- a/spec/features/job_seekers_can_filter_vacancies_spec.rb
+++ b/spec/features/job_seekers_can_filter_vacancies_spec.rb
@@ -200,4 +200,20 @@ RSpec.feature 'Filtering vacancies' do
       expect(current_path).to eq root_path
     end
   end
+
+  scenario 'Filterable by newly qualified teacher', elasticsearch: true do
+    nqt_suitable_vacancy = create(:vacancy, :published, newly_qualified_teacher: true)
+    nqt_not_suitable_vacancy = create(:vacancy, :published, newly_qualified_teacher: false)
+
+    Vacancy.__elasticsearch__.client.indices.flush
+    visit jobs_path
+
+    within '.filters-form' do
+      select 'Suitable', from: 'newly_qualified_teacher'
+      page.find('.button[type=submit]').click
+    end
+
+    expect(page).to have_content(nqt_suitable_vacancy.job_title)
+    expect(page).not_to have_content(nqt_not_suitable_vacancy.job_title)
+  end
 end

--- a/spec/features/job_seekers_can_filter_vacancies_spec.rb
+++ b/spec/features/job_seekers_can_filter_vacancies_spec.rb
@@ -201,19 +201,37 @@ RSpec.feature 'Filtering vacancies' do
     end
   end
 
-  scenario 'Filterable by newly qualified teacher', elasticsearch: true do
-    nqt_suitable_vacancy = create(:vacancy, :published, newly_qualified_teacher: true)
-    nqt_not_suitable_vacancy = create(:vacancy, :published, newly_qualified_teacher: false)
+  context 'Filterable by newly qualified teacher', elasticsearch: true do
+    scenario 'Suitable for NQTs', elasticsearch: true do
+      nqt_suitable_vacancy = create(:vacancy, :published, newly_qualified_teacher: true)
+      not_nqt_suitable_vacancy = create(:vacancy, :published, newly_qualified_teacher: false)
 
-    Vacancy.__elasticsearch__.client.indices.flush
-    visit jobs_path
+      Vacancy.__elasticsearch__.client.indices.flush
+      visit jobs_path
 
-    within '.filters-form' do
-      select 'Suitable', from: 'newly_qualified_teacher'
-      page.find('.button[type=submit]').click
+      within '.filters-form' do
+        select 'Suitable', from: 'newly_qualified_teacher'
+        page.find('.button[type=submit]').click
+      end
+
+      expect(page).to have_content(nqt_suitable_vacancy.job_title)
+      expect(page).not_to have_content(not_nqt_suitable_vacancy.job_title)
     end
 
-    expect(page).to have_content(nqt_suitable_vacancy.job_title)
-    expect(page).not_to have_content(nqt_not_suitable_vacancy.job_title)
+    scenario 'Not suitable for NQTs', elasticsearch: true do
+      nqt_suitable_vacancy = create(:vacancy, :published, newly_qualified_teacher: true)
+      not_nqt_suitable_vacancy = create(:vacancy, :published, newly_qualified_teacher: false)
+
+      Vacancy.__elasticsearch__.client.indices.flush
+      visit jobs_path
+
+      within '.filters-form' do
+        select 'Not suitable', from: 'newly_qualified_teacher'
+        page.find('.button[type=submit]').click
+      end
+
+      expect(page).to have_content(not_nqt_suitable_vacancy.job_title)
+      expect(page).not_to have_content(nqt_suitable_vacancy.job_title)
+    end
   end
 end

--- a/spec/features/job_seekers_can_filter_vacancies_spec.rb
+++ b/spec/features/job_seekers_can_filter_vacancies_spec.rb
@@ -202,7 +202,7 @@ RSpec.feature 'Filtering vacancies' do
   end
 
   context 'Filterable by newly qualified teacher', elasticsearch: true do
-    scenario 'Suitable for NQTs', elasticsearch: true do
+    scenario 'Suitable for NQTs' do
       nqt_suitable_vacancy = create(:vacancy, :published, newly_qualified_teacher: true)
       not_nqt_suitable_vacancy = create(:vacancy, :published, newly_qualified_teacher: false)
 
@@ -216,9 +216,10 @@ RSpec.feature 'Filtering vacancies' do
 
       expect(page).to have_content(nqt_suitable_vacancy.job_title)
       expect(page).not_to have_content(not_nqt_suitable_vacancy.job_title)
+      expect(page).to have_field('newly_qualified_teacher', checked: true)
     end
 
-    scenario 'Display all available jobs when NQT suitable is unchecked', elasticsearch: true do
+    scenario 'Display all available jobs when NQT suitable is unchecked' do
       nqt_suitable_vacancy = create(:vacancy, :published, newly_qualified_teacher: true)
       not_nqt_suitable_vacancy = create(:vacancy, :published, newly_qualified_teacher: false)
 
@@ -233,6 +234,7 @@ RSpec.feature 'Filtering vacancies' do
 
       expect(page).to have_content(not_nqt_suitable_vacancy.job_title)
       expect(page).to have_content(nqt_suitable_vacancy.job_title)
+      expect(page).to have_field('newly_qualified_teacher', checked: false)
     end
   end
 end

--- a/spec/features/job_seekers_can_filter_vacancies_spec.rb
+++ b/spec/features/job_seekers_can_filter_vacancies_spec.rb
@@ -210,7 +210,7 @@ RSpec.feature 'Filtering vacancies' do
       visit jobs_path
 
       within '.filters-form' do
-        select 'Suitable', from: 'newly_qualified_teacher'
+        check 'newly_qualified_teacher'
         page.find('.button[type=submit]').click
       end
 
@@ -218,7 +218,7 @@ RSpec.feature 'Filtering vacancies' do
       expect(page).not_to have_content(not_nqt_suitable_vacancy.job_title)
     end
 
-    scenario 'Not suitable for NQTs', elasticsearch: true do
+    scenario 'Display all available jobs when NQT suitable is unchecked', elasticsearch: true do
       nqt_suitable_vacancy = create(:vacancy, :published, newly_qualified_teacher: true)
       not_nqt_suitable_vacancy = create(:vacancy, :published, newly_qualified_teacher: false)
 
@@ -226,12 +226,13 @@ RSpec.feature 'Filtering vacancies' do
       visit jobs_path
 
       within '.filters-form' do
-        select 'Not suitable', from: 'newly_qualified_teacher'
+        check 'newly_qualified_teacher'
+        uncheck 'newly_qualified_teacher'
         page.find('.button[type=submit]').click
       end
 
       expect(page).to have_content(not_nqt_suitable_vacancy.job_title)
-      expect(page).not_to have_content(nqt_suitable_vacancy.job_title)
+      expect(page).to have_content(nqt_suitable_vacancy.job_title)
     end
   end
 end

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Vacancy, type: :model do
                 minimum_salary: nil,
                 maximum_salary: nil,
                 working_pattern: nil,
+                newly_qualified_teacher: nil,
                 phase: nil)
 
         results = Vacancy.public_search(filters: filters, sort: VacancySort.new)

--- a/spec/services/vacancy_filters_spec.rb
+++ b/spec/services/vacancy_filters_spec.rb
@@ -26,6 +26,11 @@ RSpec.describe VacancyFilters do
       expect(vacancy_filters.working_pattern).to eq('full_time')
     end
 
+    it 'sets the newly qualified teacher filter if provided' do
+      vacancy_filters = VacancyFilters.new(newly_qualified_teacher: true)
+      expect(vacancy_filters.newly_qualified_teacher).to eq(true)
+    end
+
     it 'does not set the working pattern filter if invalid' do
       vacancy_filters = VacancyFilters.new(working_pattern: 'home_time')
       expect(vacancy_filters.working_pattern).to be_nil
@@ -56,6 +61,7 @@ RSpec.describe VacancyFilters do
         minimum_salary: 'minimum_salary',
         maximum_salary: 'maximum_salary',
         working_pattern: 'working_pattern',
+        newly_qualified_teacher: false,
         phase: 'phase',
       )
 
@@ -67,6 +73,7 @@ RSpec.describe VacancyFilters do
         radius: '20km',
         minimum_salary: 'minimum_salary',
         maximum_salary: 'maximum_salary',
+        newly_qualified_teacher: false,
         working_pattern: nil,
         phase: nil
       )


### PR DESCRIPTION
### Better filtering options for nqts (wip)
- added newly_qualified_teacher to filter options, controllers and views
- jobs can be filtered by newly_qualified_teacher value
- added newly_qualified_teacher to elasticsearch indexes and queries
- added test specs for job seekers filtering by NQTs

_Dependent on #507_
Should only be reviewed/merged after #507 is merged in.
