### PR TITLE
[Fix][549] Bug: Search filter values for radius and NQT disappear when reordering by date

### DIFF
--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -24,8 +24,8 @@ module VacanciesHelper
   end
 
   def vacancy_params_whitelist
-    %i[sort_column sort_order location keyword minimum_salary
-       maximum_salary working_pattern phase page]
+    %i[sort_column sort_order page location radius keyword minimum_salary
+       maximum_salary working_pattern phase newly_qualified_teacher]
   end
 
   def vacancy_params(overwrite = {})

--- a/app/services/vacancy_filters.rb
+++ b/app/services/vacancy_filters.rb
@@ -1,6 +1,8 @@
 class VacancyFilters
-  attr_reader :location, :radius, :keyword, :minimum_salary, :maximum_salary, :working_pattern, :phase,
-              :newly_qualified_teacher
+  AVAILABLE_FILTERS = %i[location radius keyword minimum_salary maximum_salary working_pattern
+                         phase newly_qualified_teacher].freeze
+
+  attr_reader(*AVAILABLE_FILTERS)
 
   def initialize(args)
     args = ActiveSupport::HashWithIndifferentAccess.new(args)

--- a/spec/helpers/vacancies_helper_spec.rb
+++ b/spec/helpers/vacancies_helper_spec.rb
@@ -56,4 +56,13 @@ RSpec.describe VacanciesHelper, type: :helper do
       end
     end
   end
+
+  describe '#vacancy_params_whitelist' do
+    it 'should include all available filtering params' do
+      filters = %i[sort_column sort_order page]
+      filters.push(*VacancyFilters::AVAILABLE_FILTERS)
+
+      expect(helper.vacancy_params_whitelist). to eq(filters)
+    end
+  end
 end


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/TRPNKevB/549-bug-search-filter-values-for-radius-and-newlyqualifiedteacher-disappear-when-reordering-by-date

## Changes in this PR:
Ensures all filter values persist when ordering is applied. `newly_qualified_teacher` and `radius` were missing.

## Screenshots of UI changes:
### Before
<img width="905" alt="step 1 - filtering by nqt" src="https://user-images.githubusercontent.com/159200/47735936-78207200-dc65-11e8-810c-bd8080d023be.png">


<img width="796" alt="step 2 - ordering by date posted" src="https://user-images.githubusercontent.com/159200/47735939-7b1b6280-dc65-11e8-8867-1ba745edab8e.png">

### After
<img width="969" alt="filtering" src="https://user-images.githubusercontent.com/159200/47736016-a3a35c80-dc65-11e8-9e44-c6fb8aa134d1.png">
<img width="989" alt="ordering" src="https://user-images.githubusercontent.com/159200/47736020-a56d2000-dc65-11e8-889f-b6533f0232dd.png">

