### PR TITLE
[Fix] remove data-turbolink property as it causes map to not load

### DIFF
--- a/app/views/hiring_staff/vacancies/_show.html.haml
+++ b/app/views/hiring_staff/vacancies/_show.html.haml
@@ -83,7 +83,7 @@
                                                               lat: @vacancy.school_geolocation.x,
                                                               lng: @vacancy.school_geolocation.y }
 
-        %script{async: true, defer: true, src: "https://maps.googleapis.com/maps/api/js?key=#{ENV['GOOGLE_MAPS_API_KEY']}&callback=initMap", 'data-turbolinks-eval': 'false'}
+        %script{async: true, defer: true, src: "https://maps.googleapis.com/maps/api/js?key=#{ENV['GOOGLE_MAPS_API_KEY']}&callback=initMap" }
 
     .govuk-grid-column-one-third
       %aside.vacancy--metadata

--- a/app/views/vacancies/_show.html+phone.haml
+++ b/app/views/vacancies/_show.html+phone.haml
@@ -26,7 +26,7 @@
                                                             lat: @vacancy.school_geolocation.x,
                                                             lng: @vacancy.school_geolocation.y }
 
-      %script{async: true, defer: true, src: "https://maps.googleapis.com/maps/api/js?key=#{ENV['GOOGLE_MAPS_API_KEY']}&callback=initMap", 'data-turbolinks-eval': 'false'}
+      %script{async: true, defer: true, src: "https://maps.googleapis.com/maps/api/js?key=#{ENV['GOOGLE_MAPS_API_KEY']}&callback=initMap" }
 
     %h2.mt1.govuk-heading-m= t('jobs.key_info')
 

--- a/app/views/vacancies/_show.html.haml
+++ b/app/views/vacancies/_show.html.haml
@@ -50,7 +50,7 @@
                                                             lat: @vacancy.school_geolocation.x,
                                                             lng: @vacancy.school_geolocation.y }
 
-      %script{async: true, defer: true, src: "https://maps.googleapis.com/maps/api/js?key=#{ENV['GOOGLE_MAPS_API_KEY']}&callback=initMap", 'data-turbolinks-eval': 'false'}
+      %script{async: true, defer: true, src: "https://maps.googleapis.com/maps/api/js?key=#{ENV['GOOGLE_MAPS_API_KEY']}&callback=initMap"}
 
   .govuk-grid-column-one-third
     %aside.vacancy--metadata


### PR DESCRIPTION
Release bug fix

## Trello card URL:
https://trello.com/c/sdo4L745/526-google-maps-not-showing-on-listings-on-first-view-at-least-as-a-job-seeker
