### PR TITLE
[Feature] hiring staff are redirected to the last incomplete step 

### DIFF
--- a/app/form_models/application_details_form.rb
+++ b/app/form_models/application_details_form.rb
@@ -14,4 +14,8 @@ class ApplicationDetailsForm < VacancyForm
   def publish_on_change?
     original_publish_on.present? ? !publish_on.eql?(original_publish_on) : false
   end
+
+  def completed?
+    application_link && contact_email && publish_on && expires_on
+  end
 end

--- a/app/form_models/candidate_specification_form.rb
+++ b/app/form_models/candidate_specification_form.rb
@@ -1,3 +1,7 @@
 class CandidateSpecificationForm < VacancyForm
   include VacancyCandidateSpecificationValidations
+
+  def completed?
+    valid?
+  end
 end


### PR DESCRIPTION
…n attempting to get to the review page

## Trello card URL:
https://trello.com/c/rIYYPmMQ/488-hiring-staff-can-continue-the-publishing-journey-where-they-left-it

## Changes in this PR:
Redirects hirings staff to a vacancy's last incomplete step
