### PR TITLE
[feature] add introductory text on stats page

### DIFF
--- a/app/views/stats/index.html.haml
+++ b/app/views/stats/index.html.haml
@@ -4,6 +4,7 @@
   .column-two-thirds
     %h1.heading-large
       Statistics
+    %p=t('stats.intro')
 
 .grid-row
   .column-two-thirds

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -221,6 +221,9 @@ en:
       - 'Listing data'
     please_accept: 'Please accept the terms and conditions'
     label: 'I agree to all of the Terms and Conditions of the Teaching Jobs service.'
+  stats:
+    title: Statistics
+    intro: This page is an event log used by the service team to measure and monitor the stability and performance of Teaching Jobs. It keeps a live count of key user interactions with the service since 20 April 2018 (the date we began recording statistics).
   buttons:
     apply_filters: 'Search'
     apply_filters_if_criteria: 'Refine search'

--- a/spec/features/application_stats_spec.rb
+++ b/spec/features/application_stats_spec.rb
@@ -12,5 +12,6 @@ RSpec.feature 'Application statistics' do
     expect(page).to have_content('dfe-sign-in.authentication.success: 5')
     expect(page).to have_content('vacancy.publish: 1')
     expect(page).to have_content('vacancy.update: 4')
+    expect(page).to have_content(I18n.t('stats.intro'))
   end
 end


### PR DESCRIPTION
<img width="913" alt="screen shot 2018-09-21 at 16 51 18" src="https://user-images.githubusercontent.com/159200/45891907-9cfc0c80-bdbe-11e8-9bb1-0dc24510f45f.png">
