### PR TITLE
[594] API returns as many jobs by default as possible

### DIFF
--- a/app/controllers/api/vacancies_controller.rb
+++ b/app/controllers/api/vacancies_controller.rb
@@ -3,8 +3,7 @@ class Api::VacanciesController < Api::ApplicationController
   before_action :verify_json_or_csv_request, only: %w[index]
 
   def index
-    filters = VacancyFilters.new({})
-    records = Vacancy.public_search(filters: filters, sort: {}).records
+    records = Vacancy.listed.where.not(status: :draft).where.not(status: :trashed)
     @vacancies = VacanciesPresenter.new(records, searched: false)
 
     respond_to do |format|

--- a/spec/services/auditor_spec.rb
+++ b/spec/services/auditor_spec.rb
@@ -62,6 +62,8 @@ RSpec.describe 'Auditor::Auth' do
       expect(latest_activities.count).to eq(2)
       expect(latest_activities.first.key).to eq('azure.authentication')
       expect(latest_activities.last.key).to eq('dfe-sign-in.authentication.failure')
+
+      Timecop.return
     end
   end
 end


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/S84E2Fvl

## Changes in this PR:
* We cannot yet make assumptions about the users of the API, if this is someone who wants information on expired listings or someone else who wants to use the data to publish on their site. By folllowing the standard, we make all data that’s been made public past and present available by default. In future, we can add filter parameters to help users get to the subsets of data they want more efficiently.
* Does not couple itself to the other user search code as the needs of this endpoint are different from the needs of users searching through the front end. We may introduce “API search” in future but we shouldn’t set early assumptions that they will use the same code. This is already an issue as lots more code is being run than nescassry to fulfill the task at hand and is prone to any changes we do for job seeker users.
* We don’t want to accidentally call any extra code like Rollbar.info(‘0 results searched’) which could lead to misleading data.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
