### PR TITLE
[Feature][504] Sidekiq jobs should have unique queue names and priority levels

### DIFF
--- a/app/jobs/cache_total_analytics_pageviews_queue_job.rb
+++ b/app/jobs/cache_total_analytics_pageviews_queue_job.rb
@@ -1,7 +1,7 @@
 require 'analytics'
 class CacheTotalAnalyticsPageviewsQueueJob < ApplicationJob
   include ActionView::Helpers::UrlHelper
-  queue_as :default
+  queue_as :page_view_collector
 
   def perform(vacancy_id)
     vacancy = Vacancy.find(vacancy_id)

--- a/app/jobs/cache_weekly_analytics_pageviews_queue_job.rb
+++ b/app/jobs/cache_weekly_analytics_pageviews_queue_job.rb
@@ -1,7 +1,7 @@
 require 'analytics'
 class CacheWeeklyAnalyticsPageviewsQueueJob < ApplicationJob
   include ActionView::Helpers::UrlHelper
-  queue_as :default
+  queue_as :page_view_collector
 
   def perform(vacancy_id)
     vacancy = Vacancy.find(vacancy_id)

--- a/app/jobs/performance_platform_feedback_queue_job.rb
+++ b/app/jobs/performance_platform_feedback_queue_job.rb
@@ -1,6 +1,6 @@
 require 'performance_platform'
 class PerformancePlatformFeedbackQueueJob < ApplicationJob
-  queue_as :default
+  queue_as :performance_platform
 
   def perform(time_to_s)
     date = Time.zone.parse(time_to_s)

--- a/app/jobs/performance_platform_transactions_queue_job.rb
+++ b/app/jobs/performance_platform_transactions_queue_job.rb
@@ -1,6 +1,6 @@
 require 'performance_platform'
 class PerformancePlatformTransactionsQueueJob < ApplicationJob
-  queue_as :default
+  queue_as :performance_platform
 
   def perform(time_to_s)
     date = Time.zone.parse(time_to_s)

--- a/app/jobs/remove_google_index_queue_job.rb
+++ b/app/jobs/remove_google_index_queue_job.rb
@@ -1,6 +1,6 @@
 require 'indexing'
 class RemoveGoogleIndexQueueJob < ApplicationJob
-  queue_as :default
+  queue_as :google_indexing
 
   def perform(url)
     Indexing.new(url).remove

--- a/app/jobs/update_google_index_queue_job.rb
+++ b/app/jobs/update_google_index_queue_job.rb
@@ -1,6 +1,6 @@
 require 'indexing'
 class UpdateGoogleIndexQueueJob < ApplicationJob
