### PR TITLE
(chore) Update text on Job Title help label

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -147,7 +147,7 @@ en:
       flexible_working: 'Flexible working (optional)'
       newly_qualified_teacher: 'Newly qualified teacher (optional)'
     form_hints:
-      job_title: "For secondary school roles include subject to be taught and, if applicable, level of seniority ('Subject leader for Science', for example)"
+      job_title: "For secondary school roles include subject and, if relevant, level of seniority ('Subject leader for science', for example)."
       description: 'Briefly describe the duties and responsibilities involved in the role (minimum 10 characters)'
       subject: 'What subject will the teacher focus on?'
       salary_range: 'Enter annual pay before tax, without commas or decimal points (for example 30000)'


### PR DESCRIPTION

## Trello card URL:

https://trello.com/c/mqPHi5ZW/489-job-title-help-text-revision

## Changes in this PR:

Updated the help text below the Job Title label in the job creation form

## Screenshots of UI changes:

![screen shot 2018-10-25 at 13 54 31](https://user-images.githubusercontent.com/1089521/47501513-a06f3180-d85d-11e8-92e1-b9f8ba31ebe5.png)
