### PR TITLE
[Do not merge](chore) change Teaching Jobs to Teaching Vacancies

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ bin/dstart
 
 ## User accounts & data
 
-Before you can log in to the application locally you will need a __DfE Sign-in__ and an __invitation to join Teaching Jobs__. Talk to the team to get these set up.
+Before you can log in to the application locally you will need a __DfE Sign-in__ and an __invitation to join Teaching Vacancies__. Talk to the team to get these set up.
 
 ### Importing school data
 

--- a/app/views/pages/cookies.html.haml
+++ b/app/views/pages/cookies.html.haml
@@ -6,7 +6,7 @@
   .govuk-grid-column-two-thirds
     %h1.govuk-heading-xl Cookies
 
-    %p.govuk-body-l ‘Teaching Jobs’ puts small files (known as ‘cookies’) onto your computer to collect information about how you use the site.
+    %p.govuk-body-l ‘Teaching Vacancies’ puts small files (known as ‘cookies’) onto your computer to collect information about how you use the site.
 
     %p Cookies are used to:
 
@@ -16,19 +16,19 @@
       %li remember who you are when you have logged in so we can show you your information and information relevant to you
 
     .panel.panel-border-wide
-      %p ‘Teaching Jobs’ cookies aren’t used to identify you personally.
+      %p ‘Teaching Vacancies’ cookies aren’t used to identify you personally.
     %p Find out more about #{link_to 'how to manage cookies.', 'http://www.aboutcookies.org/', class: 'govuk-link'}
 
     %h2.govuk-heading-l How we use cookies
 
     %h3.govuk-heading-m Measuring website usage (Google Analytics)
 
-    %p We use Google Analytics software to collect information about how you use ‘Teaching Jobs’. We do this to help make sure the site is meeting the needs of its users and to help us make improvements.
+    %p We use Google Analytics software to collect information about how you use ‘Teaching Vacancies’. We do this to help make sure the site is meeting the needs of its users and to help us make improvements.
 
     %p Google Analytics stores information about:
 
     %ul.govuk-list.govuk-list--bullet
-      %li the pages you visit on ‘Teaching Jobs’
+      %li the pages you visit on ‘Teaching Vacancies’
       %li how long you spend on each page
       %li how you got to the site
       %li what you click on while you’re visiting the site
@@ -71,7 +71,7 @@
 
     %h3.govuk-heading-m Our introductory message
 
-    %p You may see a pop-up welcome message when you first visit ‘Teaching Jobs’. We’ll store a cookie so that your computer knows you’ve seen it and knows not to show it again.
+    %p You may see a pop-up welcome message when you first visit ‘Teaching Vacancies’. We’ll store a cookie so that your computer knows you’ve seen it and knows not to show it again.
 
     %table.govuk-table.mb1
       %thead.govuk-table__head

--- a/app/views/pages/privacy-policy.html.haml
+++ b/app/views/pages/privacy-policy.html.haml
@@ -3,31 +3,31 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    %h1.govuk-heading-l Privacy Notice: Teaching Jobs
+    %h1.govuk-heading-l Privacy Notice: Teaching Vacancies
 
     %h2.govuk-heading-m Who we are
-    %p This work is being carried out by Department for Education (DfE) Digital, which is a part of DfE. DfE engages the private company dxw to help improve and provide the service. For the purpose of data protection legislation, the DfE is the data controller for the personal data processed as part of Teaching Jobs. Teaching Jobs is a free and optional service for schools to advertise teaching roles.
+    %p This work is being carried out by Department for Education (DfE) Digital, which is a part of DfE. DfE engages the private company dxw to help improve and provide the service. For the purpose of data protection legislation, the DfE is the data controller for the personal data processed as part of Teaching Vacancies. Teaching Vacancies is a free and optional service for schools to advertise teaching roles.
 
     %h2.govuk-heading-m When we collect personal information
     %p
       We receive your personal data when you submit it:
       %ul.govuk-list.govuk-list--bullet
         %li when contacting us for support using the service or any other matters
