### PR TITLE
[feature][554] bulk download of vacancy data from the api per the gds standard

### DIFF
--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -1,2 +1,13 @@
 class Api::ApplicationController < ApplicationController
+  def set_headers
+    response.set_header('X-Robots-Tag', 'noarchive')
+  end
+
+  def verify_json_request
+    not_found unless request.format.json?
+  end
+
+  def verify_json_or_csv_request
+    not_found unless request.format.json? || request.format.csv?
+  end
 end

--- a/app/controllers/api/vacancies_controller.rb
+++ b/app/controllers/api/vacancies_controller.rb
@@ -1,10 +1,16 @@
 class Api::VacanciesController < Api::ApplicationController
-  before_action :verify_json_request
+  before_action :verify_json_request, only: %w[show]
+  before_action :verify_json_or_csv_request, only: %w[index]
 
   def index
     filters = VacancyFilters.new({})
     records = Vacancy.public_search(filters: filters, sort: {}).records
     @vacancies = VacanciesPresenter.new(records, searched: false)
+
+    respond_to do |format|
+      format.csv { send_data @vacancies.to_csv, filename: "#{Time.zone.now.iso8601}_jobs.csv", template: false }
+      format.json
+    end
   end
 
   def show
@@ -16,13 +22,5 @@ class Api::VacanciesController < Api::ApplicationController
 
   def id
     params[:id]
-  end
-
-  def set_headers
-    response.set_header('X-Robots-Tag', 'noarchive')
-  end
-
-  def verify_json_request
-    not_found unless request.format.json?
   end
 end

--- a/app/presenters/vacancies_presenter.rb
+++ b/app/presenters/vacancies_presenter.rb
@@ -1,5 +1,12 @@
 class VacanciesPresenter < BasePresenter
+  include ActionView::Helpers::UrlHelper
   attr_reader :decorated_collection, :searched
+
+  CSV_ATTRIBUTES = %w[title description jobBenefits datePosted educationRequirements qualifications
+                      experienceRequirements employmentType jobLocation.addressLocality
+                      jobLocation.addressRegion jobLocation.streetAddress jobLocation.postalCode url
+                      baseSalary.currency baseSalary.minValue baseSalary.maxValue baseSalary.unitText
+                      hiringOrganization.type hiringOrganization.name hiringOrganization.identifier].freeze
 
   def initialize(vacancies, searched:)
     @decorated_collection = vacancies.map { |v| VacancyPresenter.new(v) }
@@ -29,9 +36,40 @@ class VacanciesPresenter < BasePresenter
     end
   end
 
+  def to_csv
+    CSV.generate(headers: true) do |csv|
+      csv << CSV_ATTRIBUTES
+      @decorated_collection.map { |vacancy| csv << to_csv_row(vacancy) }
+    end
+  end
+
   private
 
   def total_count
     model.total_count
   end
+
+  # rubocop:disable Metrics/AbcSize
+  def to_csv_row(vacancy)
+    [vacancy.job_title,
+     vacancy.job_description,
+     vacancy.benefits,
+     vacancy.publish_on.to_time.iso8601,
+     vacancy.education,
+     vacancy.qualifications,
+     vacancy.experience,
+     vacancy.working_pattern_for_job_schema,
+     vacancy.school.town,
+     vacancy.school&.region&.name,
+     vacancy.school.address,
+     vacancy.school.postcode,
+     Rails.application.routes.url_helpers.job_url(vacancy, protocol: 'https'),
+     'GBP', vacancy.minimum_salary,
+     vacancy.maximum_salary,
+     'YEAR',
+     'School',
+     vacancy.school.name,
+     vacancy.school.urn]
+  end
+  # rubocop:enable Metrics/AbcSize
 end

--- a/spec/controllers/api/vacancies_controller_spec.rb
+++ b/spec/controllers/api/vacancies_controller_spec.rb
@@ -7,6 +7,23 @@ RSpec.describe Api::VacanciesController, type: :controller do
     request.accept = 'application/json'
   end
 
+  describe 'GET /api/v1/jobs.html' do
+    it 'returns status :not_found as only CSV and JSON format is allowed' do
+      get :index, params: { api_version: 1 }, format: :html
+
+      expect(response.status).to eq(Rack::Utils.status_code(:not_found))
+    end
+  end
+
+  describe 'GET /api/v1/jobs.csv' do
+    it 'robots are asked to index but not to follow' do
+      get :index, params: { api_version: 1 }, format: :csv
+
+      expect(response.status).to eq(Rack::Utils.status_code(:ok))
+      expect(response.content_type).to eq('text/csv')
+    end
+  end
+
   describe 'GET /api/v1/jobs.json', elasticsearch: true do
     render_views
 


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/VvzFdJsd/554-bulk-download-of-vacancy-data-from-the-api-per-the-gds-standard

## Changes in this PR:
Enables downloading of the data in csv format using the same field names as the JSON response.
