### PR TITLE
(chore) Bug: Don't show weekly_hours label unless job weekly_hours pr…

### DIFF
--- a/app/views/hiring_staff/vacancies/_show.html.haml
+++ b/app/views/hiring_staff/vacancies/_show.html.haml
@@ -102,7 +102,7 @@
           %dt= t('jobs.working_pattern')
           %dd= @vacancy.working_pattern
 
-          - if @vacancy.part_time? && @vacancy.weekly_hours
+          - if @vacancy.part_time? && @vacancy.weekly_hours.present?
             %dt= t('jobs.weekly_hours')
             %dd= @vacancy.weekly_hours
 

--- a/spec/features/job_seekers_can_view_vacancies_spec.rb
+++ b/spec/features/job_seekers_can_view_vacancies_spec.rb
@@ -183,6 +183,15 @@ RSpec.feature 'Viewing vacancies' do
     end
   end
 
+  context 'when the vacancy is full_time' do
+    scenario 'Does not show the weekly hours even if weekly_hours is set' do
+      vacancy = create(:vacancy, working_pattern: :full_time, weekly_hours: '5')
+      Vacancy.__elasticsearch__.client.indices.flush
+      visit job_path(vacancy)
+      expect(page).not_to have_content(I18n.t('jobs.weekly_hours'))
+    end
+  end
+
   context 'when the user is not on mobile' do
     scenario 'they should not see the \'refine your search\' link' do
       visit jobs_path


### PR DESCRIPTION
## Trello card URL: 

https://trello.com/c/rgoszAbU/477-bug-weekly-hours-label-rendered-even-when-no-weekly-hours-set

## Changes in this PR:

Don't show the `weekly_hours` label unless the job is part time AND there are weekly hours present in the record.

## Screenshots of UI changes:

### Before

<img width="584" alt="screen_shot_2018-10-05_at_13 05 18" src="https://user-images.githubusercontent.com/1089521/46682094-90f8b300-cbe4-11e8-8893-ff7e14d07339.png">

### After

<img width="593" alt="screen shot 2018-10-09 at 16 58 56" src="https://user-images.githubusercontent.com/1089521/46682139-a66ddd00-cbe4-11e8-9dd3-5ddf77da987a.png">

