### PR TITLE
(487) Display detailed error messages on review page if vacancy publish fails

### DIFF
--- a/app/controllers/hiring_staff/vacancies/application_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/application_controller.rb
@@ -49,6 +49,10 @@ class HiringStaff::Vacancies::ApplicationController < HiringStaff::BaseControlle
     school_job_review_path(school_id: school.id, job_id: vacancy.id)
   end
 
+  def review_path_with_errors(vacancy)
+    school_job_review_path(school_id: school.id, job_id: vacancy.id, anchor: 'errors', source: 'publish')
+  end
+
   def redirect_unless_vacancy_session_id
     redirect_to job_specification_school_job_path(school_id: school.id) unless session_vacancy_id
   end

--- a/app/controllers/hiring_staff/vacancies/application_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/application_controller.rb
@@ -50,7 +50,7 @@ class HiringStaff::Vacancies::ApplicationController < HiringStaff::BaseControlle
   end
 
   def review_path_with_errors(vacancy)
-    school_job_review_path(school_id: school.id, job_id: vacancy.id, anchor: 'errors', source: 'publish')
+    school_job_review_path(job_id: vacancy.id, anchor: 'errors', source: 'publish')
   end
 
   def redirect_unless_vacancy_session_id

--- a/app/controllers/hiring_staff/vacancies/publish_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/publish_controller.rb
@@ -9,7 +9,7 @@ class HiringStaff::Vacancies::PublishController < HiringStaff::Vacancies::Applic
       reset_session_vacancy!
       redirect_to school_job_summary_path(vacancy.id)
     else
-      redirect_to review_path(vacancy), notice: I18n.t('errors.jobs.unable_to_publish')
+      redirect_to review_path_with_errors(vacancy), notice: I18n.t('errors.jobs.unable_to_publish')
     end
   end
 

--- a/app/controllers/hiring_staff/vacancies_controller.rb
+++ b/app/controllers/hiring_staff/vacancies_controller.rb
@@ -31,6 +31,8 @@ class HiringStaff::VacanciesController < HiringStaff::Vacancies::ApplicationCont
     store_vacancy_attributes(vacancy.attributes.compact)
 
     @vacancy = VacancyPresenter.new(vacancy)
+
+    @vacancy.valid? if params[:source]&.eql?('publish')
   end
 
   def destroy

--- a/app/presenters/vacancy_presenter.rb
+++ b/app/presenters/vacancy_presenter.rb
@@ -85,6 +85,11 @@ class VacancyPresenter < BasePresenter
     model.working_pattern.upcase
   end
 
+  def review_page_title
+    page_title = I18n.t('jobs.review_page_title', school: model.school.name)
+    "#{model.errors.present? ? 'Error: ' : ''}#{page_title}"
+  end
+
   private
 
   def pay_scale_range_label

--- a/app/views/hiring_staff/vacancies/review.html.haml
+++ b/app/views/hiring_staff/vacancies/review.html.haml
@@ -1,4 +1,4 @@
-- content_for :page_title_prefix, "#{@vacancy.errors.present? ? 'Error: ' : ''}Review the job details — Publish a job for #{@school.name}"
+- content_for :page_title_prefix, @vacancy.review_page_title
 =render partial: 'school_vacancy_breadcrumb'
 
 .govuk-grid-row

--- a/app/views/hiring_staff/vacancies/review.html.haml
+++ b/app/views/hiring_staff/vacancies/review.html.haml
@@ -1,5 +1,4 @@
-- content_for :page_title_prefix, "Review the job details — Publish a job for #{@school.name}"
-
+- content_for :page_title_prefix, "#{@vacancy.errors.present? ? 'Error: ' : ''}Review the job details — Publish a job for #{@school.name}"
 =render partial: 'school_vacancy_breadcrumb'
 
 .govuk-grid-row
@@ -8,6 +7,7 @@
       = t('jobs.review_heading', school: @vacancy.school.name)
     %p.govuk-body-l
       = t('jobs.review')
+    = render 'hiring_staff/vacancies/error_messages', errors: @vacancy.errors
 
 .vacancy.govuk-grid-row
   .govuk-grid-column-two-thirds
@@ -23,7 +23,7 @@
     %dl.app-check-your-answers.app-check-your-answers--short
 
       .app-check-your-answers__contents
-        %dt.app-check-your-answers__question
+        %dt.app-check-your-answers__question#job_title
           = t('jobs.job_title')
         %dd.app-check-your-answers__answer
           = @vacancy.job_title
@@ -31,7 +31,7 @@
           = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'job_title'), 'aria-label': t('jobs.aria_labels.change_job_title'), class: 'govuk-link'
 
       .app-check-your-answers__contents
-        %dt.app-check-your-answers__question
+        %dt.app-check-your-answers__question#description
           = t('jobs.description')
         %dd.app-check-your-answers__answer
           = @vacancy.job_description
@@ -39,7 +39,7 @@
           = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'job_description'), 'aria-label': t('jobs.aria_labels.change_job_description'), class: 'govuk-link'
 
       .app-check-your-answers__contents
