### PR TITLE
(fix) add missing AWS_ELASTICSEARCH_SECRET to worker container defini…

### DIFF
--- a/worker_container_definition.json
+++ b/worker_container_definition.json
@@ -78,6 +78,10 @@
       {
         "name": "GOOGLE_ANALYTICS_PROFILE_ID",
         "value": "${google_analytics_profile_id}"
+      },
+      {
+        "name": "AWS_ELASTICSEARCH_SECRET",
+        "value": "${aws_elasticsearch_secret}"
       }
     ]
   }


### PR DESCRIPTION
Fixed production worker issue

## Changes in this PR:
The missing key was causing ElasticSearch to break and resulted in the `TypeError: no implicit conversion of nil into String (Error)` logged on Rollbar.

Setting `AWS_ELASTICSEARCH_SECRET` key resolves the problem.

I also attempted to remove the `after_commit` callback and to only trigger the document index update via the controller but that ended up causing version conflict issues as the document index was out of date. Ensuring the update document is always called is necessary so the `after_commit` trigger in the vacancy model is required.

This has been verified on Edge.