### PR TITLE
[feature][555] set API encoding to UTF-8

### DIFF
--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -1,6 +1,7 @@
 class Api::ApplicationController < ApplicationController
   def set_headers
     response.set_header('X-Robots-Tag', 'noarchive')
+    response.charset = 'utf-8'
   end
 
   def verify_json_request

--- a/spec/controllers/api/vacancies_controller_spec.rb
+++ b/spec/controllers/api/vacancies_controller_spec.rb
@@ -25,17 +25,8 @@ RSpec.describe Api::VacanciesController, type: :controller do
     context 'sets headers' do
       before(:each) { get :index, params: { api_version: 1 }, format: :csv }
 
-      describe 'X-Robots-Tag' do
-        it 'robots are asked to index but not to follow' do
-          expect(response.headers['X-Robots-Tag']).to eq('noarchive')
-        end
-      end
-
-      describe 'Content-Type' do
-        it 'type is set to text/csv' do
-          expect(response.content_type).to eq('text/csv')
-        end
-      end
+      it_behaves_like 'X-Robots-Tag'
+      it_behaves_like 'Content-Type CSV'
     end
   end
 
@@ -45,21 +36,8 @@ RSpec.describe Api::VacanciesController, type: :controller do
     context 'sets headers' do
       before(:each) { get :index, params: { api_version: 1 } }
 
-      describe 'X-Robots-Tag' do
-        it 'robots are asked to index but not to follow' do
-          expect(response.headers['X-Robots-Tag']).to eq('noarchive')
-        end
-      end
-
-      describe 'Content-Type' do
-        it 'charset is set to UTF-8' do
-          expect(response.charset.to_s).to eq('utf-8')
-        end
-
-        it 'type is set to application/json' do
-          expect(response.content_type).to include('application/json')
-        end
-      end
+      it_behaves_like 'X-Robots-Tag'
+      it_behaves_like 'Content-Type JSON'
     end
 
     it 'returns status :not_found if the request format is not JSON' do
@@ -113,21 +91,8 @@ RSpec.describe Api::VacanciesController, type: :controller do
     context 'sets headers' do
       before(:each) { get :show, params: { id: vacancy.slug, api_version: 1 } }
 
-      describe 'X-Robots-Tag' do
-        it 'robots are asked to index but not to follow' do
-          expect(response.headers['X-Robots-Tag']).to eq('noarchive')
-        end
-      end
-
-      describe 'Content-Type' do
-        it 'charset is set to UTF-8' do
-          expect(response.charset.to_s).to eq('utf-8')
-        end
-
-        it 'type is set to text/csv' do
-          expect(response.content_type).to eq('application/json')
-        end
-      end
+      it_behaves_like 'X-Robots-Tag'
+      it_behaves_like 'Content-Type JSON'
     end
 
     it 'returns status code :ok' do

--- a/spec/support/shared_examples/api.rb
+++ b/spec/support/shared_examples/api.rb
@@ -1,0 +1,31 @@
+RSpec.shared_examples 'X-Robots-Tag' do
+  describe 'X-Robots-Tag' do
+    it 'robots are asked to index but not to follow' do
+      expect(response.headers['X-Robots-Tag']).to eq('noarchive')
+    end
+  end
+end
+
+RSpec.shared_examples 'charset is UTF-8' do
+  it 'charset is set to UTF-8' do
+    expect(response.charset.to_s.downcase).to eq('utf-8')
+  end
+end
+
+RSpec.shared_examples 'Content-Type JSON' do
+  describe 'Content-Type' do
+    it_behaves_like 'charset is UTF-8'
+
+    it 'type is set to application/json' do
+      expect(response.content_type).to include('application/json')
+    end
+  end
+end
+
+RSpec.shared_examples 'Content-Type CSV' do
+  describe 'Content-Type' do
+    it 'type is set to text/csv' do
+      expect(response.content_type).to include('text/csv')
+    end
+  end
+end


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/KT55M2Cw/555-ensure-all-api-encoding-is-utf-8-per-the-gds-standard

## Changes in this PR:
Ensures that response charset is set to `UTF-8` for all JSON API requests
