### PR TITLE
(fix) Amend fuzziness level on search

### DIFF
--- a/app/services/vacancy_search_builder.rb
+++ b/app/services/vacancy_search_builder.rb
@@ -169,7 +169,7 @@ class VacancySearchBuilder
         query: keyword,
         fields: %w[job_title^5 subject.name^3],
         operator: 'and',
-        fuzziness: 1,
+        fuzziness: 'AUTO',
       },
     }
   end

--- a/spec/services/vacancy_search_builder_spec.rb
+++ b/spec/services/vacancy_search_builder_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe VacancySearchBuilder do
           query: 'german',
           fields: %w[job_title^5 subject.name^3],
           operator: 'and',
-          fuzziness: 1
+          fuzziness: 'AUTO'
         },
       }
 


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/d5SobVtq/481-investigate-es-fuzziness-level-and-change-if-appropriate

## Changes in this PR:

As per the card, I have amended the fuzziness level on search to "AUTO", which seems to have fixed the "art/part time" issue while also ensuring "maht" returns results for "math"

Screenshots:

Job with "part time" in title:

<img width="990" alt="screen shot 2018-10-16 at 15 19 47" src="https://user-images.githubusercontent.com/1089521/47024545-d7588f80-d159-11e8-80b8-08800e4b0c9c.png">

Search for "art" which does not return job with "part time" in title:

<img width="974" alt="screen shot 2018-10-16 at 15 20 03" src="https://user-images.githubusercontent.com/1089521/47024589-edfee680-d159-11e8-8698-00515b4a9853.png">

Search for "maht" which returns a job with "math" in title:

<img width="1025" alt="screen shot 2018-10-16 at 15 38 10" src="https://user-images.githubusercontent.com/1089521/47024619-fb1bd580-d159-11e8-9ba4-6f2f944061d7.png">