-        %li as a headteacher or other authorised person at a school when selecting which hiring staff can create Teaching Jobs accounts
-        %li as hiring staff in order to create a Teaching Jobs account
-        %li as a contact person for a job that has been listed on Teaching Jobs
+        %li as a headteacher or other authorised person at a school when selecting which hiring staff can create Teaching Vacancies accounts
+        %li as hiring staff in order to create a Teaching Vacancies account
+        %li as a contact person for a job that has been listed on Teaching Vacancies
 
     %h2.govuk-heading-m What personal information we will collect
     %p
       We will collect:
       %ul.govuk-list.govuk-list--bullet
         %li your name, email and (if applicable) your phone number when you contact us
-        %li email addresses that are shared with us by schools for the purposes of creating a Teaching Jobs account and posting jobs
-        %li personal information such as the name and email of a contact person at your school, if you choose to share this in a job listing you post to Teaching Jobs
+        %li email addresses that are shared with us by schools for the purposes of creating a Teaching Vacancies account and posting jobs
+        %li personal information such as the name and email of a contact person at your school, if you choose to share this in a job listing you post to Teaching Vacancies
 
     %h2.govuk-heading-m How we will use your information
     %p If you contact us, DfE and (where applicable) dxw will use your name and contact information for the purpose of responding to you and providing support. We will not share this information with any other parties.
-    %p To list jobs on the service, hiring staff at schools need a Teaching Jobs account, which requires them to supply their name and email address. Names and email addresses shared with us for this purpose are not shared by us with other parties.
+    %p To list jobs on the service, hiring staff at schools need a Teaching Vacancies account, which requires them to supply their name and email address. Names and email addresses shared with us for this purpose are not shared by us with other parties.
     %p Information published in job listings may be used by third party job listing sites that use our job listing data via an application programming interface (API), as described in our Terms and Conditions. We are not responsible for how a third party handles any personal information you choose to include in a job listing.
 
     %h2.govuk-heading-m Why our use of your personal data is lawful
@@ -35,13 +35,13 @@
 
     %h2.govuk-heading-m Who we will make your personal data available to
     %p We sometimes need to make personal data available to other organisations. These might include contracted partners (who we have employed to process your personal data on our behalf) and/or other organisations (with whom we need to share your personal data for specific purposes).
-    %p Where we need to share your personal data with others, we ensure that this data sharing complies with data protection legislation. We share specific types of personal data with dxw, who have been contracted by DfE to manage the delivery of the digital service. If you represent a school and are publishing a job listing through Teaching Jobs we share your email with #{link_to('Microsoft','https://privacy.microsoft.com/en-us/privacystatement', class: 'govuk-link')} solely for the purpose of enabling sign-in to the publishing environment.
+    %p Where we need to share your personal data with others, we ensure that this data sharing complies with data protection legislation. We share specific types of personal data with dxw, who have been contracted by DfE to manage the delivery of the digital service. If you represent a school and are publishing a job listing through Teaching Vacancies we share your email with #{link_to('Microsoft','https://privacy.microsoft.com/en-us/privacystatement', class: 'govuk-link')} solely for the purpose of enabling sign-in to the publishing environment.
     %p
       The firm dxw uses your data:
       %ul.govuk-list.govuk-list--bullet
         %li for user research that informs development of the service, where you have shared your name, email address and/or phone number for this purpose
-        %li for security purposes: dxw collects part of the IP addresses of people visiting the Teaching Jobs website (for example, if we were receiving continuous direct denial of service attacks from an IP address range then we could block it)
-        %li to enable users to use the service and receive updates: dxw collects the emails of those publishing job listings on Teaching Jobs
+        %li for security purposes: dxw collects part of the IP addresses of people visiting the Teaching Vacancies website (for example, if we were receiving continuous direct denial of service attacks from an IP address range then we could block it)
+        %li to enable users to use the service and receive updates: dxw collects the emails of those publishing job listings on Teaching Vacancies
 
     %h2.govuk-heading-m How long we will keep your personal data
     %p Neither DfE nor dxw will keep your personal data longer than we need it for the purpose(s) of research, security and/or delivery of the service, and in any case not longer than 7 years. Your data will be deleted when DfE and dxw no longer need it for these purposes, or when 7 years have passed, whichever comes first.

