### PR TITLE
(feature) add subnavigation

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -19,6 +19,7 @@ $govuk-image-url-function: 'image-url';
 @import 'components/check_your_answers';
 @import 'components/pagination';
 @import 'components/statistics';
+@import 'components/navigation';
 @import 'ie';
 
 input[type='search'] {

--- a/app/assets/stylesheets/components/navigation.scss
+++ b/app/assets/stylesheets/components/navigation.scss
@@ -1,0 +1,57 @@
+.app-navigation {
+  $navigation-height: 53px;
+  border-bottom: 1px solid govuk-colour("grey-2");
+  font-weight: bold;
+  margin-bottom: 2em;
+
+  @include clearfix;
+
+  &__list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    font-size: 0.85em;
+
+    @include govuk-media-query($from: tablet) {
+      font-size: 1em;
+    }
+
+    &>li {
+      box-sizing: border-box;
+      height: $navigation-height;
+      float: left;
+      line-height: $navigation-height;
+      -moz-box-sizing: border-box;
+      -webkit-box-sizing: border-box;
+
+      &:hover {
+        border-bottom: 4px solid govuk-colour("light-blue");
+      }
+
+      &.active {
+        border-bottom: 4px solid govuk-colour("blue") !important;
+
+        a:hover {
+          color: $govuk-link-colour;
+        }
+      }
+
+      a {
+        display: block;
+        padding: 0 1em;
+        color: $govuk-link-colour;
+        text-decoration: none;
+
+        &:visited {
+          color: $govuk-link-colour;
+        }
+
+        &:hover,
+        &:focus {
+          color: $govuk-link-hover-colour;
+          background-color: inherit;
+        }
+      }
+    }
+  }
+}

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -42,14 +42,6 @@
         .govuk-header__content
           %a.govuk-header__link.govuk-header__link--service-name{href: "/"}
             = t('app.title')
-          %button.govuk-header__menu-button.js-header-toggle{"aria-controls": "navigation", "aria-label": "Show or hide Top Level Navigation", role: "button"} Menu
-          %nav
-            %ul#navigation.govuk-header__navigation{"aria-label": "Top Level Navigation"}
-              - if authenticated?
-                %li.govuk-header__navigation-item= link_to t('nav.school_page_link'), school_path, class: ['govuk-header__link', active_link_class(school_path)]
-                %li.govuk-header__navigation-item= link_to t('nav.sign_out'), sessions_path, method: :delete, class: 'govuk-header__link'
-              - else
-                %li.govuk-header__navigation-item= link_to t('nav.sign_in'), new_identifications_path, class: 'govuk-header__link'
 
     .govuk-width-container
       .govuk-phase-banner
@@ -58,6 +50,8 @@
             beta
           %span.govuk-phase-banner__text
             This is a new service - #{link_to 'your feedback', 'https://www.surveymonkey.co.uk/r/FV5YF9Q', class: 'govuk-link'} will help us to improve it.
+
+      = render partial: 'shared/navigation'
 
       %main#main-content.govuk-main-wrapper.app-main-class{role: "main"}
         - flash.each do |name, msg|

--- a/app/views/shared/_navigation.haml
+++ b/app/views/shared/_navigation.haml
@@ -1,0 +1,8 @@
+%nav.app-navigation.govuk-clearfix
+  %ul.app-navigation__list
+    - if authenticated?
+      %li{class: active_link_class(school_path)}= link_to t('nav.school_page_link'), school_path, class: [active_link_class(school_path), 'govuk-link']
+      %li{class: active_link_class(root_path)}= link_to t('nav.jobseekers_index_link'), root_path, class: [active_link_class(root_path), 'govuk-link']
+      %li{class: active_link_class(sessions_path)}= link_to t('nav.sign_out'), sessions_path, method: :delete, class: 'govuk-link'
+    - else
+      %li{class: active_link_class(new_identifications_path)}= link_to t('nav.sign_in'), new_identifications_path, class: 'govuk-link'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,7 +14,8 @@ en:
   nav:
     sign_in: 'List a teaching job at your school'
     sign_out: 'Sign out'
