### PR TITLE
(fix) add spacing after warning banner

### DIFF
--- a/app/assets/stylesheets/components/banners.scss
+++ b/app/assets/stylesheets/components/banners.scss
@@ -2,6 +2,7 @@
   font-size: $large-font-size;
   padding: $govuk-gutter-half;
   margin-top: $govuk-gutter-half;
+  margin-bottom: $govuk-gutter;
   border: $thick-border solid;
   font-weight: $bold-font-weight;
 }


### PR DESCRIPTION
### Before:
<img width="1007" alt="before" src="https://user-images.githubusercontent.com/822507/46467446-ab3a2780-c7c5-11e8-9b46-56831aba5a4b.png">

### After:
<img width="1001" alt="after" src="https://user-images.githubusercontent.com/822507/46467448-ab3a2780-c7c5-11e8-805a-78e62fe98179.png">