--- a/app/views/pages/terms-and-conditions.html.haml
+++ b/app/views/pages/terms-and-conditions.html.haml
@@ -9,8 +9,8 @@
     %h2.govuk-heading-l All Users
 
     %h3.govuk-heading-m Using the website
-    %p Please read these Terms of Use (“General Terms”) carefully before using this Teaching Jobs website (the “Service”).
-    %P This Service  is maintained for your personal use and viewing. Access and use by you of this Service constitutes your acceptance of these General Terms . This takes effect from the date on which you first use this website. If you do not agree to these terms, you must not use this website.
+    %p Please read these Terms of Use (“General Terms”) carefully before using this Teaching Vacancies website (the “Service”).
+    %P This Service is maintained for your personal use and viewing. Access and use by you of this Service constitutes your acceptance of these General Terms . This takes effect from the date on which you first use this website. If you do not agree to these terms, you must not use this website.
     %p If we change these General Terms we will post the revised document here with an updated effective date. If we make significant changes to these terms, we may notify you by other means such as sending an email or posting a notice on our home page.
 
     %h3.govuk-heading-m Information About Us
@@ -22,8 +22,8 @@
     %p If you choose, or are provided with, a user identification code, password or any other piece of information as part of our security procedures, you must treat such information as confidential, and you must not disclose it to any third party.
     %p We reserve the right to restrict or deny you access to all or some part of the Site if in our opinion, you have failed to comply with these General Terms.
 
-    %h3.govuk-heading-m Hyperlinking to the Teaching Jobs website
-    %p We do not object to you linking directly to pages on this site and you do not need to ask permission to do so. However, we do not permit our pages to be loaded into frames on your site. The Teaching Jobs pages must be displayed in the user's entire browser window.
+    %h3.govuk-heading-m Hyperlinking to the Teaching Vacancies website
+    %p We do not object to you linking directly to pages on this site and you do not need to ask permission to do so. However, we do not permit our pages to be loaded into frames on your site. The Teaching Vacancies pages must be displayed in the user's entire browser window.
     %p You may not charge your website's users to click on a link to any page on the Service.
 
     %h3.govuk-heading-m Third Party Content and Hyperlinking from the Service
@@ -66,7 +66,7 @@
     %h2.govuk-heading-l Terms and Conditions for Schools
     %h3.govuk-heading-m Using the Service
     %p Access and use by you of this Service constitutes your acceptance of these Terms and Conditions. This takes effect from the date on which you first use this website. If you do not agree to these terms, you must not use this website.
-    %p By using Teaching Jobs you agree to abide by the following terms and conditions.
+    %p By using Teaching Vacancies you agree to abide by the following terms and conditions.
 
     %h3.govuk-heading-m Unacceptable Use
     %p
@@ -87,11 +87,11 @@
     %p The Department for Education withholds the right to withdraw without notice listings that breach these terms and to withdraw the access of users who breach them.
 
     %h3.govuk-heading-m Listing Data
-    %p Application Programming Interface (API) use: listings are published under the <a href='http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/open-government-licence/' target='_blank' class='govuk-link'>Open Government License</a> (OGL), which permits a wide range of information in the public sector to be reused free of charge. This means the listing data on Teaching Jobs will be available to third parties to publish on external sites after the pilot phase, aside from where <a href='http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/open-government-licence/exceptions-to-ogl/' target='_blank' class='govuk-link'>exceptions to the OGL</a> prohibit it.
+    %p Application Programming Interface (API) use: listings are published under the <a href='http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/open-government-licence/' target='_blank' class='govuk-link'>Open Government License</a> (OGL), which permits a wide range of information in the public sector to be reused free of charge. This means the listing data on Teaching Vacancies will be available to third parties to publish on external sites after the pilot phase, aside from where <a href='http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/open-government-licence/exceptions-to-ogl/' target='_blank' class='govuk-link'>exceptions to the OGL</a> prohibit it.
     %p Data ownership: schools have sole responsibility for maintaining the accuracy and appropriateness of the data contained in their listings.
 
     %h3.govuk-heading-m Terms and Conditions for API users
     %p
       You are free to reuse job listing data under the terms of the <a href='https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/' target='_blank' class='govuk-link'>Open Government Licence</a> for public sector information with the following exception:
       %ul.govuk-list.govuk-list--bullet
