### PR TITLE
[feature] move Google index calls to background jobs

### DIFF
--- a/app/controllers/hiring_staff/vacancies/application_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/application_controller.rb
@@ -63,11 +63,11 @@ class HiringStaff::Vacancies::ApplicationController < HiringStaff::BaseControlle
 
   def update_google_index(job)
     url = job_url(job, protocol: 'https')
-    Indexing.new(url).update
+    UpdateGoogleIndexQueueJob.perform_later(url)
   end
 
   def remove_google_index(job)
     url = job_url(job, protocol: 'https')
-    Indexing.new(url).remove
+    RemoveGoogleIndexQueueJob.perform_later(url)
   end
 end

--- a/app/jobs/remove_google_index_queue_job.rb
+++ b/app/jobs/remove_google_index_queue_job.rb
@@ -1,0 +1,10 @@
+class RemoveGoogleIndexQueueJob < ApplicationJob
+  queue_as :default
+
+  def perform(url)
+    Indexing.new(url).remove
+  rescue StandardError => e
+    Rails.logger.error("Sidekiq: Google remove index error: #{e.message}")
+    raise
+  end
+end

--- a/app/jobs/remove_google_index_queue_job.rb
+++ b/app/jobs/remove_google_index_queue_job.rb
@@ -1,8 +1,11 @@
+require 'indexing'
 class RemoveGoogleIndexQueueJob < ApplicationJob
   queue_as :default
 
   def perform(url)
     Indexing.new(url).remove
+  rescue SystemExit => e
+    Rails.logger.info("Sidekiq: Aborting Google remove index. Error: #{e.message}")
   rescue StandardError => e
     Rails.logger.error("Sidekiq: Google remove index error: #{e.message}")
     raise

--- a/app/jobs/update_google_index_queue_job.rb
+++ b/app/jobs/update_google_index_queue_job.rb
@@ -1,0 +1,10 @@
+class UpdateGoogleIndexQueueJob < ApplicationJob
+  queue_as :default
+
+  def perform(url)
+    Indexing.new(url).update
+  rescue StandardError => e
+    Rails.logger.error("Sidekiq: Google indexing error: #{e.message}")
+    raise
+  end
+end

--- a/app/jobs/update_google_index_queue_job.rb
+++ b/app/jobs/update_google_index_queue_job.rb
@@ -1,8 +1,11 @@
+require 'indexing'
 class UpdateGoogleIndexQueueJob < ApplicationJob
   queue_as :default
 
   def perform(url)
     Indexing.new(url).update
+  rescue SystemExit => e
+    Rails.logger.info("Sidekiq: Aborting Google update index. Error: #{e.message}")
   rescue StandardError => e
     Rails.logger.error("Sidekiq: Google indexing error: #{e.message}")
     raise

--- a/config/initializers/google_api.rb
+++ b/config/initializers/google_api.rb
@@ -1,7 +1,7 @@
 require 'google/apis/indexing_v3'
 
-GOOGLE_API_JSON_KEY = ENV['GOOGLE_API_JSON_KEY']
-return if GOOGLE_API_JSON_KEY.nil?
+GOOGLE_API_JSON_KEY = ENV.fetch('GOOGLE_API_JSON_KEY', '')
+return Rails.logger.info('***No GOOGLE_API_JSON_KEY set') if GOOGLE_API_JSON_KEY.empty?
 
 key = StringIO.new(GOOGLE_API_JSON_KEY)
 scope = 'https://www.googleapis.com/auth/indexing'

--- a/lib/indexing.rb
+++ b/lib/indexing.rb
@@ -9,6 +9,8 @@ class Indexing
   attr_reader :service, :url
 
   def initialize(url)
+    abort('No Google API key set.') if GOOGLE_API_JSON_KEY.empty?
+
     @service = API::IndexingService.new
     @url = url
   end

--- a/spec/features/hiring_staff_can_delete_vacancies_spec.rb
+++ b/spec/features/hiring_staff_can_delete_vacancies_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature 'School deleting vacancies' do
     stub_hiring_staff_auth(urn: school.urn, session_id: session_id)
   end
 
-  scenario 'A school can delete a vacancy from a list', :stub_indexing_api do
+  scenario 'A school can delete a vacancy from a list' do
     vacancy1 = create(:vacancy, school: school)
     vacancy2 = create(:vacancy, school: school)
 
