### PR TITLE
(fix) add missing `REDIS_URL` to google_api container definition

### DIFF
--- a/google_api_rake_container_definition.json
+++ b/google_api_rake_container_definition.json
@@ -60,6 +60,10 @@
       {
         "name": "GOOGLE_ANALYTICS_PROFILE_ID",
         "value": "${google_analytics_profile_id}"
+      },
+      {
+        "name": "REDIS_URL",
+        "value": "${redis_url}"
       }
     ]
   }

--- a/terraform/modules/ecs/ecs.tf
+++ b/terraform/modules/ecs/ecs.tf
@@ -382,6 +382,7 @@ data "template_file" "vacancies_pageviews_refresh_cache_container_definition" {
     google_api_json_key          = "${replace(jsonencode(var.google_api_json_key), "/([\"\\\\])/", "\\$1")}"
     google_analytics_profile_id  = "${var.google_analytics_profile_id}"
     entrypoint                   = "${jsonencode(var.vacancies_pageviews_refresh_cache_task_command)}"
+    redis_url                    = "${var.redis_url}"
   }
 }
 


### PR DESCRIPTION
Fix for production release

## Changes in this PR:
Adds missing `REDIS_URL` variable to google_api's container definition
## Next steps:



- [x] Terraform deployment required?