### PR TITLE
[568] Cloudfront caches all API requests

### DIFF
--- a/terraform/modules/cloudfront/cloudfront.tf
+++ b/terraform/modules/cloudfront/cloudfront.tf
@@ -99,6 +99,29 @@ resource "aws_cloudfront_distribution" "default" {
     viewer_protocol_policy = "redirect-to-https"
   }
 
+  cache_behavior {
+    allowed_methods  = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "${var.project_name}-${var.environment}-default-origin"
+
+    path_pattern = "/api/*"
+
+    forwarded_values = {
+      query_string = false
+      headers      = ["Host"]
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl     = 60
+    default_ttl = 900
+    max_ttl     = 86400
+
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
   price_class = "PriceClass_100"
 
   restrictions {


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/szyBtECp

## Changes in this PR:

* defaults to 15 minutes
* miniumum of 60 seconds to resist DOS attacks or events
* expires after a maximum of 24 hours
* to test on an environment with basic auth you also need to add the `Authorization` header to see the hits coming from Cloudfront

## Screenshots of UI changes:

### Before
```
HTTP/2 200 
content-type: application/json; charset=utf-8
date: Wed, 07 Nov 2018 16:40:07 GMT
x-frame-options: SAMEORIGIN
x-xss-protection: 1; mode=block
x-content-type-options: nosniff
x-download-options: noopen
x-permitted-cross-domain-policies: none
referrer-policy: strict-origin-when-cross-origin
x-robots-tag: noarchive
etag: W/"6cbaa8f3928f1a57459fd13ef973df6d"
cache-control: max-age=0, private, must-revalidate
x-request-id: 71319216-af9e-44d3-bc06-f3eaa4de03c1
x-runtime: 4.857703
strict-transport-security: max-age=31536000; includeSubDomains
x-cache: Miss from cloudfront
via: 1.1 ba7014bad8e9bf2ed075d09443ccc4f4.cloudfront.net (CloudFront)
x-amz-cf-id: 5PcjZN2ZE2AJI4T3SxzZZ5ZLInhg7J-1vXgdyK0WBxkKq4t7CpouKQ==
```
### After
Note the `x-cache: Hit from cloudfront` line.

```
HTTP/2 200 
content-type: application/json; charset=utf-8
date: Wed, 07 Nov 2018 17:05:50 GMT
x-frame-options: SAMEORIGIN
x-xss-protection: 1; mode=block
x-content-type-options: nosniff
x-download-options: noopen
x-permitted-cross-domain-policies: none
referrer-policy: strict-origin-when-cross-origin
x-robots-tag: noarchive
etag: W/"6cbaa8f3928f1a57459fd13ef973df6d"
cache-control: max-age=0, private, must-revalidate
x-request-id: df8fdb47-299f-4ae5-ba0e-cbc934653d66
x-runtime: 2.296244
strict-transport-security: max-age=31536000; includeSubDomains
age: 2
x-cache: Hit from cloudfront
via: 1.1 9b873c22fb06a32f8142a90b7071aba9.cloudfront.net (CloudFront)
x-amz-cf-id: kcCuOsRyLJ2Y2I-KeV4WvmtgCy7NI0_p1TwXqNZ4rkbhn30ITg4uow==
```

## Next steps:

- [x] Terraform deployment required?

- [ ] New development configuration to be shared?
