### PR TITLE
(fix) text amend to ‘unauthorised user’ heading

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -281,7 +281,7 @@ en:
 
   static_pages:
     not_authorised:
-      title: You are not yet authorised to use the Teaching Jobs service
+      title: The email you're signed in with hasn't been authorised to list jobs for this school
       without_email:
         text:
           - You can register your interest to use the service by emailing %{mailto_url}. It is currently open to schools in Cambridgeshire and the North East but will be rolled out in phases to other areas across England.


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/5JziHG2w/552-change-header-on-error-for-authenticated-but-unauthorised-hiring-staff

## Changes in this PR:
Text amends.

## Screenshots of UI changes:

### Before
<img width="749" alt="screenshot_2018-10-25_at_11 47 44" src="https://user-images.githubusercontent.com/822507/47849251-d1ed7d00-ddc8-11e8-9ea5-60f75b1d0263.png">

### After
<img width="679" alt="screenshot 2018-11-01 at 11 12 30" src="https://user-images.githubusercontent.com/822507/47849257-d6199a80-ddc8-11e8-851b-2444345586aa.png">
