### PR TITLE
(fix) stats use a monospace font

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -18,6 +18,7 @@ $govuk-image-url-function: 'image-url';
 @import 'components/share-url';
 @import 'components/check_your_answers';
 @import 'components/pagination';
+@import 'components/statistics';
 @import 'ie';
 
 input[type='search'] {

--- a/app/assets/stylesheets/components/statistics.scss
+++ b/app/assets/stylesheets/components/statistics.scss
@@ -1,0 +1,6 @@
+ul.statistics {
+  font-family: monospace;
+  li {
+    margin-bottom: 4px;
+  }
+}

--- a/app/views/stats/index.html.haml
+++ b/app/views/stats/index.html.haml
@@ -8,7 +8,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    %ul
+    %ul.statistics
       - @audit_summary.each do |key, value|
         %li
           #{key}: #{value}


### PR DESCRIPTION
using a monospace font here marks it out as ‘technical’ content, implying that it’s not meant for general consumption

<img width="787" alt="monospace font" src="https://user-images.githubusercontent.com/822507/46077286-3b55ec80-c188-11e8-92a4-e126f4d02ef3.png">
