### PR TITLE
(fix) Remove async defer attributes from Google maps API link

### DIFF
--- a/app/views/vacancies/_show.html.haml
+++ b/app/views/vacancies/_show.html.haml
@@ -50,7 +50,7 @@
                                                             lat: @vacancy.school_geolocation.x,
                                                             lng: @vacancy.school_geolocation.y }
 
-      %script{async: true, defer: true, src: "https://maps.googleapis.com/maps/api/js?key=#{ENV['GOOGLE_MAPS_API_KEY']}&callback=initMap"}
+      %script{src: "https://maps.googleapis.com/maps/api/js?key=#{ENV['GOOGLE_MAPS_API_KEY']}&callback=initMap"}
 
   .govuk-grid-column-one-third
     %aside.vacancy--metadata


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/zS86O5L4/503-bug-copying-a-job-listing-link-doesnt-change-clipboard

## Changes in this PR:

The async defer attributes were causing the Google maps API to be included in the page multiple times. See https://stackoverflow.com/questions/33115375/prevent-google-maps-js-executing-multiple-times-caused-by-rails-turbolinks
