### PR TITLE
[bug] starts_on and ends_on must be after the vacancy closing date

### DIFF
--- a/app/form_models/job_specification_form.rb
+++ b/app/form_models/job_specification_form.rb
@@ -1,7 +1,8 @@
 class JobSpecificationForm < VacancyForm
   # rubocop:disable Lint/AmbiguousOperator
   delegate *['starts_on_yyyy', 'starts_on_mm', 'starts_on_dd',
-             'ends_on_dd', 'ends_on_mm', 'ends_on_yyyy'].map { |attr| [attr, "#{attr}="] }.flatten, to: :vacancy
+             'ends_on_dd', 'ends_on_mm', 'ends_on_yyyy',
+             'expires_on'].map { |attr| [attr, "#{attr}=", "#{attr}?"] }.flatten, to: :vacancy
   # rubocop:enable Lint/AmbiguousOperator
 
   include VacancyJobSpecificationValidations

--- a/app/models/concerns/vacancy_job_specification_validations.rb
+++ b/app/models/concerns/vacancy_job_specification_validations.rb
@@ -16,6 +16,9 @@ module VacancyJobSpecificationValidations
     validate :starts_on_in_future?, if: :starts_on?
     validate :ends_on_in_future?, if: :ends_on?
     validate :starts_on_before_ends_on?
+
+    validate :starts_on_before_closing_date, if: :starts_on?
+    validate :ends_on_before_closing_date, if: :ends_on?
   end
 
   def starts_on_before_ends_on?
@@ -32,6 +35,22 @@ module VacancyJobSpecificationValidations
 
   def starts_on_past_error
     I18n.t('activerecord.errors.models.vacancy.attributes.starts_on.past')
+  end
+
+  def starts_on_before_closing_date
+    errors.add(:starts_on, starts_on_must_be_before_closing_date_error) if expires_on? && starts_on <= expires_on
+  end
+
+  def ends_on_before_closing_date
+    errors.add(:ends_on, ends_on_must_be_before_closing_date_error) if expires_on? && ends_on <= expires_on
+  end
+
+  def starts_on_must_be_before_closing_date_error
+    I18n.t('activerecord.errors.models.vacancy.attributes.starts_on.before_expires_on')
+  end
+
+  def ends_on_must_be_before_closing_date_error
+    I18n.t('activerecord.errors.models.vacancy.attributes.ends_on.before_expires_on')
   end
 
   def ends_on_in_future?

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -44,8 +44,10 @@ en:
             starts_on:
               past: can't be in the past
               after_ends_on: can't be after the end date
+              before_expires_on: must be after the closing date
             ends_on:
               past: can't be in the past
+              before_expires_on: must be after the closing date
             weekly_hours:
               negative: can't be negative
               invalid: must be a valid number

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -51,8 +51,10 @@ FactoryBot.define do
     end
 
     trait :complete do
-      starts_on { Faker::Time.between(Time.zone.today, Time.zone.today + 30.days) }
+      starts_on { Faker::Time.between(Time.zone.today + 10.days, Time.zone.today + 30.days) }
       ends_on { Faker::Time.between(Time.zone.today + 30.days, Time.zone.today + 60.days) }
+      expires_on { Faker::Time.between(Time.zone.today + 2.days, Time.zone.today + 9.days) }
+      publish_on { Faker::Time.between(Time.zone.today, Time.zone.today + 1.day) }
       flexible_working { true }
     end
 

--- a/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
@@ -219,6 +219,20 @@ RSpec.feature 'Creating a vacancy' do
         verify_all_vacancy_details(vacancy)
       end
 
