### PR TITLE
(fix) update styles of stats page

### DIFF
--- a/app/views/stats/index.html.haml
+++ b/app/views/stats/index.html.haml
@@ -2,13 +2,13 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    %h1.heading-large
+    %h1.govuk-heading-xl
       Statistics
     %p=t('stats.intro')
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    %ul.statistics
+    %ul.govuk-list.statistics
       - @audit_summary.each do |key, value|
         %li
           #{key}: #{value}


### PR DESCRIPTION
### Before
![screen_shot_2018-10-02_at_12 44 47](https://user-images.githubusercontent.com/822507/46347281-eeb85880-c642-11e8-8d0c-7ed3378cf7a3.png)

### After
<img width="691" alt="screen shot 2018-10-02 at 12 54 12" src="https://user-images.githubusercontent.com/822507/46347288-f4ae3980-c642-11e8-8d7c-182514606819.png">
