### PR TITLE
(fix) Fix invalid application link issue

### DIFF
--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -132,7 +132,11 @@ class Vacancy < ApplicationRecord
   def application_link=(value)
     # Data may not include a scheme/protocol so we must be careful when creating
     # links that Rails doesn't make them incorrectly relative.
-    value = Addressable::URI.heuristic_parse(value).to_s
+    begin
+      value = Addressable::URI.heuristic_parse(value).to_s
+    rescue Addressable::URI::InvalidURIError
+      Rails.logger.debug('Validation error: Invalid application link format')
+    end
     super(value)
   end
 

--- a/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
@@ -360,6 +360,25 @@ RSpec.feature 'Creating a vacancy' do
           expect(page).to have_content('a@valid.email')
         end
 
+        scenario 'fails validation correctly when an invalid link is entered' do
+          vacancy = create(:vacancy, :draft, :complete, school_id: school.id)
+          visit school_job_review_path(vacancy.id)
+          click_link_in_container_with_text('Link for more information')
+
+          expect(page).to have_content('Step 3 of 3')
+
+          fill_in 'application_details_form[application_link]', with: 'www invalid.domain.com'
+          click_on 'Save and continue'
+
+          expect(page).to have_content('Application link is not a valid URL')
+
+          fill_in 'application_details_form[application_link]', with: 'www.valid-domain.com'
+          click_on 'Save and continue'
+
+          expect(page).to have_content("Review the job for #{school.name}")
+          expect(page).to have_content('www.valid-domain.com')
+        end
+
         scenario 'updates the vacancy details' do
           vacancy = create(:vacancy, :draft, :complete, school_id: school.id)
           visit school_job_review_path(vacancy.id)


### PR DESCRIPTION
Resolves issue where attempting to save an `application_link` with a malformed url causes the app to crash and ensures that new value goes through the validation process and returns relevant error message.

## Trello card URL:
https://trello.com/c/oxsyFlAB/518-bug-attempting-to-store-incorrectly-formatted-text-in-application-link-field-causes-application-error