+      scenario 'enables the user to resolve cross-form errors' do
+        vacancy = build(:vacancy, :draft, :complete, slug: 'vacancy-slug', school_id: school.id,
+                                                     starts_on: Time.zone.today)
+        vacancy.save(validate: false)
+
+        visit school_job_review_path(vacancy.id)
+        expect(page)
+          .to have_content(I18n.t('activerecord.errors.models.vacancy.attributes.starts_on.before_expires_on'))
+
+        click_link_in_container_with_text(I18n.t('jobs.starts_on'))
+        expect(page)
+          .to have_content(I18n.t('activerecord.errors.models.vacancy.attributes.starts_on.before_expires_on'))
+      end
+
       context 'when the listing is full-time' do
         scenario 'lists all the full-time vacancy details correctly' do
           vacancy = VacancyPresenter.new(

--- a/spec/features/job_seekers_can_view_vacancies_spec.rb
+++ b/spec/features/job_seekers_can_view_vacancies_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 RSpec.feature 'Viewing vacancies' do
   scenario 'Vacancies are listed with summary information' do
     vacancy = create(:vacancy)
-
     Vacancy.__elasticsearch__.client.indices.flush
     visit jobs_path
 

--- a/spec/form_models/job_specification_form_spec.rb
+++ b/spec/form_models/job_specification_form_spec.rb
@@ -49,6 +49,16 @@ RSpec.describe JobSpecificationForm, type: :model do
       expect(job_specification_form.errors.messages[:starts_on][0])
         .to eq('can\'t be after the end date')
     end
+
+    it 'must be after the closing date' do
+      job_specification_form = JobSpecificationForm.new(starts_on: Time.zone.today,
+                                                        expires_on: Time.zone.tomorrow)
+      expect(job_specification_form.valid?).to be false
+
+      expect(job_specification_form).to have(1).errors_on(:starts_on)
+      expect(job_specification_form.errors.messages[:starts_on][0])
+        .to eq('must be after the closing date')
+    end
   end
 
   describe '#ends_on' do
@@ -66,6 +76,16 @@ RSpec.describe JobSpecificationForm, type: :model do
       expect(job_specification_form).to have(1).errors_on(:ends_on)
       expect(job_specification_form.errors.messages[:ends_on][0])
         .to eq('can\'t be in the past')
+    end
+
+    it 'must be after the closing date' do
+      job_specification_form = JobSpecificationForm.new(ends_on: Time.zone.today,
+                                                        expires_on: Time.zone.tomorrow)
+      expect(job_specification_form.valid?).to be false
+
+      expect(job_specification_form).to have(1).errors_on(:ends_on)
+      expect(job_specification_form.errors.messages[:ends_on][0])
+        .to eq('must be after the closing date')
     end
   end
 


### PR DESCRIPTION

## Trello card URL:
https://trello.com/c/f7TzJvvp/538-bug-no-validation-present-for-vacancy-start-and-end-date-vs-closing-date

## Changes in this PR:
- Validates vacancy `starts_on` and `ends_on` if the closing date is set.
The failed validation can be first seen in the review page.

## Screenshots of UI changes:

### Before
<img width="1011" alt="expires_next_year" src="https://user-images.githubusercontent.com/159200/47743074-0ac90d00-dc76-11e8-9e13-abb8759c96fa.png">



### After

Starts_on set to 20/12
<img width="871" alt="screen shot 2018-10-30 at 18 38 26 1" src="https://user-images.githubusercontent.com/159200/47742914-9db57780-dc75-11e8-9b73-d53b913954ac.png">

Ends_on set to 30/12
<img width="500" alt="screen shot 2018-10-30 at 18 40 02" src="https://user-images.githubusercontent.com/159200/47742948-b32aa180-dc75-11e8-89ae-6da8dc4353d0.png">

Validation error on review page
<img width="436" alt="screen shot 2018-10-30 at 18 39 54" src="https://user-images.githubusercontent.com/159200/47742963-bb82dc80-dc75-11e8-96fb-24fa3e58a9cf.png">

Validation error on job specification page
<img width="663" alt="screen shot 2018-10-30 at 18 40 10 1" src="https://user-images.githubusercontent.com/159200/47742986-cccbe900-dc75-11e8-8c25-6d00e2216e8e.png">
