### PR TITLE
(fix) Only show these warnings in Rails development env

### DIFF
--- a/config/initializers/authorisation_service.rb
+++ b/config/initializers/authorisation_service.rb
@@ -1,10 +1,10 @@
 AUTHORISATION_SERVICE_URL = ENV['AUTHORISATION_SERVICE_URL']
 AUTHORISATION_SERVICE_TOKEN = ENV['AUTHORISATION_SERVICE_TOKEN']
 
-if AUTHORISATION_SERVICE_URL.nil?
+if AUTHORISATION_SERVICE_URL.nil? && Rails.env.development?
   Rails.logger.error('***No authorisation service url configured. To configure set AUTHORISATION_SERVICE_URL')
 end
 
-if AUTHORISATION_SERVICE_TOKEN.nil?
+if AUTHORISATION_SERVICE_TOKEN.nil? && Rails.env.development?
   Rails.logger.error('***No authorisation service token configured. To configure set AUTHORISATION_SERVICE_TOKEN')
 end


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/Clj34m9S/570-prod-stage-report-that-no-authorisation-env-is-set-bug

## Changes in this PR:

Wrap the missing `AUTHORISATION_SERVICE_URL` and AUTHORISATION_SERVICE_TOKEN` warnings in Rails.env.development? so that they don't appear in production.

We decided to only show these warnings in development. In production this warning will be handled by Rollbar.

I wanted to test this, perhaps in `spec/services/teacher_vacancy_authorisation_spec.rb` but it's hard to test initializers with rspec. I can keep plugging away at it if it's important?

