### PR TITLE
(fix) Static pages should not have NOINDEX unless it is the user-not-…

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -4,4 +4,9 @@ class PagesController < ApplicationController
   def invalid_page
     redirect_to '/404'
   end
+
+  def set_headers
+    return super if page_path.include?('user-not-authorised')
+    response.set_header('X-Robots-Tag', 'index, nofollow')
+  end
 end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -9,6 +9,14 @@ RSpec.describe PagesController, type: :controller do
 
       it { should respond_with(:success) }
       it { should render_template(page) }
+
+      it 'should not have a noindex header, unless it is the unauthorised user page' do
+        if page == 'user-not-authorised'
+          expect(response.headers['X-Robots-Tag']).to include('noindex')
+        else
+          expect(response.headers['X-Robots-Tag']).to_not include('noindex')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
…authorised page

## Trello card URL:

https://trello.com/c/JfT23ZhJ/579-fix-google-search-coverage-error-for-static-pages-that-are-included-in-the-sitemap

## Changes in this PR:

Remove the NOINDEX header from static pages so that Google will index them.

However, I have left NOINDEX on the `user-not-authorised` page as I don't think we want Google to crawl that (@tahb can you confirm?)