### PR TITLE
(chore) link to API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Teacher Vacancy Service (TVS)
 
+[API Documentation](https://dfe-digital.github.io/teaching-jobs-api-docs)
+
 ### Prerequisites
  - [Docker](https://docs.docker.com/docker-for-mac) greater than or equal to `18.03.1-ce-mac64 (24245)`
 


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/sb5gn0fQ/425-document-the-api-to-the-gds-standard

## Changes in this PR:
Adds link to API docs in README