### PR TITLE
[fix][534] Reset search link now appears when filters are applied

### DIFF
--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -16,7 +16,7 @@ class VacanciesController < ApplicationController
 
     records = Vacancy.public_search(filters: @filters, sort: @sort).page(params[:page]).records
 
-    @vacancies = VacanciesPresenter.new(records, searched: searched?)
+    @vacancies = VacanciesPresenter.new(records, searched: @filters.any?)
   end
 
   def show
@@ -90,11 +90,6 @@ class VacanciesController < ApplicationController
 
   def sort_order
     params[:sort_order]
-  end
-
-  def searched?
-    params[:commit]&.eql?(I18n.t('buttons.apply_filters')) ||
-      params[:commit]&.eql?(I18n.t('buttons.apply_filters_if_criteria'))
   end
 
   def set_headers

--- a/app/services/vacancy_filters.rb
+++ b/app/services/vacancy_filters.rb
@@ -28,6 +28,12 @@ class VacancyFilters
     }
   end
 
+  def any?
+    filters = to_hash
+    filters.delete_if { |k, v| k.eql?(:radius) || v.nil? }
+    filters.any?
+  end
+
   private
 
   def extract_working_pattern(params)

--- a/spec/features/job_seekers_can_filter_vacancies_spec.rb
+++ b/spec/features/job_seekers_can_filter_vacancies_spec.rb
@@ -244,4 +244,31 @@ RSpec.feature 'Filtering vacancies' do
       expect(page).to have_field('newly_qualified_teacher', checked: false)
     end
   end
+
+  context 'Resetting search filters' do
+    it 'Hiring staff can reset search after filtering' do
+      create(:vacancy, :published, job_title: 'Physics Teacher')
+
+      Vacancy.__elasticsearch__.client.indices.flush
+      visit jobs_path
+
+      within '.filters-form' do
+        fill_in 'keyword', with: 'Physics'
+        page.find('.govuk-button[type=submit]').click
+      end
+
+      expect(page).to have_content(I18n.t('jobs.filters.clear_filters'))
+      click_on 'Closing date'
+      expect(page).to have_content(I18n.t('jobs.filters.clear_filters'))
+    end
+
+    it 'Hiring staff can reset search after adding any filter params to the url' do
+      create(:vacancy, :published, job_title: 'Physics Teacher')
+      Vacancy.__elasticsearch__.client.indices.flush
+
+      visit jobs_path(keyword: 'Other')
+
+      expect(page).to have_content(I18n.t('jobs.filters.clear_filters'))
+    end
+  end
 end

--- a/spec/services/vacancy_filters_spec.rb
+++ b/spec/services/vacancy_filters_spec.rb
@@ -79,4 +79,23 @@ RSpec.describe VacancyFilters do
       )
     end
   end
+
+  describe '#any?' do
+    it 'returns true if any filters other than radius are set' do
+      filters = described_class.new(
+        radius: 20
+      )
+
+      expect(filters.any?).to be false
+    end
+
+    it 'returns true if any filters are set' do
+      filters = described_class.new(
+        minimum_salary: 'minimum_salary',
+        maximum_salary: 'maximum_salary',
+      )
+
+      expect(filters.any?).to be true
+    end
+  end
 end


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/oeSnEH20/534-bug-reset-search-link-disappears-when-sorting-results-by-date

## Changes in this PR:
Check if any filter values are set rather than the commit param values to ensure the `Reset search` link is displayed correctly whenever any filters are applied.


## Screenshots of UI changes:

### Before

**Before filtering**
<img width="1214" alt="screen shot 2018-10-30 at 16 07 39 1" src="https://user-images.githubusercontent.com/159200/47732425-13154e00-dc5e-11e8-8b56-dd0c3bcd6798.png">

**After filtering**
<img width="1240" alt="screen shot 2018-10-30 at 16 07 51" src="https://user-images.githubusercontent.com/159200/47732430-1577a800-dc5e-11e8-8b2e-57242d33abb3.png">


### After
**Before filtering**
<img width="1239" alt="screen shot 2018-10-30 at 16 07 11 1" src="https://user-images.githubusercontent.com/159200/47732496-33450d00-dc5e-11e8-9783-7cf1a639e56c.png">

**After filtering** - Reset search link does not disappear
<img width="1134" alt="screen shot 2018-10-30 at 16 07 18" src="https://user-images.githubusercontent.com/159200/47732501-363ffd80-dc5e-11e8-881c-d9b90c51d5c5.png">
