### PR TITLE
[Feature] add a sitemap

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,8 @@ gem 'rails-html-sanitizer', '~> 1.0.4', '>= 1.0.4' # Must be above this version 
 gem 'gov_uk_date_fields', git: 'https://github.com/despo/gov_uk_date_fields.git',
                           branch: 'trigger-iphone-numeric-keyboard-for-new-gov-uk-ds'
 
+gem 'xml-sitemap'
+
 gem 'rollbar', '~> 2.17'
 
 gem 'rubocop' # Not in Test group due to: https://github.com/chapmanu/imposter/issues/4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -469,6 +469,8 @@ GEM
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
+    xml-sitemap (1.3.3)
+      builder (>= 2.0)
     xpath (3.1.0)
       nokogiri (~> 1.8)
 
@@ -537,6 +539,7 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
   webmock (~> 3.4)
+  xml-sitemap
 
 RUBY VERSION
    ruby 2.4.1p111

--- a/app/controllers/sitemap_controller.rb
+++ b/app/controllers/sitemap_controller.rb
@@ -1,0 +1,21 @@
+class SitemapController < ApplicationController
+  def show
+    map = XmlSitemap::Map.new(DOMAIN) do |m|
+      Vacancy.listed.find_each do |vacancy|
+        m.add job_path(vacancy, protocol: 'https'), updated: vacancy.updated_at,
+                                                    expires: vacancy.expires_on,
+                                                    period: 'hourly', priority: 0.7
+      end
+
+      m.add new_identifications_path(protocol: 'https'), period: 'weekly',
+                                                         priority: 0.8
+
+      m.add page_path('privacy-policy', protocol: 'https'), period: 'weekly'
+      m.add page_path('terms-and-conditions', protocol: 'https'), period: 'weekly'
+      m.add page_path('cookies', protocol: 'https'), period: 'weekly'
+    end
+
+    expires_in 3.hours
+    render xml: map.render
+  end
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -58,5 +58,5 @@ Rails.application.configure do
   config.logger    = ActiveSupport::TaggedLogging.new(logger)
 end
 
-domain = URI('localhost:3000')
-Rails.application.routes.default_url_options[:host] = domain.to_s
+DOMAIN = ENV.fetch('DOMAIN') { 'localhost:3000' }
+Rails.application.routes.default_url_options[:host] = DOMAIN.to_s

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -53,5 +53,5 @@ OmniAuth.config.on_failure = proc { |env|
 
 Elasticsearch::Model.client = Elasticsearch::Client.new host: ENV['ELASTICSEARCH_URL']
 
-domain = URI('localhost:3000')
-Rails.application.routes.default_url_options[:host] = domain.to_s
+DOMAIN = URI('localhost:3000')
+Rails.application.routes.default_url_options[:host] = DOMAIN.to_s

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   root 'vacancies#index'
 
   get 'check' => 'application#check'
+  get 'sitemap' => 'sitemap#show', format: 'xml'
 
   get '/pages/*id' => 'pages#show', as: :page, format: false
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,4 @@
+SITEMAP: https://teachings-jobs.service.gov.uk/sitemap.xml
 User-agent: *
 Allow: /
 Disallow: /vacancy/

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,6 @@
+User-agent: *
+Allow: /
+Disallow: /vacancy/
+Disallow: /school/
+Disallow: /check
+Disallow: /stats

--- a/spec/features/application_sitemap_spec.rb
+++ b/spec/features/application_sitemap_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+RSpec.feature 'Application sitemap', sitemap: true do
+  context 'sitemap.xml' do
+    scenario 'generates a sitemap of the application' do
+      published_jobs = create_list(:vacancy, 4, :published)
+
+      visit sitemap_path(format: :xml)
+      document = Nokogiri::XML::Document.parse(body)
+      nodes = document.search('url')
+
+      expect(nodes.count).to eq(9)
+      expect(nodes.search("loc[text()='#{root_url}']").text).to eq(root_url)
+
+      published_jobs.each do |job|
+        expect(nodes.search("loc:contains('#{job_url(job)}')").text).to eq(job_url(job))
+      end
+
+      expect(nodes.search("loc:contains('#{page_url('terms-and-conditions')}')").text)
+        .to eq(page_url('terms-and-conditions'))
+      expect(nodes.search("loc:contains('#{page_url('cookies')}')").text)
+        .to eq(page_url('cookies'))
+      expect(nodes.search("loc:contains('#{page_url('privacy-policy')}')").text)
+        .to eq(page_url('privacy-policy'))
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -27,6 +27,10 @@ RSpec.configure do |config|
     stub_const("#{SalaryValidator}::MIN_SALARY_ALLOWED", '1')
   end
 
+  config.before(:each, :sitemap) do
+    default_url_options[:host] = DOMAIN.to_s
+  end
+
   config.include ActionView::Helpers::NumberHelper
   config.include ApplicationHelpers
   config.include DateHelper


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/tpSa7LsX/478-add-a-sitemap-as-reccommended-by-google-to-ensure-coverage-of-entire-site

## Changes in this PR:

Generate a dynamic sitemap.xml for teaching-jobs which includes active pages and job listings. This should enable us to ping any search engine and request indexing and ensure that all pages listed on Teaching Jobs are indexed.

This PR also re-adds robots.txt as they dictate site or directory-wide crawl behavior, whereas meta and x-robots can dictate indexation behavior at the individual page (or page element) level.
