### PR TITLE
[fix] ensure that only published non expired vacancies are included in sitemap

### DIFF
--- a/app/controllers/sitemap_controller.rb
+++ b/app/controllers/sitemap_controller.rb
@@ -1,6 +1,6 @@
 class SitemapController < ApplicationController
   def show
-    map = XmlSitemap::Map.new(DOMAIN) do |m|
+    map = XmlSitemap::Map.new(DOMAIN, secure: true) do |m|
       Vacancy.listed.applicable.find_each do |vacancy|
         m.add job_path(vacancy, protocol: 'https'), updated: vacancy.updated_at,
                                                     expires: vacancy.expires_on,

--- a/app/controllers/sitemap_controller.rb
+++ b/app/controllers/sitemap_controller.rb
@@ -1,7 +1,7 @@
 class SitemapController < ApplicationController
   def show
     map = XmlSitemap::Map.new(DOMAIN) do |m|
-      Vacancy.listed.find_each do |vacancy|
+      Vacancy.listed.applicable.find_each do |vacancy|
         m.add job_path(vacancy, protocol: 'https'), updated: vacancy.updated_at,
                                                     expires: vacancy.expires_on,
                                                     period: 'hourly', priority: 0.7

--- a/spec/features/application_sitemap_spec.rb
+++ b/spec/features/application_sitemap_spec.rb
@@ -3,6 +3,7 @@ RSpec.feature 'Application sitemap', sitemap: true do
   context 'sitemap.xml' do
     scenario 'generates a sitemap of the application' do
       published_jobs = create_list(:vacancy, 4, :published)
+      build_list(:vacancy, 2, :expired).each { |j| j.save(validate: false) }
 
       visit sitemap_path(format: :xml)
       document = Nokogiri::XML::Document.parse(body)

--- a/spec/features/application_sitemap_spec.rb
+++ b/spec/features/application_sitemap_spec.rb
@@ -4,24 +4,27 @@ RSpec.feature 'Application sitemap', sitemap: true do
     scenario 'generates a sitemap of the application' do
       published_jobs = create_list(:vacancy, 4, :published)
       build_list(:vacancy, 2, :expired).each { |j| j.save(validate: false) }
+      stub_const('DOMAIN', 'localhost:3000')
 
       visit sitemap_path(format: :xml)
       document = Nokogiri::XML::Document.parse(body)
       nodes = document.search('url')
 
       expect(nodes.count).to eq(9)
-      expect(nodes.search("loc[text()='#{root_url}']").text).to eq(root_url)
+      expect(nodes.search("loc[text()='#{root_url(protocol: 'https')}']").text)
+        .to eq(root_url(protocol: 'https'))
 
       published_jobs.each do |job|
-        expect(nodes.search("loc:contains('#{job_url(job)}')").text).to eq(job_url(job))
+        expect(nodes.search("loc:contains('#{job_path(job, protocol: 'https')}')").text)
+          .to eq(job_url(job, protocol: 'https'))
       end
 
-      expect(nodes.search("loc:contains('#{page_url('terms-and-conditions')}')").text)
-        .to eq(page_url('terms-and-conditions'))
-      expect(nodes.search("loc:contains('#{page_url('cookies')}')").text)
-        .to eq(page_url('cookies'))
-      expect(nodes.search("loc:contains('#{page_url('privacy-policy')}')").text)
-        .to eq(page_url('privacy-policy'))
+      expect(nodes.search("loc:contains('#{page_url('terms-and-conditions', protocol: 'https')}')").text)
+        .to eq(page_url('terms-and-conditions', protocol: 'https'))
+      expect(nodes.search("loc:contains('#{page_url('cookies', protocol: 'https')}')").text)
+        .to eq(page_url('cookies', protocol: 'https'))
+      expect(nodes.search("loc:contains('#{page_url('privacy-policy', protocol: 'https')}')").text)
+        .to eq(page_url('privacy-policy', protocol: 'https'))
     end
   end
 end


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/mwY3kTX3/514-sitemap-should-also-only-include-published-but-not-expired-vacancies

## Changes in this PR:
- Only lists published non expired vacancies in generated sitemap. We want the crawler to know and keep our published vacancies up-to-date, not every single job that was ever published!
- Fix to ensure secure paths are linked 
