### PR TITLE
(fix) Revert email address back to  teaching.vacancies@education.gov.uk

### DIFF
--- a/app/views/hiring_staff/sign_in/dfe/sessions/user-not-authorised.html.haml
+++ b/app/views/hiring_staff/sign_in/dfe/sessions/user-not-authorised.html.haml
@@ -6,5 +6,5 @@
   .govuk-grid-column-two-thirds
     %h1.govuk-heading-xl=t('static_pages.not_authorised.title')
 
-    -t('static_pages.not_authorised.with_email.text', email: @identifier, signin_url: "<a href='https://profile.signin.education.gov.uk/' class='govuk-link'>https://profile.signin.education.gov.uk/</a>", blog_url: "<a href='https://dfedigital.blog.gov.uk/2018/09/21/how-were-rolling-out-our-search-and-listing-service-to-more-schools-to-support-their-teacher-recruitment-needs/' class='govuk-link'>blog on the service's phased roll-out</a>", mailto_url: "<a href='mailto:teachingjobs@digital.education.gov.uk', class='govuk-link'>teachingjobs@digital.education.gov.uk</a>").each do |p|
+    -t('static_pages.not_authorised.with_email.text', email: @identifier, signin_url: "<a href='https://profile.signin.education.gov.uk/' class='govuk-link'>https://profile.signin.education.gov.uk/</a>", blog_url: "<a href='https://dfedigital.blog.gov.uk/2018/09/21/how-were-rolling-out-our-search-and-listing-service-to-more-schools-to-support-their-teacher-recruitment-needs/' class='govuk-link'>blog on the service's phased roll-out</a>", mailto_url: "<a href='mailto:teaching.vacancies@education.gov.uk', class='govuk-link'>teaching.vacancies@education.gov.uk</a>").each do |p|
       %p=p.html_safe

--- a/app/views/pages/user-not-authorised.html.haml
+++ b/app/views/pages/user-not-authorised.html.haml
@@ -6,5 +6,5 @@
   .govuk-grid-column-two-thirds
     %h1.govuk-heading-xl=t('static_pages.not_authorised.title')
 
-    -t('static_pages.not_authorised.without_email.text', mailto_url: "<a href='mailto:teachingjobs@digital.education.gov.uk', class='govuk-link'>teachingjobs@digital.education.gov.uk</a>").each do |p|
+    -t('static_pages.not_authorised.without_email.text', mailto_url: "<a href='mailto:teaching.vacancies@education.gov.uk', class='govuk-link'>teaching.vacancies@education.gov.uk</a>").each do |p|
       %p=p.html_safe

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -278,7 +278,7 @@ en:
     server_error: Something went wrong at our end.
 
   help:
-    email: teachingjobs@digital.education.gov.uk
+    email: teaching.vacancies@education.gov.uk
 
   static_pages:
     not_authorised:


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/NlR6ykbK/606-switch-support-email-address-as-the-new-email-address-is-now-available#

## Changes in this PR:

Email `teaching.vacancies@education.gov.uk` is now available to use