### PR TITLE
(fix) link classes and page title

### DIFF
--- a/app/views/errors/unauthorised.html.haml
+++ b/app/views/errors/unauthorised.html.haml
@@ -1,4 +1,4 @@
 - content_for :page_title_prefix, t('error_pages.unauthorised')
 
 %h1.govuk-heading-xl=t('error_pages.unauthorised')
-%p You can email #{mail_to t('help.email')} if the problem persists.
+%p You can email #{mail_to t('help.email'), t('help.email'), class: 'govuk-link'} if the problem persists.

--- a/app/views/pages/user-not-authorised.html.haml
+++ b/app/views/pages/user-not-authorised.html.haml
@@ -1,4 +1,4 @@
-- content_for :page_title do
+- content_for :page_title_prefix do
   =t('static_pages.not_authorised.title')
 
 .govuk-grid-row

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -272,7 +272,7 @@ en:
     not_authorised:
       title: You are not yet authorised to use the Teaching Jobs service
       text:
-        - You can register your interest to use the service by emailing <a href='mailto:teachingjobs@digital.education.gov.uk'>teachingjobs@digital.education.gov.uk</a>. It is currently open to schools in Cambridgeshire and the North East but will be rolled out in phases to other areas across England.
+        - You can register your interest to use the service by emailing <a href='mailto:teachingjobs@digital.education.gov.uk', class='govuk-link'>teachingjobs@digital.education.gov.uk</a>. It is currently open to schools in Cambridgeshire and the North East but will be rolled out in phases to other areas across England.
 
         - If your Teaching Jobs account has already been set up but you are unable to sign in, email the same address with “help” in the subject line.
   beta_banner:


### PR DESCRIPTION
### before
![screen shot 2018-10-02 at 14 39 56](https://user-images.githubusercontent.com/822507/46353046-24653d80-c653-11e8-8def-99d7035c8844.png)
### after
<img width="722" alt="screen shot 2018-10-02 at 14 49 20" src="https://user-images.githubusercontent.com/822507/46353078-35ae4a00-c653-11e8-8ab2-9291c4173c8e.png">

