### PR TITLE
(bug) Show correct share URL in clipboard link

### DIFF
--- a/app/views/hiring_staff/vacancies/_show.html.haml
+++ b/app/views/hiring_staff/vacancies/_show.html.haml
@@ -13,7 +13,7 @@
       .govuk-grid-column-one-half
         .share-url.mb1.display-none
           %h2.govuk-heading-m.mt0 Share this job
-          #{link_to t('jobs.view_public_link'), @vacancy.share_url, class: 'govuk-link', id: 'share-url', 'aria-label': t('jobs.view_public_link')}, or #{link_to t('jobs.copy_public_url'), '#', class: 'govuk-link copy-to-clipboard', 'data-clipboard-text': @vacancy.share_url, 'aria-label': t('jobs.copy_public_url')}
+          #{link_to t('jobs.view_public_link'), @vacancy.share_url, class: 'govuk-link', id: 'share-url', 'aria-label': t('jobs.view_public_link')}, or #{link_to t('jobs.copy_public_url'), @vacancy.share_url, class: 'govuk-link copy-to-clipboard', 'data-clipboard-text': @vacancy.share_url, 'aria-label': t('jobs.copy_public_url')}
         .share-url-no-js.mb1
           %h2.govuk-heading-s.mt0 Share this job
           #{link_to "#{t('jobs.view_public_link')} (#{@vacancy.share_url})", job_path(@vacancy), class: 'govuk-link', id: 'share-url'}


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/SFubdNnv/506-copying-a-public-job-listing-url-uses-the-internal-url

## Changes in this PR:

The "copy the public URL to the clipboard" link in the Share page appeared to be showing the internal URL for the job, but in reality the URL was "#", so the URL we saw on hover was simply the URL to the current page. 

I have amended this URL to be the actual public share URL. 

This also seems to have fixed https://trello.com/c/zS86O5L4/503-bug-copying-a-job-listing-link-doesnt-change-clipboard but I'm not sure how because `clipboard.js` and `share_url.js` are slightly mysterious to me! But copying the link to the clipboard on click seems to work now 🤷‍♀️ 