### PR TITLE
(fix) Back link from job page should preserve query string

### DIFF
--- a/app/views/vacancies/_back_link.html.haml
+++ b/app/views/vacancies/_back_link.html.haml
@@ -1,3 +1,3 @@
 .govuk-grid-row
   .govuk-grid-column-full
-    = link_to 'Back', root_path, class: 'govuk-back-link'
+    = link_to t('nav.back'), url_for(:back), class: 'govuk-back-link'

--- a/app/views/vacancies/_back_link.html.haml
+++ b/app/views/vacancies/_back_link.html.haml
@@ -1,3 +1,6 @@
 .govuk-grid-row
   .govuk-grid-column-full
-    = link_to t('nav.back'), url_for(:back), class: 'govuk-back-link'
+    -if request.referrer
+      = link_to t('nav.back'), request.referrer, class: 'govuk-back-link'
+    -else
+      = link_to t('nav.back'), root_path, class: 'govuk-back-link'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,6 +17,7 @@ en:
     sign_out: 'Sign out'
     school_page_link: 'Manage jobs'
     jobseekers_index_link: 'View public jobs'
+    back: 'Back'
   sign_in:
     title: 'Sign in to Teaching Jobs'
     link: 'Sign in'

--- a/spec/features/job_seekers_can_search_vacancies_spec.rb
+++ b/spec/features/job_seekers_can_search_vacancies_spec.rb
@@ -157,4 +157,25 @@ RSpec.feature 'Searching vacancies by keyword' do
       expect(page).to have_content('0 jobs match your search.')
     end
   end
+
+  context 'search parameters are persisted on navigation' do
+    scenario 'back link perists search params' do
+      create(:vacancy, job_title: 'Maths Teacher')
+
+      Vacancy.__elasticsearch__.client.indices.flush
+
+      visit jobs_path
+
+      within '.filters-form' do
+        fill_in 'keyword', with: 'Math'
+        page.find('.govuk-button[type=submit]').click
+      end
+
+      page.find('.view-vacancy-link').click
+      expect(page).to have_content('Maths Teacher')
+
+      page.find('.govuk-back-link').click
+      expect(page.current_url).to include('keyword=Math')
+    end
+  end
 end


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/nB5v9dZ8/593-bug-back-link-from-a-job-page-doesnt-persist-search-query

## Changes in this PR:

Use the `url_for(:back)` helper to preserve any query params on the referrer url. 