-        %li you may not charge a school any fee or commission for contacting, interviewing or hiring a respondent to your advertisement or listing if it is based on Teaching Jobs data that you have reused.
+        %li you may not charge a school any fee or commission for contacting, interviewing or hiring a respondent to your advertisement or listing if it is based on Teaching Vacancies data that you have reused.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -99,6 +99,6 @@ Rails.application.configure do
   config.action_dispatch.trusted_proxies = AWSIpRanges.cloudfront_ips.map { |proxy| IPAddr.new(proxy) }
 end
 
-DOMAIN = ENV.fetch('DOMAIN') { 'teaching-jobs.service.gov.uk' }
+DOMAIN = ENV.fetch('DOMAIN') { 'teaching-vacancies.service.gov.uk' }
 domain = URI(DOMAIN)
 Rails.application.routes.default_url_options[:host] = domain.to_s

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,7 +9,7 @@ en:
         precision: 0
         delimiter: ','
   app:
-    title: 'Teaching Jobs'
+    title: 'Teaching Vacancies'
     menu: 'Menu'
     description: 'The free service for schools in England to list teaching roles and for jobseekers to find them.'
   nav:
@@ -18,9 +18,9 @@ en:
     school_page_link: 'Manage jobs'
     jobseekers_index_link: 'View public jobs'
   sign_in:
-    title: 'Sign in to Teaching Jobs'
+    title: 'Sign in to Teaching Vacancies'
     link: 'Sign in'
-    guidance: 'Once you have received an email invitation from Teaching Jobs you can sign in to this service. %{link}'
+    guidance: 'Once you have received an email invitation from Teaching Vacancies you can sign in to this service. %{link}'
     organisation:
       title: 'Select your organisation'
       legend: 'You are associated with more than one organisation, please select the one you wish to sign-in with.'
@@ -223,7 +223,7 @@ en:
           - 'end date (for fixed-term jobs)'
   terms_and_conditions:
     page_title: 'Terms and Conditions'
-    intro: 'Before listing any role at your school on Teaching Jobs you must first read our Terms and Conditions and agree to abide by them.'
+    intro: 'Before listing any role at your school on Teaching Vacancies you must first read our Terms and Conditions and agree to abide by them.'
     intro_link: 'Of particular importance is the section %{link} which includes:'
     summary_list:
       - 'Using the Service'
@@ -231,10 +231,10 @@ en:
       - 'Access to the Service'
       - 'Listing data'
     please_accept: 'Please accept the terms and conditions'
-    label: 'I agree to all of the Terms and Conditions of the Teaching Jobs service.'
+    label: 'I agree to all of the Terms and Conditions of the Teaching Vacancies service.'
   stats:
     title: Statistics
-    intro: This page is an event log used by the service team to measure and monitor the stability and performance of Teaching Jobs. It keeps a live count of key user interactions with the service since 20 April 2018 (the date we began recording statistics).
+    intro: This page is an event log used by the service team to measure and monitor the stability and performance of Teaching Vacancies. It keeps a live count of key user interactions with the service since 20 April 2018 (the date we began recording statistics).
   buttons:
     apply_filters: 'Search'
     apply_filters_if_criteria: 'Refine search'
@@ -286,17 +286,17 @@ en:
         text:
           - You can register your interest to use the service by emailing %{mailto_url}. It is currently open to schools in Cambridgeshire and the North East but will be rolled out in phases to other areas across England.
 
-          - If your Teaching Jobs account has already been set up but you are unable to sign in, email the same address with "help" in the subject line.
+          - If your Teaching Vacancies account has already been set up but you are unable to sign in, email the same address with "help" in the subject line.
       with_email:
         text:
