### PR TITLE
[434] Hiring staff sign in attempts log their DSI ID

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -61,7 +61,7 @@ Metrics/MethodLength:
     Exclude:
 
 Metrics/AbcSize:
-    Max: 20
+    Max: 25
     Exclude:
       - 'spec/**/*'
       - 'app/jobs/performance_platform_feedback_queue_job.rb'

--- a/app/controllers/hiring_staff/sign_in/dfe/sessions_controller.rb
+++ b/app/controllers/hiring_staff/sign_in/dfe/sessions_controller.rb
@@ -9,6 +9,8 @@ class HiringStaff::SignIn::Dfe::SessionsController < HiringStaff::BaseController
   end
 
   def create
+    Rails.logger.warn("Hiring staff signed in: #{oid}")
+
     permissions = TeacherVacancyAuthorisation::Permissions.new
     permissions.authorise(identifier, selected_school_urn)
     Auditor::Audit.new(nil, 'dfe-sign-in.authentication.success', current_session_id).log_without_association
@@ -18,7 +20,7 @@ class HiringStaff::SignIn::Dfe::SessionsController < HiringStaff::BaseController
       redirect_to school_path
     else
       Auditor::Audit.new(nil, 'dfe-sign-in.authorisation.failure', current_session_id).log_without_association
-      log_debug_information
+      Rails.logger.warn("Hiring staff not authorised: #{oid} for school: #{selected_school_urn}")
       redirect_to page_path('user-not-authorised')
     end
   end
@@ -44,10 +46,5 @@ class HiringStaff::SignIn::Dfe::SessionsController < HiringStaff::BaseController
 
   def selected_school_urn
     auth_hash.dig('extra', 'raw_info', 'organisation', 'urn')
-  end
-
-  def log_debug_information
-    anonymised_email = identifier.gsub(/(.)./, '\1*')
-    logger.warn("Unauthenticated user for identifier: #{anonymised_email}, school_urn: #{selected_school_urn}")
   end
 end

--- a/app/controllers/hiring_staff/vacancies/job_specification_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/job_specification_controller.rb
@@ -7,7 +7,6 @@ class HiringStaff::Vacancies::JobSpecificationController < HiringStaff::Vacancie
     @job_specification_form.valid?
   end
 
-  # rubocop:disable Metrics/AbcSize
   def create
     @job_specification_form = JobSpecificationForm.new(job_specification_form)
     store_vacancy_attributes(@job_specification_form.vacancy.attributes.compact)
@@ -22,7 +21,6 @@ class HiringStaff::Vacancies::JobSpecificationController < HiringStaff::Vacancie
       redirect_to job_specification_school_job_path(anchor: 'errors')
     end
   end
-  # rubocop:enable Metrics/AbcSize
 
   def edit
     vacancy_attributes = source_update? ? session[:vacancy_attributes] : retrieve_job_from_db

--- a/app/services/vacancy_search_builder.rb
+++ b/app/services/vacancy_search_builder.rb
@@ -2,7 +2,6 @@ require 'geocoding'
 class VacancySearchBuilder
   MIN_ALLOWED_RADIUS = 1
 
-  # rubocop:disable Metrics/AbcSize
   def initialize(filters:, sort:, expired: false, status: :published)
     @keyword = filters.keyword.to_s.strip
     @working_pattern = filters.working_pattern
@@ -18,7 +17,6 @@ class VacancySearchBuilder
     @geocoded_location = Geocoding.new(filters.location).coordinates
     @radius = filters.radius.to_i.positive? ? filters.radius.to_i : MIN_ALLOWED_RADIUS
   end
-  # rubocop:enable Metrics/AbcSize
 
   def call
     { search_query: search_query, search_sort: sort_query }

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,13 +50,6 @@ Rails.application.configure do
   config.force_ssl = true
   config.ssl_options = { redirect: { exclude: ->(request) { request.path =~ /check/ } } }
 
-  # Use the lowest log level to ensure availability of diagnostic information
-  # when problems arise.
-  config.log_level = :debug
-
-  # Prepend all log lines with the following tags.
-  config.log_tags = [:request_id]
-
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 
@@ -78,14 +71,13 @@ Rails.application.configure do
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify
 