@@ -21,7 +21,7 @@ RSpec.feature 'School deleting vacancies' do
     expect(page).to have_content('The job has been deleted')
   end
 
-  scenario 'The last vacancy is deleted', :stub_indexing_api do
+  scenario 'The last vacancy is deleted' do
     vacancy = create(:vacancy, school: school)
 
     visit school_path(school)
@@ -32,7 +32,7 @@ RSpec.feature 'School deleting vacancies' do
     expect(page).to have_content(I18n.t('schools.no_jobs.heading'))
   end
 
-  scenario 'Audits the vacancy deletion', :stub_indexing_api do
+  scenario 'Audits the vacancy deletion' do
     vacancy = create(:vacancy, school: school)
 
     visit school_path(school)
@@ -48,9 +48,9 @@ RSpec.feature 'School deleting vacancies' do
 
   scenario 'Notifies the Google index service' do
     vacancy = create(:vacancy, school: school)
-    indexing_service = double(:mock)
-    expect(Indexing).to receive(:new).with(job_url(vacancy, protocol: 'https')).and_return(indexing_service)
-    expect(indexing_service).to receive(:remove)
+    vacancy_url = job_url(vacancy, protocol: 'https')
+
+    expect(RemoveGoogleIndexQueueJob).to receive(:perform_later).with(vacancy_url)
 
     visit school_path(school)
 

--- a/spec/features/hiring_staff_can_edit_a_published_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_edit_a_published_vacancy_spec.rb
@@ -48,7 +48,7 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
         expect(page).to have_content('Job title can\'t be blank')
       end
 
-      scenario 'can be succesfuly edited', :stub_indexing_api do
+      scenario 'can be succesfuly edited' do
         vacancy = create(:vacancy, :published, school: school)
         visit edit_school_job_path(vacancy.id)
         click_link_in_container_with_text('Job title')
@@ -60,7 +60,7 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
         expect(page).to have_content('Assistant Head Teacher')
       end
 
-      scenario 'ensures the vacancy slug is updated when the title is saved', :stub_indexing_api do
+      scenario 'ensures the vacancy slug is updated when the title is saved' do
         vacancy = create(:vacancy, :published, slug: 'the-vacancy-slug', school: school)
         visit edit_school_job_path(vacancy.id)
         click_link_in_container_with_text('Job title')
@@ -75,7 +75,7 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
         expect(page.current_path).to eq('/jobs/assistant-head-teacher')
       end
 
-      scenario 'tracks the vacancy update', :stub_indexing_api do
+      scenario 'tracks the vacancy update' do
         vacancy = create(:vacancy, :published, school: school)
         job_title = vacancy.job_title
 
@@ -93,10 +93,9 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
 
       scenario 'notifies the Google index service' do
         vacancy = create(:vacancy, :published, school: school)
+        vacancy_url = job_url(vacancy, protocol: 'https')
 
-        indexing_service = double(:mock)
-        expect(Indexing).to receive(:new).with(job_url(vacancy, protocol: 'https')).and_return(indexing_service)
-        expect(indexing_service).to receive(:update)
+        expect(UpdateGoogleIndexQueueJob).to receive(:perform_later).with(vacancy_url)
 
         visit edit_school_job_path(vacancy.id)
         click_link_in_container_with_text('Job title')
@@ -122,7 +121,7 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
         end
       end
 
-      scenario 'can be succesfuly edited', :stub_indexing_api do
+      scenario 'can be succesfuly edited' do
         vacancy = create(:vacancy, :published, school: school)
         visit edit_school_job_path(vacancy.id)
         click_link_in_container_with_text(I18n.t('jobs.qualifications'))
@@ -134,7 +133,7 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
         expect(page).to have_content('Teaching deegree')
       end
 
-      scenario 'tracks the vacancy update', :stub_indexing_api do
+      scenario 'tracks the vacancy update' do
         vacancy = create(:vacancy, :published, school: school)
         qualifications = vacancy.qualifications
 
@@ -151,12 +150,11 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
                                                                                'Teaching deegree'])
       end
 
-      scenario 'notifies the Google index service' do
+      scenario 'adds a job to update the Google index in the queue' do
         vacancy = create(:vacancy, :published, school: school)
+        vacancy_url = job_url(vacancy, protocol: 'https')
 
