### PR TITLE
[feature] always redirect to latest slugged vacancy path

### DIFF
--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -21,6 +21,7 @@ class VacanciesController < ApplicationController
 
   def show
     vacancy = Vacancy.listed.friendly.find(id)
+    return redirect_to(job_path(vacancy), status: :moved_permanently) if old_vacancy_path?(vacancy)
     @vacancy = VacancyPresenter.new(vacancy)
   end
 
@@ -37,6 +38,10 @@ class VacanciesController < ApplicationController
     params.permit(:keyword, :location, :radius,
                   :minimum_salary, :maximum_salary, :phase,
                   :phase, :working_pattern, :newly_qualified_teacher).to_hash
+  end
+
+  def old_vacancy_path?(vacancy)
+    request.path != job_path(vacancy) && !request.format.json?
   end
 
   def id

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -45,7 +45,7 @@ class Vacancy < ApplicationRecord
 
   extend FriendlyId
 
-  friendly_id :slug_candidates, use: :slugged
+  friendly_id :slug_candidates, use: %w[slugged history]
 
   enum status: %i[published draft trashed]
   enum working_pattern: %i[full_time part_time]

--- a/db/migrate/20181010093949_create_friendly_id_slugs.rb
+++ b/db/migrate/20181010093949_create_friendly_id_slugs.rb
@@ -1,0 +1,15 @@
+class CreateFriendlyIdSlugs < ActiveRecord::Migration[5.1]
+  def change
+    create_table :friendly_id_slugs do |t|
+      t.string   :slug,           :null => false
+      t.uuid  :sluggable_id,   :null => false
+      t.string   :sluggable_type, :limit => 50
+      t.string   :scope
+      t.datetime :created_at
+    end
+    add_index :friendly_id_slugs, :sluggable_id
+    add_index :friendly_id_slugs, [:slug, :sluggable_type], length: { slug: 140, sluggable_type: 50 }
+    add_index :friendly_id_slugs, [:slug, :sluggable_type, :scope], length: { slug: 70, sluggable_type: 50, scope: 70 }, unique: true
+    add_index :friendly_id_slugs, :sluggable_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_03_155423) do
+ActiveRecord::Schema.define(version: 2018_10_10_093949) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -47,6 +47,18 @@ ActiveRecord::Schema.define(version: 2018_10_03_155423) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["vacancy_id"], name: "index_feedbacks_on_vacancy_id", unique: true
+  end
+
+  create_table "friendly_id_slugs", force: :cascade do |t|
+    t.string "slug", null: false
+    t.uuid "sluggable_id", null: false
+    t.string "sluggable_type", limit: 50
+    t.string "scope"
+    t.datetime "created_at"
+    t.index ["slug", "sluggable_type", "scope"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope", unique: true
+    t.index ["slug", "sluggable_type"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type"
+    t.index ["sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_id"
+    t.index ["sluggable_type"], name: "index_friendly_id_slugs_on_sluggable_type"
   end
 
   create_table "leaderships", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/controllers/vacancies_controller_spec.rb
+++ b/spec/controllers/vacancies_controller_spec.rb
@@ -107,8 +107,19 @@ RSpec.describe VacanciesController, type: :controller do
       let(:vacancy) { create(:vacancy) }
 
       it 'returns status code :ok' do
-        get :show, params: { id: vacancy.id }
+        get :show, params: { id: vacancy.slug }
 
+        expect(response.status).to eq(Rack::Utils.status_code(:ok))
+      end
+
+      it 'never redirects to latest url' do
+        vacancy = create(:vacancy, :published)
+        old_slug = vacancy.slug
+        vacancy.job_title = 'A new job title'
+        vacancy.refresh_slug
+        vacancy.save
+
+        get :show, params: { id: old_slug }
         expect(response.status).to eq(Rack::Utils.status_code(:ok))
       end
 

--- a/spec/features/job_seekers_can_view_a_vacancy_spec.rb
+++ b/spec/features/job_seekers_can_view_a_vacancy_spec.rb
@@ -81,5 +81,20 @@ RSpec.feature 'Viewing a single published vacancy' do
 
       expect(page).to have_content(published_vacancy.job_title)
     end
+
+    context 'when the vacancy\'s url changes' do
+      scenario 'the user is still able to use the old url' do
+        vacancy = VacancyPresenter.new(create(:vacancy, :published))
+        old_path = job_path(vacancy)
+        vacancy.job_title = 'A new job title'
+        vacancy.refresh_slug
+        vacancy.save
+        new_path = job_path(vacancy)
+
+        visit old_path
+
+        expect(page.current_path).to eq(new_path)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/Pnx3NERl/314-links-that-hiring-staff-share-should-not-break-if-the-job-title-is-updated

## Changes in this PR:
Utilise friendly_id history module to enable redirection to latest slugged url. Do not redirect when requests are JSON.