### PR TITLE
[chore] add `expires_on` support to vacancy update script

### DIFF
--- a/lib/tasks/vacancies.rake
+++ b/lib/tasks/vacancies.rake
@@ -32,6 +32,7 @@ namespace :vacancies do
         vacancy.qualifications  = data['qualifications'] if data.key?('qualifications')
         vacancy.starts_on       = Date.parse(data['starts_on']) if data.key?('starts_on')
         vacancy.ends_on         = Date.parse(data['ends_on']) if data.key?('ends_on')
+        vacancy.expires_on      = Date.parse(data['expires_on']) if data.key?('expires_on')
         vacancy.min_pay_scale = PayScale.find_by(label: data['min_pay_scale']) if data.key?('min_pay_scale')
         vacancy.max_pay_scale = PayScale.find_by(label: data['max_pay_scale']) if data.key?('max_pay_scale')
         vacancy.working_pattern = extract_working_pattern(data) if data.key?('working_pattern')

--- a/lib/tasks/vacancies_to_update.yaml
+++ b/lib/tasks/vacancies_to_update.yaml
@@ -1208,7 +1208,7 @@ Telephone: 0191 2598500</p>
       Tel: 01429 273790<br>
       11-18 CATHOLIC COMPREHENSIVE SCHOOL<br>
       Number on Roll 1240 + 198 in Sixth Form</p>"
-      ends_on: '12/10/2018'
+      expires_on: '12/10/2018'
     -
       slug: 'teacher-of-english-norham-high-school'
       job_title: 'Teacher of English'
@@ -1262,4 +1262,4 @@ Telephone: 0191 2598500</p>
       <li>the support of experienced, enthusiastic and dedicated staff;</li>
       <li>the opportunity for on-going personal and professional development;</li>
       <li>a strong and effective governing body, which is both supportive and challenging and wholly committed to working in partnership</li></ul>"
-      ends_on: '22/10/2018'
+      expires_on: '22/10/2018'

--- a/spec/lib/tasks/vacancies_rake_spec.rb
+++ b/spec/lib/tasks/vacancies_rake_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe 'rake vacancies:data:update', type: :task do
     create(:vacancy, slug: 'teacher-of-maths-maternity-cover', job_title: 'Another french teacher',
                      updated_at: Time.zone.now + 2.minutes)
     create(:vacancy, slug: 'teaching-assistants', working_pattern: 'part_time')
+    expired_slug = 'teacher-of-science-the-english-martyrs-school-and-sixth-form-college-hartlepool'
+    create(:vacancy, slug: expired_slug, expires_on: Time.zone.now + 1.year)
 
     task.invoke
 
@@ -26,6 +28,7 @@ RSpec.describe 'rake vacancies:data:update', type: :task do
     pay_scale_vacancy = Vacancy.find_by(slug: 'teacher-of-french')
     edited_vacancy = Vacancy.find_by(slug: 'teacher-of-maths-maternity-cover')
     dont_reset_working_pattern = Vacancy.find_by(slug: 'teaching-assistants')
+    expired_update = Vacancy.find_by(slug:  expired_slug)
 
     expect(vacancy.experience).to eq(sanitize(data[index]['experience']))
     expect(vacancy.job_title).to eq(data[index]['job_title'])
@@ -38,6 +41,7 @@ RSpec.describe 'rake vacancies:data:update', type: :task do
     expect(pay_scale_vacancy.max_pay_scale).to eq(ups)
     expect(edited_vacancy.job_title).to eq('Another french teacher')
     expect(dont_reset_working_pattern.working_pattern).to eq('part_time')
+    expect(expired_update.expires_on).to eq(Date.parse('12/10/2018'))
   end
 end
 


### PR DESCRIPTION
Release fix to enable vacancy update script to expire vacancies with wrongly set future expiry date.