### PR TITLE
[chore] convert key to json in terraform

### DIFF
--- a/config/initializers/google_api.rb
+++ b/config/initializers/google_api.rb
@@ -1,7 +1,10 @@
 require 'google/apis/indexing_v3'
 
 GOOGLE_API_JSON_KEY = ENV.fetch('GOOGLE_API_JSON_KEY', '')
-return Rails.logger.info('***No GOOGLE_API_JSON_KEY set') if GOOGLE_API_JSON_KEY.empty?
+
+if GOOGLE_API_JSON_KEY.empty? || JSON.parse(GOOGLE_API_JSON_KEY).empty?
+  return Rails.logger.info('***No GOOGLE_API_JSON_KEY set')
+end
 
 key = StringIO.new(GOOGLE_API_JSON_KEY)
 scope = 'https://www.googleapis.com/auth/indexing'

--- a/lib/indexing.rb
+++ b/lib/indexing.rb
@@ -9,7 +9,7 @@ class Indexing
   attr_reader :service, :url
 
   def initialize(url)
-    abort('No Google API key set.') if GOOGLE_API_JSON_KEY.empty?
+    abort('No Google API key set.') if api_key_empty?
 
     @service = API::IndexingService.new
     @url = url
@@ -28,5 +28,9 @@ class Indexing
   def call(action)
     notification = API::UrlNotification.new(url: url, type: ACTIONS[action])
     service.publish_url_notification(notification)
+  end
+
+  def api_key_empty?
+    GOOGLE_API_JSON_KEY.empty? || JSON.parse(GOOGLE_API_JSON_KEY).empty?
   end
 end

--- a/spec/lib/indexing_spec.rb
+++ b/spec/lib/indexing_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Indexing do
 
   context 'Successful requests' do
     before(:each) do
-      stub_const('GOOGLE_API_JSON_KEY', 'some value')
+      stub_const('GOOGLE_API_JSON_KEY', '{ "key": "value" }')
     end
 
     context 'Requesting a url index update' do

--- a/terraform.tf
+++ b/terraform.tf
@@ -126,7 +126,7 @@ module "ecs" {
   auth_spreadsheet_id              = "${var.auth_spreadsheet_id}"
   domain                           = "${var.domain}"
   google_geocoding_api_key         = "${var.google_geocoding_api_key}"
-  google_api_json_key              = "${var.google_api_json_key}"
+  google_api_json_key              = "${jsonencode(var.google_api_json_key)}"
 }
 
 module "logs" {

--- a/terraform.tf
+++ b/terraform.tf
@@ -126,7 +126,7 @@ module "ecs" {
   auth_spreadsheet_id              = "${var.auth_spreadsheet_id}"
   domain                           = "${var.domain}"
   google_geocoding_api_key         = "${var.google_geocoding_api_key}"
-  google_api_json_key              = "${jsonencode(var.google_api_json_key)}"
+  google_api_json_key              = "${var.google_api_json_key}"
 }
 
 module "logs" {

--- a/terraform/modules/ecs/ecs.tf
+++ b/terraform/modules/ecs/ecs.tf
@@ -415,7 +415,7 @@ resource "aws_ecs_task_definition" "web" {
 }
 
 resource "aws_ecs_task_definition" "worker" {
-  family                   = "${var.ecs_service_web_task_name}"
+  family                   = "${var.ecs_service_worker_name}"
   container_definitions    = "${data.template_file.worker_container_definition.rendered}"
   requires_compatibilities = ["EC2"]
   network_mode             = "bridge"

--- a/terraform/modules/ecs/ecs.tf
+++ b/terraform/modules/ecs/ecs.tf
@@ -158,14 +158,13 @@ data "template_file" "web_container_definition" {
     google_drive_json_key            = "${var.google_drive_json_key}"
     auth_spreadsheet_id              = "${var.auth_spreadsheet_id}"
     domain                           = "${var.domain}"
-    google_api_json_key              = "${var.google_api_json_key}"
+    google_api_json_key              = "${replace(jsonencode(var.google_api_json_key), "/([\"\\\\])/", "\\$1")}"
   }
 }
 
 /* import_schools task definition*/
 data "template_file" "import_schools_container_definition" {
   template = "${file(var.ecs_service_rake_container_definition_file_path)}"
-
   vars {
     image                    = "${aws_ecr_repository.default.repository_url}"
     secret_key_base          = "${var.secret_key_base}"
@@ -397,7 +396,7 @@ data "template_file" "worker_container_definition" {
 
     pp_transactions_by_channel_token = "${var.pp_transactions_by_channel_token}"
     pp_user_satisfaction_token       = "${var.pp_user_satisfaction_token}"
-    google_api_json_key              = "${var.google_api_json_key}"
+    google_api_json_key              = "${replace(jsonencode(var.google_api_json_key), "/([\"\\\\])/", "\\$1")}"
     domain                           = "${var.domain}"
 
     worker_command = "${jsonencode(var.worker_command)}"

--- a/terraform/modules/ecs/ecs.tf
+++ b/terraform/modules/ecs/ecs.tf
@@ -58,7 +58,7 @@ resource "aws_ecs_service" "web" {
   depends_on = ["aws_iam_role.ecs_role"]
 
   lifecycle {
-    ignore_changes = ["task_definition", "desired_count"]
+    ignore_changes = ["desired_count"]
   }
 }
 

--- a/terraform/modules/ecs/input.tf
+++ b/terraform/modules/ecs/input.tf
@@ -54,7 +54,9 @@ variable "google_drive_json_key" {}
 variable "auth_spreadsheet_id" {}
 variable "domain" {}
 variable "google_geocoding_api_key" {}
-variable "google_api_json_key" {}
+variable "google_api_json_key" {
+  type = "map"
+}
 
 variable "ecs_service_logspout_container_definition_file_path" {}
 

--- a/variables.tf
+++ b/variables.tf
@@ -321,4 +321,7 @@ variable "google_geocoding_api_key" {}
 variable "rollbar_access_token" {}
 variable "pp_transactions_by_channel_token" {}
 variable "pp_user_satisfaction_token" {}
-variable "google_api_json_key" {}
+
+variable "google_api_json_key" {
+  type = "map"
+}

--- a/workspace-variables/workspace.tfvars.example
+++ b/workspace-variables/workspace.tfvars.example
@@ -64,4 +64,4 @@ domain = # "tvs.dxw.net"
 pp_transactions_by_channel_token =
 pp_user_satisfaction_token =
 
-google_api_json_key =
+google_api_json_key = {}


### PR DESCRIPTION
- configure google_api_json_key as a terraform `map` type variable
- handle both an empty string and empty JSON
- remove ignoring changes to task definition for web aws_ecs_service. This ensures that the latest definition is always used (this was causing the wrong task definition version to be mapped to the service)
- fix spec: change key value to JSON
