### PR TITLE
(feature) Show more useful text with instructions to unauthorised user

### DIFF
--- a/app/controllers/hiring_staff/sign_in/dfe/sessions_controller.rb
+++ b/app/controllers/hiring_staff/sign_in/dfe/sessions_controller.rb
@@ -19,13 +19,18 @@ class HiringStaff::SignIn::Dfe::SessionsController < HiringStaff::BaseController
       update_session(permissions.school_urn, permissions)
       redirect_to school_path
     else
-      Auditor::Audit.new(nil, 'dfe-sign-in.authorisation.failure', current_session_id).log_without_association
-      Rails.logger.warn("Hiring staff not authorised: #{oid} for school: #{selected_school_urn}")
-      redirect_to page_path('user-not-authorised')
+      not_authorised
     end
   end
 
   private
+
+  def not_authorised
+    Auditor::Audit.new(nil, 'dfe-sign-in.authorisation.failure', current_session_id).log_without_association
+    Rails.logger.warn("Hiring staff not authorised: #{oid} for school: #{selected_school_urn}")
+    flash[:hidden] = identifier
+    redirect_to page_path('user-not-authorised')
+  end
 
   def update_session(school_urn, permissions)
     session.update(session_id: oid, urn: school_urn, multiple_schools: permissions.many?)

--- a/app/controllers/hiring_staff/sign_in/dfe/sessions_controller.rb
+++ b/app/controllers/hiring_staff/sign_in/dfe/sessions_controller.rb
@@ -28,8 +28,8 @@ class HiringStaff::SignIn::Dfe::SessionsController < HiringStaff::BaseController
   def not_authorised
     Auditor::Audit.new(nil, 'dfe-sign-in.authorisation.failure', current_session_id).log_without_association
     Rails.logger.warn("Hiring staff not authorised: #{oid} for school: #{selected_school_urn}")
-    flash[:hidden] = identifier
-    redirect_to page_path('user-not-authorised')
+    @identifier = identifier
+    render 'user-not-authorised'
   end
 
   def update_session(school_urn, permissions)

--- a/app/views/hiring_staff/sign_in/dfe/sessions/user-not-authorised.html.haml
+++ b/app/views/hiring_staff/sign_in/dfe/sessions/user-not-authorised.html.haml
@@ -1,0 +1,10 @@
+- content_for :page_title_prefix do
+  =t('static_pages.not_authorised.title')
+
+.govuk-grid-row
+
+  .govuk-grid-column-two-thirds
+    %h1.govuk-heading-xl=t('static_pages.not_authorised.title')
+
+    -t('static_pages.not_authorised.with_email.text', email: @identifier, signin_url: "<a href='https://profile.signin.education.gov.uk/' class='govuk-link'>https://profile.signin.education.gov.uk/</a>", blog_url: "<a href='https://dfedigital.blog.gov.uk/2018/09/21/how-were-rolling-out-our-search-and-listing-service-to-more-schools-to-support-their-teacher-recruitment-needs/' class='govuk-link'>blog on the service's phased roll-out</a>", mailto_url: "<a href='mailto:teachingjobs@digital.education.gov.uk', class='govuk-link'>teachingjobs@digital.education.gov.uk</a>").each do |p|
+      %p=p.html_safe

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -56,8 +56,9 @@
 
       %main#main-content.govuk-main-wrapper.app-main-class{role: "main"}
         - flash.each do |name, msg|
-          %div{class: "flash #{name}"}
-            %span= msg
+          - unless name == 'hidden'
+            %div{class: "flash #{name}"}
+              %span= msg
 
         = yield
 

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -56,9 +56,8 @@
 
       %main#main-content.govuk-main-wrapper.app-main-class{role: "main"}
         - flash.each do |name, msg|
-          - unless name == 'hidden'
-            %div{class: "flash #{name}"}
-              %span= msg
+          %div{class: "flash #{name}"}
+            %span= msg
 
         = yield
 

--- a/app/views/pages/user-not-authorised.html.haml
+++ b/app/views/pages/user-not-authorised.html.haml
@@ -6,5 +6,9 @@
   .govuk-grid-column-two-thirds
     %h1.govuk-heading-xl=t('static_pages.not_authorised.title')
 
-    -t('static_pages.not_authorised.text').each do |p|
-      %p=p.html_safe
+    -if flash[:hidden]&.present?
+      -t('static_pages.not_authorised.with_email.text', email: flash[:hidden]).each do |p|
+        %p=p.html_safe
+    -else
+      -t('static_pages.not_authorised.without_email.text').each do |p|
+        %p=p.html_safe

--- a/app/views/pages/user-not-authorised.html.haml
+++ b/app/views/pages/user-not-authorised.html.haml
@@ -7,8 +7,8 @@
     %h1.govuk-heading-xl=t('static_pages.not_authorised.title')
 
     -if flash[:hidden]&.present?
