### PR TITLE
(chore) (bug) Remove weekly_hours label on mobile if no weekly hours …

### DIFF
--- a/app/views/vacancies/_show.html+phone.haml
+++ b/app/views/vacancies/_show.html+phone.haml
@@ -37,7 +37,7 @@
       .app-check-your-answers__contents
         %dt.app-check-your-answers__question= t('jobs.working_pattern')
         %dd.app-check-your-answers__answer= @vacancy.working_pattern
-      - if @vacancy.part_time? && @vacancy.weekly_hours
+      - if @vacancy.part_time? && @vacancy.weekly_hours.present?
         .app-check-your-answers__contents
           %dt.app-check-your-answers__question= t('jobs.weekly_hours')
           %dd.app-check-your-answers__answer= @vacancy.weekly_hours


### PR DESCRIPTION
…present

## Trello card URL:

https://trello.com/b/vo4AYL7a/dfe-teaching-jobs-development

## Changes in this PR:

When working on https://github.com/dxw/teacher-vacancy-service/pull/550 I completely missed that there are separate templates for mobile, so I didn't remove the `weekly_hours` label from the mobile site when weekly hours are not set.

This PR is therefore a straight duplication of #550 in the mobile template. 