-        %dt.app-check-your-answers__question
+        %dt.app-check-your-answers__question#main_subject
           = t('jobs.main_subject')
         %dd.app-check-your-answers__answer
           = @vacancy.main_subject
@@ -47,7 +47,7 @@
           = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'subject'), 'aria-label': t('jobs.aria_labels.change_main_subject'), class: 'govuk-link'
 
       .app-check-your-answers__contents
-        %dt.app-check-your-answers__question
+        %dt.app-check-your-answers__question#pay_scale
           = t('jobs.pay_scale')
         %dd.app-check-your-answers__answer
           =@vacancy.pay_scale_range
@@ -55,7 +55,7 @@
           = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'pay_scale_range'), 'aria-label': t('jobs.aria_labels.change_pay_scale'), class: 'govuk-link'
 
       .app-check-your-answers__contents
-        %dt.app-check-your-answers__question
+        %dt.app-check-your-answers__question#salary_range
           = t('jobs.salary_range')
         %dd.app-check-your-answers__answer
           = @vacancy.salary_range("to")
@@ -63,7 +63,7 @@
           = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'salary_range'), 'aria-label': t('jobs.aria_labels.change_salary_range'), class: 'govuk-link'
 
       .app-check-your-answers__contents
-        %dt.app-check-your-answers__question
+        %dt.app-check-your-answers__question#working_pattern
           = t('jobs.working_pattern')
         %dd.app-check-your-answers__answer
           = @vacancy.working_pattern.humanize
@@ -71,7 +71,7 @@
           = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'working_pattern'), 'aria-label': t('jobs.aria_labels.change_working_pattern'), class: 'govuk-link'
 
       .app-check-your-answers__contents
-        %dt.app-check-your-answers__question
+        %dt.app-check-your-answers__question#newly_qualified_teacher
           = t('jobs.newly_qualified_teacher')
         %dd.app-check-your-answers__answer
           = @vacancy.newly_qualified_teacher
@@ -79,7 +79,7 @@
           = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'newly_qualified_teacher'), 'aria-label': t('jobs.aria_labels.newly_qualified_teacher'), class: 'govuk-link'
 
       .app-check-your-answers__contents
-        %dt.app-check-your-answers__question
+        %dt.app-check-your-answers__question#flexible_working
           = t('jobs.flexible_working')
         %dd.app-check-your-answers__answer
           = @vacancy.flexible_working
@@ -87,7 +87,7 @@
           = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'flexible_working'), 'aria-label': t('jobs.aria_labels.change_flexible_working'), class: 'govuk-link'
 
       .app-check-your-answers__contents
-        %dt.app-check-your-answers__question
+        %dt.app-check-your-answers__question#benefits
           = t('jobs.benefits')
         %dd.app-check-your-answers__answer
           = @vacancy.benefits
@@ -95,7 +95,7 @@
           = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'benefits'), 'aria-label': t('jobs.aria_labels.change_employee_benefits'), class: 'govuk-link'
 
       .app-check-your-answers__contents
-        %dt.app-check-your-answers__question
+        %dt.app-check-your-answers__question#weekly_hours
           = t('jobs.weekly_hours')
         %dd.app-check-your-answers__answer
           = @vacancy.weekly_hours
@@ -103,7 +103,7 @@
           = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'weekly_hours'), 'aria-label': t('jobs.aria_labels.change_weekly_hours'), class: 'govuk-link'
 
       .app-check-your-answers__contents
-        %dt.app-check-your-answers__question
+        %dt.app-check-your-answers__question#leadership_level
           = t('jobs.leadership_level')
         %dd.app-check-your-answers__answer
           - if @vacancy.leadership
@@ -112,7 +112,7 @@
           = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'leadership'), 'aria-label': t('jobs.aria_labels.change_leadership_level'), class: 'govuk-link'
 
       .app-check-your-answers__contents
-        %dt.app-check-your-answers__question
+        %dt.app-check-your-answers__question#starts_on
           = t('jobs.starts_on')
         %dd.app-check-your-answers__answer
           = format_date @vacancy.starts_on
@@ -120,7 +120,7 @@
           = link_to t('buttons.change'), job_specification_school_job_path(anchor: 'starts_on'), 'aria-label': t('jobs.aria_labels.change_expected_start_date'), class: 'govuk-link'
 
       .app-check-your-answers__contents
-        %dt.app-check-your-answers__question
+        %dt.app-check-your-answers__question#ends_on
           = t('jobs.ends_on')
         %dd.app-check-your-answers__answer
           = format_date @vacancy.ends_on
@@ -139,7 +139,7 @@
     %dl.app-check-your-answers.app-check-your-answers--short
 
       .app-check-your-answers__contents
-        %dt.app-check-your-answers__question
+        %dt.app-check-your-answers__question#education
           = t('jobs.education')
         %dd.app-check-your-answers__answer
           = @vacancy.education
@@ -147,7 +147,7 @@
           = link_to t('buttons.change'), candidate_specification_school_job_path(anchor: 'education'), 'aria-label': t('jobs.aria_labels.change_essential_educational_requirements'), class: 'govuk-link'
 
       .app-check-your-answers__contents
