### PR TITLE
[Fix] Resolve clipboardjs not working unless refreshed

### DIFF
--- a/app/assets/javascripts/share_url.js
+++ b/app/assets/javascripts/share_url.js
@@ -1,4 +1,4 @@
-$(document).ready(function() {
+$(document).on('turbolinks:load', function(){
   new ClipboardJS('.copy-to-clipboard');
 
   $('.copy-to-clipboard').click(function(event) {

--- a/app/views/hiring_staff/vacancies/_show.html.haml
+++ b/app/views/hiring_staff/vacancies/_show.html.haml
@@ -83,7 +83,7 @@
                                                               lat: @vacancy.school_geolocation.x,
                                                               lng: @vacancy.school_geolocation.y }
 
-        %script{async: true, defer: true, src: "https://maps.googleapis.com/maps/api/js?key=#{ENV['GOOGLE_MAPS_API_KEY']}&callback=initMap"}
+        %script{async: true, defer: true, src: "https://maps.googleapis.com/maps/api/js?key=#{ENV['GOOGLE_MAPS_API_KEY']}&callback=initMap", 'data-turbolinks-eval': 'false'}
 
     .govuk-grid-column-one-third
       %aside.vacancy--metadata

--- a/app/views/hiring_staff/vacancies/_show.html.haml
+++ b/app/views/hiring_staff/vacancies/_show.html.haml
@@ -13,7 +13,7 @@
       .govuk-grid-column-one-half
         .share-url.mb1.display-none
           %h2.govuk-heading-m.mt0 Share this job
-          #{link_to t('jobs.view_public_link'), @vacancy.share_url, class: 'govuk-link', id: 'share-url', 'aria-label': t('jobs.view_public_link')}, or #{link_to t('jobs.copy_public_url'), @vacancy.share_url, class: 'govuk-link copy-to-clipboard', 'data-clipboard-text': @vacancy.share_url, 'aria-label': t('jobs.copy_public_url')}
+          #{link_to t('jobs.view_public_link'), @vacancy.share_url, class: 'govuk-link', id: 'share-url', 'aria-label': t('jobs.view_public_link')}, or #{link_to t('jobs.copy_public_url'), '#', class: 'govuk-link copy-to-clipboard', 'data-clipboard-text': @vacancy.share_url, 'aria-label': t('jobs.copy_public_url')}
         .share-url-no-js.mb1
           %h2.govuk-heading-s.mt0 Share this job
           #{link_to "#{t('jobs.view_public_link')} (#{@vacancy.share_url})", job_path(@vacancy), class: 'govuk-link', id: 'share-url'}

--- a/app/views/vacancies/_show.html+phone.haml
+++ b/app/views/vacancies/_show.html+phone.haml
@@ -26,7 +26,7 @@
                                                             lat: @vacancy.school_geolocation.x,
                                                             lng: @vacancy.school_geolocation.y }
 
-      %script{async: true, defer: true, src: "https://maps.googleapis.com/maps/api/js?key=#{ENV['GOOGLE_MAPS_API_KEY']}&callback=initMap"}
+      %script{async: true, defer: true, src: "https://maps.googleapis.com/maps/api/js?key=#{ENV['GOOGLE_MAPS_API_KEY']}&callback=initMap", 'data-turbolinks-eval': 'false'}
 
     %h2.mt1.govuk-heading-m= t('jobs.key_info')
 

--- a/app/views/vacancies/_show.html.haml
+++ b/app/views/vacancies/_show.html.haml
@@ -50,7 +50,7 @@
                                                             lat: @vacancy.school_geolocation.x,
                                                             lng: @vacancy.school_geolocation.y }
 
-      %script{src: "https://maps.googleapis.com/maps/api/js?key=#{ENV['GOOGLE_MAPS_API_KEY']}&callback=initMap"}
+      %script{async: true, defer: true, src: "https://maps.googleapis.com/maps/api/js?key=#{ENV['GOOGLE_MAPS_API_KEY']}&callback=initMap", 'data-turbolinks-eval': 'false'}
 
   .govuk-grid-column-one-third
     %aside.vacancy--metadata


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/zS86O5L4/503-bug-copying-a-job-listing-link-doesnt-change-clipboard

## Changes in this PR:
- Remove link from anchor component used to trigger cliboard event
- Ensure google analytics scripts are not loaded more than once by setting `'data-turbolinks-eval': 'false'`
> Annotate <script> elements with data-turbolinks-eval="false" if you do not want Turbolinks to evaluate them after rendering. Note that this annotation will not prevent your browser from evaluating scripts on the initial page load. ([reference](https://github.com/turbolinks/turbolinks#working-with-script-elements))

- attach ClipboardJs on `turbolinks:load` event rather than on document.ready
> Turbolinks prevents `$(document).ready()` events from firing on all page visits, besides the one loaded initially, and instead fires `turbolink:load` events on every page visit. These must be used to trigger the script.