### PR TITLE
(fix) remove excessive margin from subnav

### DIFF
--- a/app/assets/stylesheets/components/navigation.scss
+++ b/app/assets/stylesheets/components/navigation.scss
@@ -2,7 +2,6 @@
   $navigation-height: 53px;
   border-bottom: 1px solid govuk-colour("grey-2");
   font-weight: bold;
-  margin-bottom: 2em;
 
   @include clearfix;
 


### PR DESCRIPTION
### Before
<img width="986" alt="screen shot 2018-10-03 at 14 41 00" src="https://user-images.githubusercontent.com/822507/46414203-876dd780-c71a-11e8-9a80-514215488f6f.png">

### After
<img width="986" alt="screen shot 2018-10-03 at 14 41 32" src="https://user-images.githubusercontent.com/822507/46414216-8ccb2200-c71a-11e8-8897-a24809df637e.png">
