### PR TITLE
(fix) Testing with expired vacancies is less fragile

### DIFF
--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -79,8 +79,8 @@ FactoryBot.define do
     trait :expired do
       status { :published }
       sequence(:slug) { |n| "slug-#{n}" }
-      publish_on { Faker::Time.backward(14) }
-      expires_on { Faker::Time.backward(7) }
+      publish_on { Faker::Time.between(Time.zone.today - 14.days, Time.zone.today - 7.days) }
+      expires_on { Faker::Time.backward(6) }
     end
 
     trait :future_publish do


### PR DESCRIPTION
## Trello card URL:

## Changes in this PR:
Sometimes when this test rungs and `publish_on { Faker::Time.backward(14) }` results in a date in the range of 7-14 days instead of 0-7 days, it fails validation that states the expiry must be after publish.

## Screenshots of UI changes:

### Before
<img width="1071" alt="screenshot 2018-11-19 at 16 57 55" src="https://user-images.githubusercontent.com/912473/48722595-4a9f6680-ec1c-11e8-9d4d-adc525f0a431.png">

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
