### PR TITLE
(chore) updated error message

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -297,12 +297,14 @@ en:
           - If your Teaching Jobs account has already been set up but you are unable to sign in, email the same address with "help" in the subject line.
       with_email:
         text:
-          - You've tried to sign in with %{email}, which is not associated with a Teaching Jobs account. If you have an account associated with another email, please first sign %{email} out of DfE Sign-in. Then sign into Teaching Jobs at %{signin_url} using your authorised email.
+          - You've tried to sign in with %{email}, which is not authorised to list jobs for this school. If you have an authorised account associated with another email, you must sign %{email} out of DfE Sign-in, then sign into Teaching Jobs with your authorised email. You can do this at %{signin_url}
 
           - If you don't have a Teaching Jobs account you will need to wait for an invitation for one. Invitations are being sent out gradually, by region. When you have accepted the invitation and created your account you will be able to start listing roles at your school.
 
           - Read the Teaching Jobs %{blog_url} to learn when schools in your area will be invited.
 
           - If your Teaching Jobs account has already been set up but you are unable to sign in, email %{mailto_url} with "help" in the subject line.
+
+          - The Teaching Jobs team
   beta_banner:
     line_1: 'This service is in development and lists jobs in select areas of England. It will be %{link} to new areas, so check back regularly for new listings.'


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/pQWLeZyC/521-update-error-message-for-authenticated-but-unauthorised-accounts-on-dfe-sign-in

## Changes in this PR:
- Updates the error message for authenticated but unauthorised accounts on DfE Sign-in

## Screenshots of UI changes:

### Before
<img width="645" alt="screen_shot_2018-10-24_at_15 42 48" src="https://user-images.githubusercontent.com/822507/47496031-a52be980-d84d-11e8-94b3-0c4f01762660.png">

### After
<img width="749" alt="screenshot 2018-10-25 at 11 47 44" src="https://user-images.githubusercontent.com/822507/47496043-a9580700-d84d-11e8-9027-ccd29ccdbdba.png">