-  # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = ::Logger::Formatter.new
-
-  # Use a different logger for distributed setups.
-  # require 'syslog/logger'
+  # Logging
+  config.log_level = :info
+  config.log_tags = [:request_id] # Prepend all log lines with the following tags.
+  config.logger = ActiveSupport::Logger.new(STDOUT)
+  config.active_record.logger = nil # Don't log SQL in production
 
   # Use Lograge for cleaner logging
-  config.log_level = :info
   config.lograge.enabled = true
   config.lograge.formatter = ColourLogFormatter.new
   config.lograge.ignore_actions = ['ApplicationController#check']
@@ -100,9 +92,6 @@ Rails.application.configure do
       params: event.payload[:params].except(*exceptions)
     }
   end
-
-  # Don't log SQL in production
-  config.active_record.logger = nil
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -50,13 +50,6 @@ Rails.application.configure do
   config.force_ssl = true
   config.ssl_options = { redirect: { exclude: ->(request) { request.path =~ /check/ } } }
 
-  # Use the lowest log level to ensure availability of diagnostic information
-  # when problems arise.
-  config.log_level = :debug
-
-  # Prepend all log lines with the following tags.
-  config.log_tags = [:request_id]
-
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 
@@ -77,6 +70,11 @@ Rails.application.configure do
 
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify
+
+  # Logging
+  config.log_level = :debug
+  config.log_tags = [:request_id] # Prepend all log lines with the following tags.
+  config.logger = ActiveSupport::Logger.new(STDOUT)
 
   # Use Lograge for cleaner logging
   config.lograge.enabled = true

--- a/spec/features/hiring_staff_can_sign_in_with_dfe_spec.rb
+++ b/spec/features/hiring_staff_can_sign_in_with_dfe_spec.rb
@@ -43,10 +43,13 @@ RSpec.shared_examples 'a failed sign in' do |options|
   end
 
   scenario 'logs a partially anonymised identifier so we can lookup any legitimate users who may be genuinley stuck' do
-    anonymised_email = options[:email].gsub(/(.)./, '\1*')
-    expect_any_instance_of(ActiveSupport::Logger)
+    expect(Rails.logger)
       .to receive(:warn)
-      .with("Unauthenticated user for identifier: #{anonymised_email}, school_urn: #{options[:school_urn]}")
+      .with("Hiring staff signed in: #{options[:dsi_id]}")
+
+    expect(Rails.logger)
+      .to receive(:warn)
+      .with("Hiring staff not authorised: #{options[:dsi_id]} for school: #{options[:school_urn]}")
 
     visit root_path
 
@@ -174,7 +177,7 @@ RSpec.feature 'Hiring staff signing-in with DfE Sign In' do
         .and_return(AuthHelpers::MockPermissions.new(mock_authorisation_response))
     end
 
-    it_behaves_like 'a failed sign in', email: 'another_email@example.com', school_urn: '110627'
+    it_behaves_like 'a failed sign in', dsi_id: 'an-unknown-oid', school_urn: '110627'
   end
 
   context 'with valid credentials and no organisation in DfE Sign In but existing permissions' do
@@ -209,6 +212,6 @@ RSpec.feature 'Hiring staff signing-in with DfE Sign In' do
         .and_return(AuthHelpers::MockPermissions.new(mock_authorisation_response))
     end
 
-    it_behaves_like 'a failed sign in', email: 'an-email@example.com', school_urn: nil
+    it_behaves_like 'a failed sign in', dsi_id: 'an-unknown-oid', school_urn: nil
   end
 end


### PR DESCRIPTION
* This also corrects the fact that no logs using Rails.logger were going
to papertrail. This is because without being configured logs were going
to <environment>.log, which isn't sent to PT due to how logspout
collects and forwards logs on the hosted environments. This is desipite
the configuration we have for lograge which just concerns itself with
formatting and colouring.
* Group logging config together for clarity and remove prod config for log level which was being overwritten
![screen shot 2018-10-01 at 17 43 30](https://user-images.githubusercontent.com/912473/46302664-91b89600-c5a1-11e8-91d1-2a313b04f4ed.png)