-      -t('static_pages.not_authorised.with_email.text', email: flash[:hidden]).each do |p|
+      -t('static_pages.not_authorised.with_email.text', email: @identifier, signin_url: "<a href='https://profile.signin.education.gov.uk/' class='govuk-link'>https://profile.signin.education.gov.uk/</a>", blog_url: "<a href='https://dfedigital.blog.gov.uk/2018/09/21/how-were-rolling-out-our-search-and-listing-service-to-more-schools-to-support-their-teacher-recruitment-needs/' class='govuk-link'>blog on the service's phased roll-out</a>", mailto_url: "<a href='mailto:teachingjobs@digital.education.gov.uk', class='govuk-link'>teachingjobs@digital.education.gov.uk</a>").each do |p|
         %p=p.html_safe
     -else
-      -t('static_pages.not_authorised.without_email.text').each do |p|
+      -t('static_pages.not_authorised.without_email.text', mailto_url: "<a href='mailto:teachingjobs@digital.education.gov.uk', class='govuk-link'>teachingjobs@digital.education.gov.uk</a>").each do |p|
         %p=p.html_safe

--- a/app/views/pages/user-not-authorised.html.haml
+++ b/app/views/pages/user-not-authorised.html.haml
@@ -6,9 +6,5 @@
   .govuk-grid-column-two-thirds
     %h1.govuk-heading-xl=t('static_pages.not_authorised.title')
 
-    -if flash[:hidden]&.present?
-      -t('static_pages.not_authorised.with_email.text', email: @identifier, signin_url: "<a href='https://profile.signin.education.gov.uk/' class='govuk-link'>https://profile.signin.education.gov.uk/</a>", blog_url: "<a href='https://dfedigital.blog.gov.uk/2018/09/21/how-were-rolling-out-our-search-and-listing-service-to-more-schools-to-support-their-teacher-recruitment-needs/' class='govuk-link'>blog on the service's phased roll-out</a>", mailto_url: "<a href='mailto:teachingjobs@digital.education.gov.uk', class='govuk-link'>teachingjobs@digital.education.gov.uk</a>").each do |p|
-        %p=p.html_safe
-    -else
-      -t('static_pages.not_authorised.without_email.text', mailto_url: "<a href='mailto:teachingjobs@digital.education.gov.uk', class='govuk-link'>teachingjobs@digital.education.gov.uk</a>").each do |p|
-        %p=p.html_safe
+    -t('static_pages.not_authorised.without_email.text', mailto_url: "<a href='mailto:teachingjobs@digital.education.gov.uk', class='govuk-link'>teachingjobs@digital.education.gov.uk</a>").each do |p|
+      %p=p.html_safe

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -276,17 +276,17 @@ en:
       title: You are not yet authorised to use the Teaching Jobs service
       without_email:
         text:
-          - You can register your interest to use the service by emailing <a href='mailto:teachingjobs@digital.education.gov.uk', class='govuk-link'>teachingjobs@digital.education.gov.uk</a>. It is currently open to schools in Cambridgeshire and the North East but will be rolled out in phases to other areas across England.
+          - You can register your interest to use the service by emailing %{mailto_url}. It is currently open to schools in Cambridgeshire and the North East but will be rolled out in phases to other areas across England.
 
           - If your Teaching Jobs account has already been set up but you are unable to sign in, email the same address with "help" in the subject line.
       with_email:
         text:
-          - You've tried to sign in with %{email}, which is not associated with a Teaching Jobs account. If you have an account associated with another email, please first sign %{email} out of DfE Sign-in. Then sign into Teaching Jobs at <a href='https://profile.signin.education.gov.uk/' class='govuk-link'>https://profile.signin.education.gov.uk/</a> using your authorised email.
+          - You've tried to sign in with %{email}, which is not associated with a Teaching Jobs account. If you have an account associated with another email, please first sign %{email} out of DfE Sign-in. Then sign into Teaching Jobs at %{signin_url} using your authorised email.
 
           - If you don't have a Teaching Jobs account you will need to wait for an invitation for one. Invitations are being sent out gradually, by region. When you have accepted the invitation and created your account you will be able to start listing roles at your school.
 
-          - Read the Teaching Jobs <a href='https://dfedigital.blog.gov.uk/2018/09/21/how-were-rolling-out-our-search-and-listing-service-to-more-schools-to-support-their-teacher-recruitment-needs/' class='govuk-link'>blog on the service's phased roll-out</a> to learn when schools in your area will be invited.
+          - Read the Teaching Jobs %{blog_url} to learn when schools in your area will be invited.
 
-          - If your Teaching Jobs account has already been set up but you are unable to sign in, email <a href='mailto:teachingjobs@digital.education.gov.uk', class='govuk-link'>teachingjobs@digital.education.gov.uk</a> with "help" in the subject line.
+          - If your Teaching Jobs account has already been set up but you are unable to sign in, email %{mailto_url} with "help" in the subject line.
   beta_banner:
     line_1: 'This service is in development and lists jobs in select areas of England. It will be %{link} to new areas, so check back regularly for new listings.'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -274,9 +274,19 @@ en:
   static_pages:
     not_authorised:
       title: You are not yet authorised to use the Teaching Jobs service
