### PR TITLE
[461] Docker tests can be run through Docker Compose

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -13,6 +13,7 @@ services:
       - docker-compose.env
     volumes:
       - .:/srv/dfe-tvs:cached
+      - node_modules:/srv/dfe-tvs/node_modules:cached
     depends_on:
       - db-test
       - elasticsearch-test
@@ -42,7 +43,6 @@ services:
     tmpfs: /usr/share/elasticsearch/test/data
     volumes:
       - elasticsearch_test:/usr/share/elasticsearch/data
-      #- ./config/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml
     networks:
       - tests
     restart: on-failure
@@ -53,3 +53,4 @@ networks:
 volumes:
   pg_test_data: {}
   elasticsearch_test: {}
+  node_modules:


### PR DESCRIPTION
* This was apart of docker-compose.yml used to start the services locally but it wasn’t copied across into the test docker-compose.yml, meaning the required deps in node_modules were indeed unavailable, as the 540 errors pointed to.