-        %dt.app-check-your-answers__question
+        %dt.app-check-your-answers__question#qualifications
           = t('jobs.qualifications')
         %dd.app-check-your-answers__answer
           = @vacancy.qualifications
@@ -155,7 +155,7 @@
           = link_to t('buttons.change'), candidate_specification_school_job_path(anchor: 'qualifications'), 'aria-label': t('jobs.aria_labels.change_essential_qualifications'), class: 'govuk-link'
 
       .app-check-your-answers__contents
-        %dt.app-check-your-answers__question
+        %dt.app-check-your-answers__question#experience
           = t('jobs.experience')
         %dd.app-check-your-answers__answer
           = @vacancy.experience
@@ -173,7 +173,7 @@
     %dl.app-check-your-answers.app-check-your-answers--short
 
       .app-check-your-answers__contents
-        %dt.app-check-your-answers__question
+        %dt.app-check-your-answers__question#contact_email
           = t('jobs.contact_email')
         %dd.app-check-your-answers__answer
           - if @vacancy.contact_email.present?
@@ -184,7 +184,7 @@
             %span= t('jobs.no_contact_email')
 
       .app-check-your-answers__contents
-        %dt.app-check-your-answers__question
+        %dt.app-check-your-answers__question#application_link
           = t('jobs.application_link')
         %dd.app-check-your-answers__answer
           - if @vacancy.application_link.present?
@@ -199,7 +199,7 @@
           = link_to t('buttons.change'), application_details_school_job_path(anchor: 'application_link'), 'aria-label': t('jobs.aria_labels.change_application_link_URL'), class: 'govuk-link'
 
       .app-check-your-answers__contents
-        %dt.app-check-your-answers__question
+        %dt.app-check-your-answers__question#publish_on
           = t('jobs.publication_date')
         %dd.app-check-your-answers__answer
           = format_date @vacancy.publish_on
@@ -207,7 +207,7 @@
           = link_to t('buttons.change'), application_details_school_job_path(anchor: 'publish_on'), 'aria-label': t('jobs.aria_labels.change_date_role_will_be_listed'), class: 'govuk-link'
 
       .app-check-your-answers__contents
-        %dt.app-check-your-answers__question
+        %dt.app-check-your-answers__question#expires_on
           = t('jobs.deadline_date')
         %dd.app-check-your-answers__answer
           = format_date @vacancy.expires_on

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -66,6 +66,7 @@ en:
     salary_range: 'Salary range'
     per_year: 'per year'
     publish_heading: 'Publish a job for %{school}'
+    review_page_title: 'Review the job details — Publish a job for %{school}'
     review_heading: 'Review the job for %{school}'
     edit_heading: 'Edit job for %{school}'
     job_specification: 'Job specification'

--- a/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
@@ -363,15 +363,24 @@ RSpec.feature 'Creating a vacancy' do
     end
 
     context '#publish' do
-      scenario 'can not be published unless the details are valid' do
+      scenario 'cannot be published unless the details are valid' do
         vacancy = create(:vacancy, :draft, school_id: school.id, publish_on: Time.zone.tomorrow)
         vacancy.assign_attributes qualifications: nil
+        vacancy.assign_attributes education: nil
+        vacancy.assign_attributes contact_email: nil
+        vacancy.assign_attributes expires_on: Time.zone.yesterday
         vacancy.save(validate: false)
 
         visit school_job_review_path(vacancy.id)
         click_on 'Confirm and submit job'
 
         expect(page).to have_content(I18n.t('errors.jobs.unable_to_publish'))
+        expect(page).to have_content(I18n.t('activerecord.errors.models.vacancy.attributes.qualifications.blank'))
+        expect(page).to have_content(I18n.t('activerecord.errors.models.vacancy.attributes.education.blank'))
+        expect(page).to have_content(I18n.t('activerecord.errors.models.vacancy.attributes.contact_email.blank'))
+        expect(page).to have_content(
+          I18n.t('activerecord.errors.models.vacancy.attributes.expires_on.before_publish_date')
+        )
       end
 
       scenario 'can be published at a later date' do
@@ -394,6 +403,7 @@ RSpec.feature 'Creating a vacancy' do
         click_on 'Confirm and submit job'
 
         expect(page).to have_content(I18n.t('errors.jobs.unable_to_publish'))
+        expect(page).to have_content(I18n.t('activerecord.errors.models.vacancy.attributes.publish_on.before_today'))
       end
 
       scenario 'displays the expiration date on the confirmation page' do


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/x14tp4v4/487-display-detailed-error-messages-if-vacancy-publication-fails

## Changes in this PR:

- Display detailed error messages on the review page if vacancy publish fails and each error message links to the relevant component on the page.

## Screenshots of UI changes:

### Before
<img width="1202" alt="screen shot 2018-10-11 at 14 12 53" src="https://user-images.githubusercontent.com/5323962/46806590-e73e3100-cd5f-11e8-99d7-ef6d17212c15.png">

### After
<img width="1034" alt="screen shot 2018-10-11 at 14 13 29" src="https://user-images.githubusercontent.com/5323962/46806615-f45b2000-cd5f-11e8-9b6d-10bae6bcf96e.png">
