### PR TITLE
[591] Redirect traffic to the old service hostname

### DIFF
--- a/terraform.tf
+++ b/terraform.tf
@@ -39,6 +39,9 @@ module "core" {
   asg_min_size     = "${var.asg_min_size}"
   asg_desired_size = "${var.asg_desired_size}"
 
+  domain = "${var.domain}"
+  redirect_old_teachingjobs_traffic = "${var.redirect_old_teachingjobs_traffic}"
+
   ecs_cluster_name                  = "${module.ecs.cluster_name}"
   ecs_service_web_name              = "${module.ecs.web_service_name}"
   aws_iam_ecs_instance_profile_name = "${module.ecs.aws_iam_ecs_instance_profile_name}"

--- a/terraform/modules/core/core.tf
+++ b/terraform/modules/core/core.tf
@@ -210,6 +210,27 @@ resource "aws_alb_listener" "default" {
   depends_on = ["aws_alb_target_group.alb_target_group"]
 }
 
+resource "aws_lb_listener_rule" "redirect_old_teachingjobs_http_traffic" {
+  count = "${var.redirect_old_teachingjobs_traffic}"
+  listener_arn = "${aws_alb_listener.default.arn}"
+
+  action {
+    type = "redirect"
+
+    redirect {
+      host        = "${var.domain}"
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+
+  condition {
+    field  = "host-header"
+    values = ["teaching-jobs.service.gov.uk"]
+  }
+}
+
 resource "aws_alb_listener" "default_https" {
   load_balancer_arn = "${aws_alb.alb_default.arn}"
   port              = "443"
@@ -223,6 +244,27 @@ resource "aws_alb_listener" "default_https" {
   }
 
   depends_on = ["aws_alb_target_group.alb_target_group"]
+}
+
+resource "aws_lb_listener_rule" "redirect_old_teachingjobs_https_traffic" {
+  count = "${var.redirect_old_teachingjobs_traffic}"
+  listener_arn = "${aws_alb_listener.default_https.arn}"
+
+  action {
+    type = "redirect"
+
+    redirect {
+      host        = "${var.domain}"
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+
+  condition {
+    field  = "host-header"
+    values = ["teaching-jobs.service.gov.uk"]
+  }
 }
 
 resource "aws_alb_target_group" "alb_target_group" {

--- a/terraform/modules/core/input.tf
+++ b/terraform/modules/core/input.tf
@@ -31,5 +31,8 @@ variable "asg_max_size" {}
 variable "asg_min_size" {}
 variable "asg_desired_size" {}
 
+variable "domain" {}
+variable "redirect_old_teachingjobs_traffic" {}
+
 variable "ecs_cluster_name" {}
 variable "ecs_service_web_name" {}

--- a/variables.tf
+++ b/variables.tf
@@ -85,6 +85,9 @@ variable "alb_certificate_arn" {
   description = "The certificate ARN to attach to the ALB's HTTPS listener"
 }
 
+variable "domain" {}
+variable "redirect_old_teachingjobs_traffic" {}
+
 # ECS
 variable "ecs_cluster_name" {}
 
@@ -313,7 +316,6 @@ variable "google_drive_json_key" {
   type = "map"
 }
 variable "published_vacancy_spreadsheet_id" {}
-variable "domain" {}
 variable "google_geocoding_api_key" {}
 variable "rollbar_access_token" {}
 variable "pp_transactions_by_channel_token" {}


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/EMDwIScy

## Changes in this PR:
* I've tested this on Edge. you can test by curling tvs.edge.dxw.net and tvs.edge2.dxw.net. The first should be a 301 redirect and the second should be as normal.
* Both HTTP and HTTPS
* Permanent solution part of the core infrastructure rather than using another service for redirection. This change is designed to be permanent since teaching-jobs.service.gov.uk has been seen, used and linked to by users in public beta
* More reliable than using a redirection service hosted somewhere
* Can turn it on/off per environment via environment variable so it can the redirect will only be running in production where more than 1 domain exists

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [x] Terraform deployment required?

- [ ] New development configuration to be shared?
