### PR TITLE
(chore) Update help text on Essential Qualifications input

### DIFF
--- a/app/views/hiring_staff/vacancies/candidate_specification/edit.html.haml
+++ b/app/views/hiring_staff/vacancies/candidate_specification/edit.html.haml
@@ -21,7 +21,7 @@
                 wrapper: 'textarea',
                 label: t('jobs.qualifications'),
                 as: :text,
-                hint: t('jobs.form_hints.qualifications'),
+                hint: t('jobs.form_hints.qualifications').html_safe,
                 input_html: {rows: 5},
                 wrapper_html: {id: 'qualifications'},
                 required: true

--- a/app/views/hiring_staff/vacancies/candidate_specification/new.html.haml
+++ b/app/views/hiring_staff/vacancies/candidate_specification/new.html.haml
@@ -23,7 +23,7 @@
                 wrapper: 'textarea',
                 label: t('jobs.qualifications'),
                 as: :text,
-                hint: t('jobs.form_hints.qualifications'),
+                hint: t('jobs.form_hints.qualifications').html_safe,
                 input_html: {rows: 5},
                 wrapper_html: {id: 'qualifications'},
                 required: true

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -158,7 +158,7 @@ en:
       start_date: 'For example, %{date}'
       end_date: 'For example, %{date}'
       education: 'Educational background needed for the position'
-      qualifications: 'Specific qualifications required for this role'
+      qualifications: 'List any qualifications needed for this role (<span arial-label="Qualified Teacher Status">QTS</span>, for example)'
       experience: 'Expected teaching or other experience'
       deadline_date: 'For example, %{date}'
       publication_date: 'For example, %{date}'


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/QZ4B12A7/491-essential-qualifications-text-revision

## Changes in this PR:

Updated help text on Essential Qualifications input on job creation form

## Screenshots of UI changes:

![screen shot 2018-10-25 at 14 52 14](https://user-images.githubusercontent.com/1089521/47505221-aa952e00-d865-11e8-9079-f81039b19c10.png)