-  queue_as :default
+  queue_as :google_indexing
 
   def perform(url)
     Indexing.new(url).update

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,5 @@
+:queues:
+  - [ page_view_collector, 2 ]
+  - [ performance_platform, 2 ]
+  - [ google_indexing, 2]
+  - [ import_school_data, 1 ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
     build: .
     env_file:
       - docker-compose.env
-    command: bundle exec sidekiq
+    command: bundle exec sidekiq -C config/sidekiq.yml
     depends_on:
       - redis
     restart: on-failure

--- a/spec/jobs/cache_total_analytics_pageviews_queue_job_spec.rb
+++ b/spec/jobs/cache_total_analytics_pageviews_queue_job_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe CacheTotalAnalyticsPageviewsQueueJob, type: :job, wip: true do
     expect { job }.to change(ActiveJob::Base.queue_adapter.enqueued_jobs, :size).by(1)
   end
 
-  it 'is in the default queue' do
-    expect(job.queue_name).to eq('default')
+  it 'is in the page_view_collector queue' do
+    expect(job.queue_name).to eq('page_view_collector')
   end
 
   it 'executes perform' do

--- a/spec/jobs/cache_weekly_analytics_pageviews_queue_job_spec.rb
+++ b/spec/jobs/cache_weekly_analytics_pageviews_queue_job_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe CacheWeeklyAnalyticsPageviewsQueueJob, type: :job do
     expect { job }.to change(ActiveJob::Base.queue_adapter.enqueued_jobs, :size).by(1)
   end
 
-  it 'is in the default queue' do
-    expect(job.queue_name).to eq('default')
+  it 'is in the page_view_collector queue' do
+    expect(job.queue_name).to eq('page_view_collector')
   end
 
   it 'executes perform' do

--- a/spec/jobs/performance_platform_feedback_queue_job_spec.rb
+++ b/spec/jobs/performance_platform_feedback_queue_job_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe PerformancePlatformFeedbackQueueJob, type: :job do
     expect { job }.to change(ActiveJob::Base.queue_adapter.enqueued_jobs, :size).by(1)
   end
 
-  it 'is in the default queue' do
-    expect(PerformancePlatformFeedbackQueueJob.new.queue_name).to eq('default')
+  it 'is in the performance_platform queue' do
+    expect(PerformancePlatformFeedbackQueueJob.new.queue_name).to eq('performance_platform')
   end
 
   it 'executes perform' do

--- a/spec/jobs/performance_platform_transactions_queue_job_spec.rb
+++ b/spec/jobs/performance_platform_transactions_queue_job_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe PerformancePlatformTransactionsQueueJob, type: :job do
     expect { job }.to change(ActiveJob::Base.queue_adapter.enqueued_jobs, :size).by(1)
   end
 
-  it 'is in the default queue' do
-    expect(PerformancePlatformTransactionsQueueJob.new.queue_name).to eq('default')
+  it 'is in the performance_platform queue' do
+    expect(PerformancePlatformTransactionsQueueJob.new.queue_name).to eq('performance_platform')
   end
 
   it 'executes perform' do

--- a/spec/jobs/remove_google_index_queue_job_spec.rb
+++ b/spec/jobs/remove_google_index_queue_job_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe RemoveGoogleIndexQueueJob, type: :job do
     expect { job }.to change(ActiveJob::Base.queue_adapter.enqueued_jobs, :size).by(1)
   end
 
-  it 'is in the default queue' do
-    expect(job.queue_name).to eq('default')
+  it 'is in the google_indexing queue' do
+    expect(job.queue_name).to eq('google_indexing')
   end
 
   it 'executes perform' do

--- a/spec/jobs/update_google_index_queue_job_spec.rb
+++ b/spec/jobs/update_google_index_queue_job_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe UpdateGoogleIndexQueueJob, type: :job do
     expect { job }.to change(ActiveJob::Base.queue_adapter.enqueued_jobs, :size).by(1)
   end
 
-  it 'is in the default queue' do
-    expect(job.queue_name).to eq('default')
+  it 'is in the google_indexing queue' do
+    expect(job.queue_name).to eq('google_indexing')
   end
 
   it 'executes perform' do

--- a/workspace-variables/workspace.tfvars.example
+++ b/workspace-variables/workspace.tfvars.example
@@ -26,7 +26,7 @@ ecs_service_web_task_port = 3000
 ecs_service_worker_task_port = 8082
 vacancies_scrape_schedule_expression = "rate(60 minutes)"
 logspout_command = ["syslog+tls://logsN.papertrailapp.com:XXXXX"]
-worker_command = ["bundle", "exec", "sidekiq"]
+worker_command = ["bundle", "exec", "sidekiq", "-C", "config/sidekiq.yml"]
 
 # RDS
 rds_storage_gb = 10


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/rxmxTB17/504-sidekiq-jobs-should-have-unique-queue-names-and-priority-levels

## Changes in this PR:
Configures sidekiq queues and queue weight

[Sidekiq advanced options](https://github.com/mperham/sidekiq/wiki/Advanced-Options#queues):
> A queue with weight of `2` will be checked twice as often as a queue with a weight of 1. 


Verified on Edge:
```logs
Oct 26 11:17:58 Edge ecs-tvs2_edge_worker-27-tvs2edgeweb-8eeff5a19489a6a60f00: Performed PerformancePlatformTransactionsQueueJob (Job ID: 6d5b5c08-b272-4028-a5fd-802bd79896eb) from Sidekiq(performance_platform) in 4116.9ms 

Oct 26 11:20:35 Edge ecs-tvs2_edge_worker-27-tvs2edgeweb-a2998ae29fbfc1db1700: Performing CacheWeeklyAnalyticsPageviewsQueueJob (Job ID: d7c8687c-e861-4dd0-8669-dbfedf405100) from Sidekiq(page_view_collector) with arguments: "8be951f5-4cfd-41d7-9467-6656e69cc022" 

Oct 26 11:20:35 Edge ecs-tvs2_edge_worker-27-tvs2edgeweb-a2998ae29fbfc1db1700: Performing CacheTotalAnalyticsPageviewsQueueJob (Job ID: df9fce45-a029-4f83-9865-86440d89c4bd) from Sidekiq(page_view_collector) with arguments: "1e7afaa8-7318-40e8-b884-9682c
```


## Next steps:

- [x] Terraform deployment required?
