### PR TITLE
(480) Add govuk-link class to roll out blog links

### DIFF
--- a/app/views/hiring_staff/identifications/new.html.haml
+++ b/app/views/hiring_staff/identifications/new.html.haml
@@ -8,5 +8,5 @@
 
     = simple_form_for :identifications, url: identifications_path, :defaults => { :input_html => { :class => "text" } }, method: :post do |f|
       .govuk-form-group
-        %p= t('sign_in.guidance', link: link_to('Invitations are being sent out gradually by region.', roll_out_blog_url, target: :_blank)).html_safe
+        %p= t('sign_in.guidance', link: link_to('Invitations are being sent out gradually by region.', roll_out_blog_url, target: :_blank, class: 'govuk-link')).html_safe
         = f.submit t('sign_in.link'), class: 'govuk-button'

--- a/app/views/shared/_beta_banner.html.haml
+++ b/app/views/shared/_beta_banner.html.haml
@@ -1,2 +1,2 @@
 .flash.notice
-  .small= t('beta_banner.line_1', link: link_to('rolled out in phases', roll_out_blog_url, target: :_blank)).html_safe
+  .small= t('beta_banner.line_1', link: link_to('rolled out in phases', roll_out_blog_url, target: :_blank, class: 'govuk-link')).html_safe


### PR DESCRIPTION
- Add govuk-link class to roll out blog links

Before:
<img width="1280" alt="screen shot 2018-10-08 at 10 33 36" src="https://user-images.githubusercontent.com/5323962/46601702-d3879600-cae5-11e8-86cc-c4fa4424f006.png">

<img width="1280" alt="screen shot 2018-10-08 at 10 33 25" src="https://user-images.githubusercontent.com/5323962/46601740-fade6300-cae5-11e8-85a0-460ae4cbf2c3.png">

After:
<img width="1280" alt="screen shot 2018-10-08 at 10 33 02" src="https://user-images.githubusercontent.com/5323962/46601691-c5397a00-cae5-11e8-9095-9cd30c03d52b.png">
<img width="1280" alt="screen shot 2018-10-08 at 10 33 12" src="https://user-images.githubusercontent.com/5323962/46601692-c5397a00-cae5-11e8-9944-fd596ddaceb7.png">