-        indexing_service = double(:mock)
-        expect(Indexing).to receive(:new).with(job_url(vacancy, protocol: 'https')).and_return(indexing_service)
-        expect(indexing_service).to receive(:update)
+        expect(UpdateGoogleIndexQueueJob).to receive(:perform_later).with(vacancy_url)
 
         visit edit_school_job_path(vacancy.id)
         click_link_in_container_with_text(I18n.t('jobs.qualifications'))
@@ -182,7 +180,7 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
         end
       end
 
-      scenario 'can be succesfuly edited', :stub_indexing_api do
+      scenario 'can be succesfuly edited' do
         vacancy = create(:vacancy, :published, school: school)
         vacancy = VacancyPresenter.new(vacancy)
         visit edit_school_job_path(vacancy.id)
@@ -199,7 +197,7 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
 
       context 'if the job post has already been published' do
         context 'and the publication date is in the past' do
-          scenario 'renders the publication date as text and does not allow editing', :stub_indexing_api do
+          scenario 'renders the publication date as text and does not allow editing' do
             vacancy = build(:vacancy, :published, slug: 'test-slug', publish_on: 1.day.ago, school: school)
             vacancy.save(validate: false)
             vacancy = VacancyPresenter.new(vacancy)
@@ -241,7 +239,7 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
         end
       end
 
-      scenario 'tracks the vacancy update', :stub_indexing_api do
+      scenario 'tracks the vacancy update' do
         vacancy = create(:vacancy, :published, school: school)
         application_link = vacancy.application_link
 
@@ -258,12 +256,11 @@ RSpec.feature 'Hiring staff can edit a vacancy' do
                                                                                  'https://schooljobs.com'])
       end
 
-      scenario 'notifies the Google index service' do
+      scenario 'adds a job to update the Google index in the queue' do
         vacancy = create(:vacancy, :published, school: school)
+        vacancy_url = job_url(vacancy, protocol: 'https')
 
-        indexing_service = double(:mock)
-        expect(Indexing).to receive(:new).with(job_url(vacancy, protocol: 'https')).and_return(indexing_service)
-        expect(indexing_service).to receive(:update)
+        expect(UpdateGoogleIndexQueueJob).to receive(:perform_later).with(vacancy_url)
 
         visit edit_school_job_path(vacancy.id)
         click_link_in_container_with_text(I18n.t('jobs.application_link'))

--- a/spec/jobs/remove_google_index_queue_job_spec.rb
+++ b/spec/jobs/remove_google_index_queue_job_spec.rb
@@ -21,4 +21,13 @@ RSpec.describe RemoveGoogleIndexQueueJob, type: :job do
 
     perform_enqueued_jobs { job }
   end
+
+  it 'aborts execution when no Google credentials are set' do
+    stub_const('GOOGLE_API_JSON_KEY', '')
+    Sidekiq::Testing.inline! do
+      expect(Indexing).to receive(:new).and_raise(SystemExit, 'No Google API')
+
+      described_class.perform_now(url)
+    end
+  end
 end

--- a/spec/jobs/remove_google_index_queue_job_spec.rb
+++ b/spec/jobs/remove_google_index_queue_job_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe RemoveGoogleIndexQueueJob, type: :job do
+  include ActiveJob::TestHelper
+
+  let(:url) { Faker::Internet.url }
+  subject(:job) { described_class.perform_later(url) }
+
+  it 'queues the job' do
+    expect { job }.to change(ActiveJob::Base.queue_adapter.enqueued_jobs, :size).by(1)
+  end
+
+  it 'is in the default queue' do
+    expect(job.queue_name).to eq('default')
+  end
+
+  it 'executes perform' do
+    indexing_service = double(:mock)
+    expect(Indexing).to receive(:new).with(url).and_return(indexing_service)
+    expect(indexing_service).to receive(:remove)
+
+    perform_enqueued_jobs { job }
+  end
+end

--- a/spec/jobs/update_google_index_queue_job_spec.rb
+++ b/spec/jobs/update_google_index_queue_job_spec.rb
@@ -21,4 +21,13 @@ RSpec.describe UpdateGoogleIndexQueueJob, type: :job do
 
     perform_enqueued_jobs { job }
   end
+
+  it 'aborts execution when no Google credentials are set' do
+    stub_const('GOOGLE_API_JSON_KEY', '')
+    Sidekiq::Testing.inline! do
+      expect(Indexing).to receive(:new).and_raise(SystemExit, 'No Google API')
+
+      described_class.perform_now(url)
+    end
+  end
 end

