### PR TITLE
(fix) fix re-introduced weekly hour label bug

### DIFF
--- a/app/views/vacancies/_show.html.haml
+++ b/app/views/vacancies/_show.html.haml
@@ -70,7 +70,7 @@
         %dd
           = @vacancy.salary_range
 
-        - if @vacancy.part_time? && @vacancy.weekly_hours
+        - if @vacancy.part_time? && @vacancy.weekly_hours.present?
           %dt= t('jobs.weekly_hours')
           %dd= @vacancy.weekly_hours
 

--- a/spec/features/job_seekers_can_view_a_vacancy_spec.rb
+++ b/spec/features/job_seekers_can_view_a_vacancy_spec.rb
@@ -71,6 +71,25 @@ RSpec.feature 'Viewing a single published vacancy' do
       expect(page).to_not have_content(I18n.t('jobs.experience'))
       expect(page).to_not have_content(I18n.t('jobs.benefits'))
     end
+
+    scenario 'does not see the Weekly hours label for part time roles that don\'t have weekly hours set' do
+      vacancy = build(:vacancy, :published_slugged, working_pattern: :part_time, weekly_hours: nil)
+      vacancy.save(validate: false)
+
+      visit job_path(vacancy)
+
+      expect(page).to_not have_content(I18n.t('jobs.weekly_hours'))
+    end
+
+    scenario 'can see the Weekly hours label for part time roles do have weekly hours set' do
+      vacancy = build(:vacancy, :published_slugged, working_pattern: :part_time, weekly_hours: 30)
+      vacancy.save(validate: false)
+
+      visit job_path(vacancy)
+
+      expect(page).to have_content(I18n.t('jobs.weekly_hours'))
+      expect(page).to have_content(30)
+    end
   end
 
   context 'when the old vacancy URL is used' do


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/cM4D4xb5/525-weekly-hours-bug-made-it-back-in

## Changes in this PR:

Small bug fix and specs to verify