-      text:
-        - You can register your interest to use the service by emailing <a href='mailto:teachingjobs@digital.education.gov.uk', class='govuk-link'>teachingjobs@digital.education.gov.uk</a>. It is currently open to schools in Cambridgeshire and the North East but will be rolled out in phases to other areas across England.
+      without_email:
+        text:
+          - You can register your interest to use the service by emailing <a href='mailto:teachingjobs@digital.education.gov.uk', class='govuk-link'>teachingjobs@digital.education.gov.uk</a>. It is currently open to schools in Cambridgeshire and the North East but will be rolled out in phases to other areas across England.
 
-        - If your Teaching Jobs account has already been set up but you are unable to sign in, email the same address with “help” in the subject line.
+          - If your Teaching Jobs account has already been set up but you are unable to sign in, email the same address with "help" in the subject line.
+      with_email:
+        text:
+          - You've tried to sign in with %{email}, which is not associated with a Teaching Jobs account. If you have an account associated with another email, please first sign %{email} out of DfE Sign-in. Then sign into Teaching Jobs at <a href='https://profile.signin.education.gov.uk/' class='govuk-link'>https://profile.signin.education.gov.uk/</a> using your authorised email.
+
+          - If you don't have a Teaching Jobs account you will need to wait for an invitation for one. Invitations are being sent out gradually, by region. When you have accepted the invitation and created your account you will be able to start listing roles at your school.
+
+          - Read the Teaching Jobs <a href='https://dfedigital.blog.gov.uk/2018/09/21/how-were-rolling-out-our-search-and-listing-service-to-more-schools-to-support-their-teacher-recruitment-needs/' class='govuk-link'>blog on the service's phased roll-out</a> to learn when schools in your area will be invited.
+
+          - If your Teaching Jobs account has already been set up but you are unable to sign in, email <a href='mailto:teachingjobs@digital.education.gov.uk', class='govuk-link'>teachingjobs@digital.education.gov.uk</a> with "help" in the subject line.
   beta_banner:
     line_1: 'This service is in development and lists jobs in select areas of England. It will be %{link} to new areas, so check back regularly for new listings.'

--- a/spec/features/hiring_staff_can_sign_in_with_dfe_spec.rb
+++ b/spec/features/hiring_staff_can_sign_in_with_dfe_spec.rb
@@ -19,13 +19,14 @@ RSpec.shared_examples 'a successful sign in' do
 end
 
 RSpec.shared_examples 'a failed sign in' do |options|
-  scenario 'it does not sign-in the user' do
+  scenario 'it does not sign-in the user, and tells the user what to do' do
     visit root_path
 
     click_on(I18n.t('nav.sign_in'))
     click_on(I18n.t('sign_in.link'))
 
     expect(page).to have_content(I18n.t('static_pages.not_authorised.title'))
+    expect(page).to have_content(options['email'])
     within('.app-navigation') { expect(page).not_to have_content(I18n.t('nav.school_page_link')) }
   end
 
@@ -177,7 +178,10 @@ RSpec.feature 'Hiring staff signing-in with DfE Sign In' do
         .and_return(AuthHelpers::MockPermissions.new(mock_authorisation_response))
     end
 
-    it_behaves_like 'a failed sign in', dsi_id: 'an-unknown-oid', school_urn: '110627'
+    it_behaves_like 'a failed sign in',
+                    dsi_id: 'an-unknown-oid',
+                    school_urn: '110627',
+                    email: 'another_email@example.com'
   end
 
   context 'with valid credentials and no organisation in DfE Sign In but existing permissions' do
@@ -212,6 +216,9 @@ RSpec.feature 'Hiring staff signing-in with DfE Sign In' do
         .and_return(AuthHelpers::MockPermissions.new(mock_authorisation_response))
     end
 
-    it_behaves_like 'a failed sign in', dsi_id: 'an-unknown-oid', school_urn: nil
+    it_behaves_like 'a failed sign in',
+                    dsi_id: 'an-unknown-oid',
+                    school_urn: nil,
+                    email: 'an-email@example.com'
   end
 end


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/wlbtv9F1/466-hiring-staff-who-sign-in-but-see-the-not-authorised-page-are-given-help

## Changes in this PR:

Vary the text on the "not authorised" page depending on whether the person accessing the page is authenticated (but not authorised) or not authenticated. 

If an unauthorised user, show copy giving them instructions on how to sign out of the unauthorised email address and re-sign in.

If the user is completely unauthenticated, show the previous existing message.

## Screenshots of UI changes:

Unauthorised:

<img width="689" alt="screen shot 2018-10-11 at 11 56 12" src="https://user-images.githubusercontent.com/1089521/46799566-02ec0c00-cd4d-11e8-99ee-f20c78b50ea1.png">

Unauthenticated:

<img width="681" alt="screen shot 2018-10-11 at 11 56 28" src="https://user-images.githubusercontent.com/1089521/46799576-08e1ed00-cd4d-11e8-9ea4-31c27900ac4a.png">
