### PR TITLE
(chore) switch to elastic.co images for docker compose files

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.1'
 services:
   test: &test
     build:
@@ -31,7 +31,8 @@ services:
     restart: on-failure
 
   elasticsearch-test:
-    image: elasticsearch
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.0.1
+    hostname: "{{.Node.Hostname}}-elasticsearch-test"
     depends_on:
       - db-test
     ports:
@@ -39,6 +40,8 @@ services:
     environment:
       - discovery.type=single-node
       - cluster.name=docker=docker-test-cluster
+      - node.name={{.Node.Hostname}}-elasticsearch-test
+      - network.host=0.0.0.0
     # place elasticsearch data on tmpfs for performance
     tmpfs: /usr/share/elasticsearch/test/data
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.1'
 services:
   web:
     build:
@@ -30,7 +30,8 @@ services:
     restart: on-failure
 
   elasticsearch:
-    image: elasticsearch
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.0.1
+    hostname: "{{.Node.Hostname}}-elasticsearch"
     depends_on:
       - db
     ports:
@@ -38,6 +39,8 @@ services:
     environment:
       - discovery.type=single-node
       - cluster.name=docker=docker-cluster
+      - node.name={{.Node.Hostname}}-elasticsearch
+      - network.host=0.0.0.0
     volumes:
       - elasticsearch:/usr/share/elasticsearch/data
     restart: on-failure


### PR DESCRIPTION
## Trello card URL:
Related to: https://trello.com/c/LHfRQ1v5/495-switch-elasticsearch-in-builds-to-make-use-of-the-official-elasticco-docker-image-and-specify-version-tag
## Changes in this PR:
- Switch to elastic.co images for docker compose files
