### PR TITLE
(chore) link to new API docs url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Teacher Vacancy Service (TVS)
 
-[API Documentation](https://dfe-digital.github.io/teaching-jobs-api-docs)
+[API Documentation](https://docs.teaching-vacancies.service.gov.uk)
 
 ### Prerequisites
  - [Docker](https://docs.docker.com/docker-for-mac) greater than or equal to `18.03.1-ce-mac64 (24245)`


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/xF65hec5/611-configure-cname-for-api-docs-and-share-link-to-new-url-from-tv-readme

## Changes in this PR:
Update API docs link to point to http://docs.teaching-vacancies.service.gov.uk/
