### PR TITLE
[fix] only refresh analytics data for listed non expired vacancies

### DIFF
--- a/lib/tasks/vacancies_pageviews_refresh_cache.rake
+++ b/lib/tasks/vacancies_pageviews_refresh_cache.rake
@@ -1,8 +1,8 @@
 namespace :vacancies do
-  desc 'Refreshes the cached pageviews for listed job vacancies'
+  desc 'Refreshes the cached pageviews for listed non expired job vacancies'
   namespace :pageviews do
     task refresh_cache: :environment do
-      Vacancy.listed.pluck(:id).each do |vacancy_id|
+      Vacancy.listed.applicable.pluck(:id).each do |vacancy_id|
         CacheTotalAnalyticsPageviewsQueueJob.perform_later(vacancy_id)
         CacheWeeklyAnalyticsPageviewsQueueJob.perform_later(vacancy_id)
       end

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -75,6 +75,8 @@ FactoryBot.define do
     end
 
     trait :expired do
+      status { :published }
+      sequence(:slug) { |n| "slug-#{n}" }
       publish_on { Faker::Time.backward(14) }
       expires_on { Faker::Time.backward(7) }
     end

--- a/spec/lib/tasks/vacancies_pageviews_refresh_cache_rake_spec.rb
+++ b/spec/lib/tasks/vacancies_pageviews_refresh_cache_rake_spec.rb
@@ -1,8 +1,9 @@
 require 'rails_helper'
 RSpec.describe 'rake vacancies:pageviews:refresh_cache', type: :task do
-  it 'Submits job publication transactions for the previous day' do
+  it 'Queues jobs to update google analytic information on active and not expired vacancies' do
     active_vacancies = create_list(:vacancy, 10, :published)
     draft_vacancies = create_list(:vacancy, 5, :draft)
+    expired_vacancies = build_list(:vacancy, 5, :expired).each { |v| v.save(validate: false) }
 
     active_vacancies.each do |vacancy|
       expect(CacheWeeklyAnalyticsPageviewsQueueJob).to receive(:perform_later).with(vacancy.id)
@@ -10,6 +11,11 @@ RSpec.describe 'rake vacancies:pageviews:refresh_cache', type: :task do
     end
 
     draft_vacancies.each do |vacancy|
+      expect(CacheWeeklyAnalyticsPageviewsQueueJob).to_not receive(:perform_later).with(vacancy.id)
+      expect(CacheTotalAnalyticsPageviewsQueueJob).to_not receive(:perform_later).with(vacancy.id)
+    end
+
+    expired_vacancies.each do |vacancy|
       expect(CacheWeeklyAnalyticsPageviewsQueueJob).to_not receive(:perform_later).with(vacancy.id)
       expect(CacheTotalAnalyticsPageviewsQueueJob).to_not receive(:perform_later).with(vacancy.id)
     end


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/CuwMQb6z/505-bug-restrict-vacancies-updated-with-google-information-to-currently-published-and-not-expired

## Changes in this PR:
Only update cached view data from Google Analytics for published non expired vacancies. Google Analytics API requests are limited and we don't want to end up doing thousands of requests daily for no reason as this may have an impact on the allowed service quota and/or request costs.
