### PR TITLE
(526) add the rollout blog link to pages

### DIFF
--- a/app/views/hiring_staff/identifications/new.html.haml
+++ b/app/views/hiring_staff/identifications/new.html.haml
@@ -8,5 +8,5 @@
 
     = simple_form_for :identifications, url: identifications_path, :defaults => { :input_html => { :class => "text" } }, method: :post do |f|
       .govuk-form-group
-        %p= t('sign_in.guidance')
+        %p= t('sign_in.guidance', link: link_to('Invitations are being sent out gradually by region.', roll_out_blog_url, target: :_blank)).html_safe
         = f.submit t('sign_in.link'), class: 'govuk-button'

--- a/app/views/shared/_beta_banner.html.haml
+++ b/app/views/shared/_beta_banner.html.haml
@@ -1,2 +1,2 @@
 .flash.notice
-  .small= t('beta_banner.line_1')
+  .small= t('beta_banner.line_1', link: link_to('rolled out in phases', roll_out_blog_url, target: :_blank)).html_safe

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,7 +19,7 @@ en:
   sign_in:
     title: 'Sign in to Teaching Jobs'
     link: 'Sign in'
-    guidance: 'Once you have received an email invitation from Teaching Jobs you can sign in to this service. Invitations are being sent out gradually by region.'
+    guidance: 'Once you have received an email invitation from Teaching Jobs you can sign in to this service. %{link}'
     organisation:
       title: 'Select your organisation'
       legend: 'You are associated with more than one organisation, please select the one you wish to sign-in with.'
@@ -277,4 +277,4 @@ en:
 
         - If your Teaching Jobs account has already been set up but you are unable to sign in, email the same address with “help” in the subject line.
   beta_banner:
-    line_1: 'This service is in development and lists jobs in select areas of England. It will be rolled out in phases to new areas, so check back regularly for new listings.'
+    line_1: 'This service is in development and lists jobs in select areas of England. It will be %{link} to new areas, so check back regularly for new listings.'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,4 +61,10 @@ Rails.application.routes.draw do
   match '/422', to: 'errors#unprocessable_entity', via: :all
   match '/500', to: 'errors#internal_server_error', via: :all
   match '*path', to: 'errors#not_found', via: :all
+
+  # External URL
+
+  direct :roll_out_blog do
+    'https://dfedigital.blog.gov.uk/2018/09/21/how-were-rolling-out-our-search-and-listing-service-to-more-schools-to-support-their-teacher-recruitment-needs/'
+  end
 end

--- a/spec/features/job_seekers_can_view_vacancies_spec.rb
+++ b/spec/features/job_seekers_can_view_vacancies_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 RSpec.feature 'Viewing vacancies' do
   scenario 'View a banner with information about the service' do
     visit jobs_path
-    expect(page).to have_content(I18n.t('beta_banner.line_1'))
+    expect(page).to have_content('This service is in development and lists jobs in select areas of England.')
   end
 
   scenario 'There are enough vacancies to invoke pagination', elasticsearch: true do

--- a/spec/features/support_links_spec.rb
+++ b/spec/features/support_links_spec.rb
@@ -32,4 +32,17 @@ RSpec.feature 'A visitor to the website can access the support links' do
     expect(page).to have_content('Please read these Terms of Use (“General Terms”) carefully before using ' \
                                  'this Teaching Jobs website (the “Service”).')
   end
+
+  context 'the roll out blog link' do
+    scenario 'on the service homepage' do
+      visit root_path
+      expect(page).to have_selector "a[href='#{roll_out_blog_url}']", text: 'rolled out in phases'
+    end
+
+    scenario 'on the hiring staff sign in page' do
+      visit new_identifications_path
+      expect(page).to have_selector "a[href='#{roll_out_blog_url}']",
+                                    text: 'Invitations are being sent out gradually by region.'
+    end
+  end
 end


### PR DESCRIPTION
added the rollout blog link to:
- the service homepage
- the hiring staff sign in page