### PR TITLE
[feature][556] version our api per the gds standard

### DIFF
--- a/app/views/api/vacancies/index.json.jbuilder
+++ b/app/views/api/vacancies/index.json.jbuilder
@@ -1,3 +1,19 @@
-json.vacancies @vacancies.decorated_collection do |vacancy|
+json.info do
+  json.title "GOV UK - #{I18n.t('app.title')}"
+  json.description I18n.t('app.description')
+  json.termsOfService terms_and_conditions_url(protocol: 'https', anchor: 'api')
+  json.contact do
+    json.name "#{I18n.t('app.title')} API Support"
+    json.email I18n.t('help.email')
+  end
+  json.license do
+    json.name 'Open Government License'
+    json.url 'https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/'
+  end
+  json.version '0.0.1'
+end
+json.openapi '3.0.0'
+
+json.data @vacancies.decorated_collection do |vacancy|
   json.partial! 'show.json.jbuilder', vacancy: vacancy
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,9 @@ Rails.application.routes.draw do
   end
 
   namespace :api do
-    resources :jobs, only: %i[index show], controller: 'vacancies'
+    scope 'v:api_version', api_version: /[1]/ do
+      resources :jobs, only: %i[index show], controller: 'vacancies'
+    end
   end
 
   resources :stats, only: [:index]

--- a/spec/controllers/api/vacancies_controller_spec.rb
+++ b/spec/controllers/api/vacancies_controller_spec.rb
@@ -23,6 +23,23 @@ RSpec.describe Api::VacanciesController, type: :controller do
       expect(response.status).to eq(Rack::Utils.status_code(:not_found))
     end
 
+    it 'returns the API\'s openapi version' do
+      get :index, params: { api_version: 1 }
+
+      expect(json[:openapi]).to eq('3.0.0')
+    end
+
+    it 'returns the API\'s info' do
+      get :index, params: { api_version: 1 }
+
+      info_object = json[:info]
+      expect(info_object[:title]).to eq("GOV UK - #{I18n.t('app.title')}")
+      expect(info_object[:description]).to eq(I18n.t('app.description'))
+      expect(info_object[:termsOfService])
+        .to eq(terms_and_conditions_url(protocol: 'https', anchor: 'api'))
+      expect(info_object[:contact][:email]).to eq(I18n.t('help.email'))
+    end
+
     it 'retrieves all available vacancies' do
       vacancies = create_list(:vacancy, 3)
 
@@ -31,9 +48,9 @@ RSpec.describe Api::VacanciesController, type: :controller do
       get :index, params: { api_version: 1 }
 
       expect(response.status).to eq(Rack::Utils.status_code(:ok))
-      expect(json[:vacancies].count).to eq(3)
+      expect(json[:data].count).to eq(3)
       vacancies.each do |v|
-        expect(json[:vacancies]).to include(vacancy_json_ld(VacancyPresenter.new(v)))
+        expect(json[:data]).to include(vacancy_json_ld(VacancyPresenter.new(v)))
       end
     end
   end


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/NcIX7BCB/556-version-our-api-per-the-gds-standard

## Changes in this PR:
- Adds version to API endpoint e.g. `/api/v1`
- Adds info object with version and other information
- Change `vacancies` to `data` following the [JSON API](https://jsonapi.org/format/) specification where `data` is the document's primary data. As this is a significant change we should include it as part of versioning so we are not required to move to v2.

## Screenshots of UI changes:

### Before
<img width="672" alt="screen_shot_2018-11-02_at_14_17_08" src="https://user-images.githubusercontent.com/159200/47920533-2c123f00-deaa-11e8-97fa-3569b5042e48.png">

### After
<img width="941" alt="screen_shot_2018-11-02_at_14_19_37_1" src="https://user-images.githubusercontent.com/159200/47920895-29fcb000-deab-11e8-81fc-48b4c1179c10.png">