-          - You've tried to sign in with %{email}, which is not authorised to list jobs for this school. If you have an authorised account associated with another email, you must sign %{email} out of DfE Sign-in, then sign into Teaching Jobs with your authorised email. You can do this at %{signin_url}
+          - You've tried to sign in with %{email}, which is not authorised to list jobs for this school. If you have an authorised account associated with another email, you must sign %{email} out of DfE Sign-in, then sign into Teaching Vacancies with your authorised email. You can do this at %{signin_url}
 
-          - If you don't have a Teaching Jobs account you will need to wait for an invitation for one. Invitations are being sent out gradually, by region. When you have accepted the invitation and created your account you will be able to start listing roles at your school.
+          - If you don't have a Teaching Vacancies account you will need to wait for an invitation for one. Invitations are being sent out gradually, by region. When you have accepted the invitation and created your account you will be able to start listing roles at your school.
 
-          - Read the Teaching Jobs %{blog_url} to learn when schools in your area will be invited.
+          - Read the Teaching Vacancies %{blog_url} to learn when schools in your area will be invited.
 
-          - If your Teaching Jobs account has already been set up but you are unable to sign in, email %{mailto_url} with "help" in the subject line.
+          - If your Teaching Vacancies account has already been set up but you are unable to sign in, email %{mailto_url} with "help" in the subject line.
 
-          - The Teaching Jobs team
+          - The Teaching Vacancies team
   beta_banner:
     line_1: 'This service is in development and lists jobs in select areas of England. It will be %{link} to new areas, so check back regularly for new listings.'

--- a/spec/features/support_links_spec.rb
+++ b/spec/features/support_links_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature 'A visitor to the website can access the support links' do
     click_on 'Cookies'
 
     expect(page).to have_content('Cookies')
-    expect(page).to have_content('‘Teaching Jobs’ puts small files (known as ‘cookies’) onto your computer ' \
+    expect(page).to have_content('‘Teaching Vacancies’ puts small files (known as ‘cookies’) onto your computer ' \
                                  'to collect information about how you use the site.')
   end
 
@@ -14,12 +14,12 @@ RSpec.feature 'A visitor to the website can access the support links' do
     visit root_path
     click_on 'Privacy policy'
 
-    expect(page).to have_content('Privacy Notice: Teaching Jobs')
+    expect(page).to have_content('Privacy Notice: Teaching Vacancies')
     expect(page).to have_content('This work is being carried out by Department for Education (DfE) Digital, ' \
                                  'which is a part of DfE. DfE engages the private company dxw to help improve ' \
                                  'and provide the service. For the purpose of data protection legislation, ' \
                                  'the DfE is the data controller for the personal data processed as part of ' \
-                                 'Teaching Jobs. Teaching Jobs is a free and optional service for schools ' \
+                                 'Teaching Vacancies. Teaching Vacancies is a free and optional service for schools ' \
                                  'to advertise teaching roles.')
   end
 
@@ -30,7 +30,7 @@ RSpec.feature 'A visitor to the website can access the support links' do
     expect(page).to have_content('Terms and Conditions')
 
     expect(page).to have_content('Please read these Terms of Use (“General Terms”) carefully before using ' \
-                                 'this Teaching Jobs website (the “Service”).')
+                                 'this Teaching Vacancies website (the “Service”).')
   end
 
   context 'the roll out blog link' do

--- a/spec/requests/stats_spec.rb
+++ b/spec/requests/stats_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Teaching Jobs stats', type: :request do
+RSpec.describe 'Teaching Vacancies stats', type: :request do
   context 'returns a JSON of useful information about the app' do
     context 'default usage' do
       it 'it includes all audited information' do


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/4DlTx5xs/551-prep-for-service-rename-content-changes-to-the-service

## Changes in this PR:
Change Teaching Jobs to Teaching Vacancies as part of prep for service rename.

## Next steps:
- [x] Terraform deployment required?
- [x] New development configuration to be shared?
