### PR TITLE
(fix) Use `.in_time_zone` to avoid any timezone issues with dates

### DIFF
--- a/lib/tasks/performance_platform.rake
+++ b/lib/tasks/performance_platform.rake
@@ -8,12 +8,12 @@ namespace :performance_platform do
   end
 
   task submit_transactions: :environment do
-    yesteday = Date.current.beginning_of_day - 1.day
+    yesteday = Date.current.beginning_of_day.in_time_zone - 1.day
     PerformancePlatformFeedbackQueueJob.perform_later(yesteday.to_s)
   end
 
   task submit_user_satisfaction: :environment do
-    yesterday = Date.current.beginning_of_day - 1.day
+    yesterday = Date.current.beginning_of_day.in_time_zone - 1.day
     PerformancePlatformTransactionsQueueJob.perform_later(yesterday.to_s)
   end
 
@@ -23,7 +23,7 @@ namespace :performance_platform do
     number_of_days = current_date.mjd - start_date.mjd
 
     while number_of_days.positive?
-      date = Date.current.beginning_of_day - number_of_days.day
+      date = Date.current.beginning_of_day.in_time_zone - number_of_days.day
       PerformancePlatformFeedbackQueueJob.perform_later(date.to_s)
       PerformancePlatformTransactionsQueueJob.perform_later(date.to_s)
       number_of_days -= 1

--- a/spec/jobs/performance_platform_feedback_queue_job_spec.rb
+++ b/spec/jobs/performance_platform_feedback_queue_job_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe PerformancePlatformFeedbackQueueJob, type: :job do
   include ActiveJob::TestHelper
 
-  subject(:date) { Date.current.beginning_of_day }
+  subject(:date) { Date.current.beginning_of_day.in_time_zone }
   subject(:job) { described_class.perform_later(date.to_s) }
 
   it 'queues the job' do

--- a/spec/jobs/performance_platform_transactions_queue_job_spec.rb
+++ b/spec/jobs/performance_platform_transactions_queue_job_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe PerformancePlatformTransactionsQueueJob, type: :job do
   include ActiveJob::TestHelper
 
-  subject(:date) { Date.current.beginning_of_day }
+  subject(:date) { Date.current.beginning_of_day.in_time_zone }
   subject(:job) { described_class.perform_later(date.to_s) }
 
   it 'queues the job' do

--- a/spec/lib/tasks/performance_platform_rake_spec.rb
+++ b/spec/lib/tasks/performance_platform_rake_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 RSpec.describe 'rake performance_platform:submit_transactions', type: :task do
   it 'Submits job publication transactions for the previous day' do
-    today = Date.current.beginning_of_day
+    today = Date.current.beginning_of_day.in_time_zone
     expect(Date).to receive_message_chain(:current, :beginning_of_day).and_return(today)
 
     expect(PerformancePlatformFeedbackQueueJob).to receive(:perform_later).with((today - 1.day).to_s)
@@ -12,7 +12,7 @@ end
 
 RSpec.describe 'rake performance_platform:submit_user_satisfaction', type: :task do
   it 'Submits user satisfaction for the previous day' do
-    today = Date.current.beginning_of_day
+    today = Date.current.beginning_of_day.in_time_zone
     expect(Date).to receive_message_chain(:current, :beginning_of_day).and_return(today)
 
     expect(PerformancePlatformTransactionsQueueJob).to receive(:perform_later).with((today - 1.day).to_s)


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/uFwUkNWe/540-bug-make-sure-time-zone-is-correctly-used-in-performanceplatform-rake-task

## Changes in this PR:

Use `.in_time_zone` qualifier on calls to Date, to ensure we don't have any date conflicts as per https://github.com/rails/rails/issues/30870