### PR TITLE
(feature): Communicate the service name change in the banner

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -518,4 +518,4 @@ en:
           line_1: "You are free to reuse job listing data under the terms of the <a href='https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/' target='_blank' class='govuk-link'>Open Government Licence</a> for public sector information with the following exception:"
           list: you may not charge a school any fee or commission for contacting, interviewing or hiring a respondent to your advertisement or listing if it is based on Teaching Vacancies data that you have reused.
   beta_banner:
-    line_1: 'This service is in development and lists jobs in select areas of England. It will be %{link} to new areas, so check back regularly for new listings.'
+    line_1: 'Teaching Jobs was renamed Teaching Vacancies on 20 November. The service lists jobs in select areas of England. It will be %{link} to new areas, so check back regularly for new listings.'

--- a/spec/features/job_seekers_can_view_vacancies_spec.rb
+++ b/spec/features/job_seekers_can_view_vacancies_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'Viewing vacancies' do
 
   scenario 'View a banner with information about the service' do
     visit jobs_path
-    expect(page).to have_content('This service is in development and lists jobs in select areas of England.')
+    expect(page).to have_css('.flash.notice')
   end
 
   scenario 'There are enough vacancies to invoke pagination', elasticsearch: true do


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/NRipLbIP

## Changes in this PR:
* The hope is that if users miss their emails that include the update they will be able to gain confidence that this is the same service as before.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
