### PR TITLE
(483) Add custom callback to refresh elasticsearch indices after update

### DIFF
--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -10,7 +10,6 @@ class Vacancy < ApplicationRecord
   include VacancyApplicationDetailValidations
 
   include Elasticsearch::Model
-  include Elasticsearch::Model::Callbacks
 
   index_name [Rails.env, model_name.collection.tr('\/', '-')].join('_')
   document_type 'vacancy'
@@ -72,6 +71,10 @@ class Vacancy < ApplicationRecord
   paginates_per 10
 
   validates :slug, presence: true
+
+  after_commit on: %i[create update] do
+    __elasticsearch__.index_document
+  end
 
   def location
     @location ||= SchoolPresenter.new(school).location


### PR DESCRIPTION
- Added custom callback to refresh elasticsearch indices after create and update, and removed elasticsearch automatic callback

This is a fix for: automatic callback not handling changes in vacancy
association models so changes are not reflected in search after vacancy
has been updated