### PR TITLE
(447) Restart redis and sidekiq docker containers on failure

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
   redis:
     image: redis:latest
     command: redis-server
+    restart: on-failure
 
   sidekiq:
     build: .
@@ -53,6 +54,7 @@ services:
     command: bundle exec sidekiq
     depends_on:
       - redis
+    restart: on-failure
 
 volumes:
   pg_data: {}


### PR DESCRIPTION
- Set `restart: on-failure` for redis and sidekiq docker containers