-    school_page_link: 'My jobs'
+    school_page_link: 'Manage jobs'
+    jobseekers_index_link: 'View public jobs'
   sign_in:
     title: 'Sign in to Teaching Jobs'
     link: 'Sign in'

--- a/spec/features/hiring_staff_can_sign_in_with_dfe_spec.rb
+++ b/spec/features/hiring_staff_can_sign_in_with_dfe_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 RSpec.shared_examples 'a successful sign in' do
   scenario 'it signs in the user successfully' do
     expect(page).to have_content("Jobs at #{school.name}")
-    within('.govuk-header__navigation') { expect(page).to have_content(I18n.t('nav.sign_out')) }
-    within('.govuk-header__navigation') { expect(page).to have_content(I18n.t('nav.school_page_link')) }
+    within('.app-navigation') { expect(page).to have_content(I18n.t('nav.sign_out')) }
+    within('.app-navigation') { expect(page).to have_content(I18n.t('nav.school_page_link')) }
   end
 
   scenario 'adds entries in the audit log' do
@@ -26,7 +26,7 @@ RSpec.shared_examples 'a failed sign in' do |options|
     click_on(I18n.t('sign_in.link'))
 
     expect(page).to have_content(I18n.t('static_pages.not_authorised.title'))
-    within('.govuk-header__navigation') { expect(page).not_to have_content(I18n.t('nav.school_page_link')) }
+    within('.app-navigation') { expect(page).not_to have_content(I18n.t('nav.school_page_link')) }
   end
 
   scenario 'adds entries in the audit log' do

--- a/spec/features/hiring_staff_can_sign_out_spec.rb
+++ b/spec/features/hiring_staff_can_sign_out_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature 'Hiring staff can sign out' do
     visit root_path
 
     click_on(I18n.t('nav.sign_out'))
-    within('.govuk-header__navigation') { expect(page).to have_content(I18n.t('nav.sign_in')) }
+    within('.app-navigation') { expect(page).to have_content(I18n.t('nav.sign_in')) }
     expect(page).to have_content(I18n.t('messages.access.signed_out'))
   end
 end

--- a/spec/features/hiring_staff_can_visit_the_public_listings_spec.rb
+++ b/spec/features/hiring_staff_can_visit_the_public_listings_spec.rb
@@ -47,7 +47,7 @@ RSpec.feature 'School viewing public listings' do
       click_on(I18n.t('sign_in.link'))
 
       expect(page).to have_content("Jobs at #{school.name}")
-      within('.govuk-header__navigation') { expect(page).to have_content(I18n.t('nav.school_page_link')) }
+      within('.app-navigation') { expect(page).to have_content(I18n.t('nav.school_page_link')) }
 
       click_on(I18n.t('app.title'))
       expect(page).to have_content(I18n.t('jobs.heading'))


### PR DESCRIPTION
> We have now had lots of user feedback suggesting the links in the top bar are not easily findable.  
 This applies to:  
'list a job at your school'  
'my jobs'  
'log out'  
'Teaching Jobs'  

This PR removes the proposition links from the GOV UK header, and places navigation in a more obvious pattern beneath the phase banner.

### Before:
<img width="980" alt="screen shot 2018-10-01 at 13 59 33" src="https://user-images.githubusercontent.com/822507/46289903-40e57500-c582-11e8-95ad-039c35a51806.png">

### After (unauthenticated):
<img width="985" alt="screen shot 2018-10-01 at 14 00 06" src="https://user-images.githubusercontent.com/822507/46289925-55297200-c582-11e8-9e06-50bcb1f898e5.png">

### After (authenticated):
<img width="1005" alt="screen shot 2018-10-01 at 13 58 54" src="https://user-images.githubusercontent.com/822507/46289889-33c88600-c582-11e8-9df1-f9371c149b40.png">