--- a/spec/jobs/update_google_index_queue_job_spec.rb
+++ b/spec/jobs/update_google_index_queue_job_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe UpdateGoogleIndexQueueJob, type: :job do
+  include ActiveJob::TestHelper
+
+  let(:url) { Faker::Internet.url }
+  subject(:job) { described_class.perform_later(url) }
+
+  it 'queues the job' do
+    expect { job }.to change(ActiveJob::Base.queue_adapter.enqueued_jobs, :size).by(1)
+  end
+
+  it 'is in the default queue' do
+    expect(job.queue_name).to eq('default')
+  end
+
+  it 'executes perform' do
+    indexing_service = double(:mock)
+    expect(Indexing).to receive(:new).with(url).and_return(indexing_service)
+    expect(indexing_service).to receive(:update)
+
+    perform_enqueued_jobs { job }
+  end
+end

--- a/spec/lib/indexing_spec.rb
+++ b/spec/lib/indexing_spec.rb
@@ -7,31 +7,45 @@ RSpec.describe Indexing do
   let(:google_service) { double(:google_service) }
   let(:service) { Indexing.new(url) }
 
-  context 'Requesting a url index update' do
-    it 'notifies the indexing API' do
-      expect(Google::Apis::IndexingV3::IndexingService)
-        .to receive(:new).and_return(google_service)
-      expect(Google::Apis::IndexingV3::UrlNotification)
-        .to receive(:new)
-        .with(url: url, type: Indexing::ACTIONS[:update])
-        .and_return(mock_request)
-      expect(google_service).to receive(:publish_url_notification).with(mock_request)
+  context 'Successful requests' do
+    before(:each) do
+      stub_const('GOOGLE_API_JSON_KEY', 'some value')
+    end
 
-      service.update
+    context 'Requesting a url index update' do
+      it 'notifies the indexing API' do
+        expect(Google::Apis::IndexingV3::IndexingService)
+          .to receive(:new).and_return(google_service)
+        expect(Google::Apis::IndexingV3::UrlNotification)
+          .to receive(:new)
+          .with(url: url, type: Indexing::ACTIONS[:update])
+          .and_return(mock_request)
+        expect(google_service).to receive(:publish_url_notification).with(mock_request)
+
+        service.update
+      end
+    end
+
+    context 'Requesting a url index removal' do
+      it 'notifies the indexing API' do
+        expect(Google::Apis::IndexingV3::IndexingService)
+          .to receive(:new).and_return(google_service)
+        expect(Google::Apis::IndexingV3::UrlNotification)
+          .to receive(:new)
+          .with(url: url, type: Indexing::ACTIONS[:remove])
+          .and_return(mock_request)
+        expect(google_service).to receive(:publish_url_notification).with(mock_request)
+
+        service.remove
+      end
     end
   end
 
-  context 'Requesting a url index removal' do
-    it 'notifies the indexing API' do
-      expect(Google::Apis::IndexingV3::IndexingService)
-        .to receive(:new).and_return(google_service)
-      expect(Google::Apis::IndexingV3::UrlNotification)
-        .to receive(:new)
-        .with(url: url, type: Indexing::ACTIONS[:remove])
-        .and_return(mock_request)
-      expect(google_service).to receive(:publish_url_notification).with(mock_request)
+  context 'When no GOOGLE_API key is set' do
+    it 'logs an error and aborts execution' do
+      stub_const('GOOGLE_API_JSON_KEY', '')
 
-      service.remove
+      expect { Indexing.new(url) }.to raise_error(SystemExit, 'No Google API key set.')
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -27,12 +27,6 @@ RSpec.configure do |config|
     stub_const("#{SalaryValidator}::MIN_SALARY_ALLOWED", '1')
   end
 
-  config.before(:each, stub_indexing_api: true) do
-    stub_request(:post, /indexing.googleapis.com/).
-      with(headers: {'Accept'=>'*/*'}).
-      to_return(status: 200, body: "stubbed response", headers: {})
-  end
-
   config.include ActionView::Helpers::NumberHelper
   config.include ApplicationHelpers
   config.include DateHelper


### PR DESCRIPTION
- run calls to Google indexing API via sidekiq
- ensure that service is only called when API credentials are specified.