### PR TITLE
[feature][493] add meta description and set mobile view meta tags

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -6,8 +6,8 @@
   %head
     = render partial: 'shared/gtag'
     = render partial: 'shared/open_graph'
+    = render partial: 'shared/meta'
     %meta{charset: "utf-8"}/
-    %meta{name: 'description', content: "#{t('app.description')}"}/
     %title #{content_for :page_title_prefix} — #{t('app.title')}
     %meta{content: "width=device-width, initial-scale=1", name: "viewport"}/
     %meta{content: "blue", name: "theme-color"}/

--- a/app/views/shared/_meta.html.haml
+++ b/app/views/shared/_meta.html.haml
@@ -1,0 +1,5 @@
+%meta{name: 'title', content: "#{content_for :page_title_prefix}".strip}/
+- if content_for :page_description
+  %meta{name: 'description', content: "#{content_for :page_description}".strip}/
+- else
+  %meta{name: 'description', content: I18n.t('app.description')}/

--- a/app/views/vacancies/_show.html+phone.haml
+++ b/app/views/vacancies/_show.html+phone.haml
@@ -1,6 +1,9 @@
 - content_for :page_title_prefix do
   #{@vacancy.job_title} — #{@vacancy.school_name}
 
+- content_for :page_description do
+  = strip_tags(@vacancy.job_description)
+
 .vacancy.govuk-grid-row
   - if @vacancy.expired?
     .govuk-grid-column-full

--- a/spec/features/job_seekers_can_view_a_vacancy_on_mobile_spec.rb
+++ b/spec/features/job_seekers_can_view_a_vacancy_on_mobile_spec.rb
@@ -1,12 +1,33 @@
 require 'rails_helper'
 
 RSpec.feature 'Viewing a single vacancy on mobile' do
-  scenario 'Published vacancies are viewable' do
+  before(:each) do
     page.driver.header('User-Agent', USER_AGENTS['MOBILE_CHROME'])
+  end
+
+  scenario 'Published vacancies are viewable' do
     published_vacancy = VacancyPresenter.new(create(:vacancy, :published))
 
     visit job_path(published_vacancy)
-
     verify_vacancy_show_page_details(published_vacancy)
+  end
+
+  context 'meta tags' do
+    include ActionView::Helpers::SanitizeHelper
+    scenario 'the vacancy\'s meta data are rendered correctly' do
+      vacancy = VacancyPresenter.new(create(:vacancy, :published))
+      visit job_path(vacancy)
+
+      expect(page.find('meta[name="description"]', visible: false)['content'])
+        .to eq(strip_tags(vacancy.job_description))
+    end
+
+    scenario 'the vacancy\'s open graph meta data are rendered correctly' do
+      vacancy = VacancyPresenter.new(create(:vacancy, :published))
+      visit job_path(vacancy)
+
+      expect(page.find('meta[property="og:description"]', visible: false)['content'])
+        .to eq(strip_tags(vacancy.job_description))
+    end
   end
 end

--- a/spec/features/job_seekers_can_view_a_vacancy_spec.rb
+++ b/spec/features/job_seekers_can_view_a_vacancy_spec.rb
@@ -116,4 +116,23 @@ RSpec.feature 'Viewing a single published vacancy' do
       end
     end
   end
+
+  context 'meta tags' do
+    include ActionView::Helpers::SanitizeHelper
+    scenario 'the vacancy\'s meta data are rendered correctly' do
+      vacancy = VacancyPresenter.new(create(:vacancy, :published))
+      visit job_path(vacancy)
+
+      expect(page.find('meta[name="description"]', visible: false)['content'])
+        .to eq(strip_tags(vacancy.job_description))
+    end
+
+    scenario 'the vacancy\'s open graph meta data are rendered correctly' do
+      vacancy = VacancyPresenter.new(create(:vacancy, :published))
+      visit job_path(vacancy)
+
+      expect(page.find('meta[property="og:description"]', visible: false)['content'])
+        .to eq(strip_tags(vacancy.job_description))
+    end
+  end
 end


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/8xlm4kc8/493-optimise-meta-description-of-individual-vacancy

## Changes in this PR:
- add missing `content_for :page_description` to mobile view to ensure both open graph and other met tags are correctly populated
- populate meta 'description' similar to 'og:description' for Google card view to be optimised
- add specs to verify all meta tags in both browser and mobile vacancy views
