### PR TITLE
[Feature][619] publish events to audit spreadsheet

### DIFF
--- a/app/controllers/hiring_staff/vacancies/feedback_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/feedback_controller.rb
@@ -16,8 +16,8 @@ class HiringStaff::Vacancies::FeedbackController < HiringStaff::Vacancies::Appli
                                 comment: feedback_params[:comment])
 
     return render 'new' unless @feedback.save
+    audit_feedback(vacancy, @feedback)
 
-    Auditor::Audit.new(vacancy, 'vacancy.feedback.create', current_session_id).log
     redirect_to school_path, notice: I18n.t('messages.feedback.submitted')
   end
 
@@ -25,5 +25,15 @@ class HiringStaff::Vacancies::FeedbackController < HiringStaff::Vacancies::Appli
 
   def feedback_params
     params.require(:feedback).permit(:rating, :comment)
+  end
+
+  def audit_feedback(vacancy, feedback)
+    Auditor::Audit.new(vacancy, 'vacancy.feedback.create', current_session_id).log
+    AuditFeedbackJob.perform_later([feedback.created_at.iso8601.to_s,
+                                    current_session_id,
+                                    vacancy.id,
+                                    vacancy.school.urn,
+                                    feedback.rating,
+                                    feedback.comment])
   end
 end

--- a/app/controllers/interests_controller.rb
+++ b/app/controllers/interests_controller.rb
@@ -2,6 +2,10 @@ class InterestsController < ApplicationController
   def new
     vacancy = Vacancy.find(vacancy_id)
     Auditor::Audit.new(vacancy, 'vacancy.get_more_information', nil).log
+    AuditExpressInterestEventJob.perform_later([Time.zone.now.iso8601.to_s,
+                                                vacancy.id,
+                                                vacancy.school.urn,
+                                                vacancy.application_link])
     redirect_to(vacancy.application_link)
   end
 

--- a/app/jobs/audit_express_interest_event_job.rb
+++ b/app/jobs/audit_express_interest_event_job.rb
@@ -1,0 +1,9 @@
+class AuditExpressInterestEventJob < SpreadsheetWriterJob
+  WORKSHEET_POSITION = 2
+  queue_as :audit_express_interest_event
+
+  def perform(data)
+    return unless AUDIT_SPREADSHEET_ID
+    write_row(data, WORKSHEET_POSITION)
+  end
+end

--- a/app/jobs/audit_feedback_job.rb
+++ b/app/jobs/audit_feedback_job.rb
@@ -1,0 +1,9 @@
+class AuditFeedbackJob < SpreadsheetWriterJob
+  WORKSHEET_POSITION = 4
+  queue_as :audit_feedback
+
+  def perform(data)
+    return unless AUDIT_SPREADSHEET_ID
+    write_row(data, WORKSHEET_POSITION)
+  end
+end

--- a/app/jobs/audit_search_event_job.rb
+++ b/app/jobs/audit_search_event_job.rb
@@ -1,0 +1,9 @@
+class AuditSearchEventJob < SpreadsheetWriterJob
+  WORKSHEET_POSITION = 3
+  queue_as :audit_search_event
+
+  def perform(data)
+    return unless AUDIT_SPREADSHEET_ID
+    write_row(data, WORKSHEET_POSITION)
+  end
+end

--- a/app/jobs/audit_sign_in_event_job.rb
+++ b/app/jobs/audit_sign_in_event_job.rb
@@ -1,21 +1,15 @@
-require 'spreadsheet_writer'
 require 'message_encryptor'
 
-class AuditSignInEventJob < ApplicationJob
+class AuditSignInEventJob < SpreadsheetWriterJob
+  WORKSHEET_POSITION = 1
   queue_as :audit_sign_in_event
 
   def perform(audit_details)
     return unless AUDIT_SPREADSHEET_ID
-
-    write_row(decrypt_data(audit_details))
+    write_row(decrypt_data(audit_details), WORKSHEET_POSITION)
   end
 
   private
-
-  def write_row(row)
-    worksheet = Spreadsheet::Writer.new(AUDIT_SPREADSHEET_ID, 1)
-    worksheet.append(row)
-  end
 
   def decrypt_data(data)
     MessageEncryptor.new(data).decrypt

--- a/app/jobs/audit_toc_acceptance_event_job.rb
+++ b/app/jobs/audit_toc_acceptance_event_job.rb
@@ -1,0 +1,9 @@
+class AuditTocAcceptanceEventJob < SpreadsheetWriterJob
+  WORKSHEET_POSITION = 5
+  queue_as :audit_toc_acceptance_event
+
+  def perform(data)
+    return unless AUDIT_SPREADSHEET_ID
+    write_row(data, WORKSHEET_POSITION)
+  end
+end

--- a/app/jobs/spreadsheet_writer_job.rb
+++ b/app/jobs/spreadsheet_writer_job.rb
@@ -1,0 +1,17 @@
+require 'spreadsheet_writer'
+
+class SpreadsheetWriterJob < ApplicationJob
+  queue_as :google_spreadsheet_event
+
+  def perform(data)
+    return unless AUDIT_SPREADSHEET_ID
+    write_row(data)
+  end
+
+  private
+
+  def write_row(row, worksheet_position = 0)
+    worksheet = Spreadsheet::Writer.new(AUDIT_SPREADSHEET_ID, worksheet_position)
+    worksheet.append(row)
+  end
+end

--- a/app/jobs/spreadsheet_writer_job.rb
+++ b/app/jobs/spreadsheet_writer_job.rb
@@ -10,7 +10,7 @@ class SpreadsheetWriterJob < ApplicationJob
 
   private
 
-  def write_row(row, worksheet_position = 0)
+  def write_row(row, worksheet_position = 99)
     worksheet = Spreadsheet::Writer.new(AUDIT_SPREADSHEET_ID, worksheet_position)
     worksheet.append(row)
   end

--- a/app/jobs/update_vacancy_spreadsheet_job.rb
+++ b/app/jobs/update_vacancy_spreadsheet_job.rb
@@ -1,20 +1,12 @@
-require 'spreadsheet_writer'
-
-class UpdateVacancySpreadsheetJob < ApplicationJob
+class UpdateVacancySpreadsheetJob < SpreadsheetWriterJob
+  WORKSHEET_POSITION = 0
   queue_as :update_vacancy_spreadsheet
 
   def perform(vacancy_id)
     return unless AUDIT_SPREADSHEET_ID
+
     vacancy = Vacancy.find(vacancy_id)
-    write_row(vacancy)
-  end
-
-  private
-
-  def write_row(vacancy)
     row = VacancyPresenter.new(vacancy).to_row
-    worksheet = Spreadsheet::Writer.new(AUDIT_SPREADSHEET_ID)
-    worksheet.append(row)
-    Rails.logger.info("Sidekiq: added vacancy #{vacancy.id} to published vacancies sheet")
+    write_row(row)
   end
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -7,6 +7,7 @@
   - [ audit_sign_in_event, 1 ]
   - [ audit_express_interest_event, 1 ]
   - [ audit_search_event, 1 ]
+  - [ audit_feedback, 1 ]
 update_vacancy_spreadsheet:
   :concurrency: 1
 audit_sign_in_event:
@@ -14,4 +15,6 @@ audit_sign_in_event:
 audit_express_interest_event:
   :concurrency: 1
 audit_search_event:
+  :concurrency: 1
+audit_feedback:
   :concurrency: 1

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -5,7 +5,10 @@
   - [ import_school_data, 1 ]
   - [ update_vacancy_spreadsheet, 1 ]
   - [ audit_sign_in_event, 1 ]
+  - [ audit_express_interest_event, 1 ]
 update_vacancy_spreadsheet:
   :concurrency: 1
 audit_sign_in_event:
+  :concurrency: 1
+audit_express_interest_event:
   :concurrency: 1

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -6,9 +6,12 @@
   - [ update_vacancy_spreadsheet, 1 ]
   - [ audit_sign_in_event, 1 ]
   - [ audit_express_interest_event, 1 ]
+  - [ audit_search_event, 1 ]
 update_vacancy_spreadsheet:
   :concurrency: 1
 audit_sign_in_event:
   :concurrency: 1
 audit_express_interest_event:
+  :concurrency: 1
+audit_search_event:
   :concurrency: 1

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -8,6 +8,7 @@
   - [ audit_express_interest_event, 1 ]
   - [ audit_search_event, 1 ]
   - [ audit_feedback, 1 ]
+  - [ audit_toc_acceptance_event, 1 ]
 update_vacancy_spreadsheet:
   :concurrency: 1
 audit_sign_in_event:
@@ -17,4 +18,6 @@ audit_express_interest_event:
 audit_search_event:
   :concurrency: 1
 audit_feedback:
+  :concurrency: 1
+audit_toc_acceptance_event:
   :concurrency: 1

--- a/spec/features/hiring_staff_can_submit_vacancy_feedback_spec.rb
+++ b/spec/features/hiring_staff_can_submit_vacancy_feedback_spec.rb
@@ -65,6 +65,24 @@ RSpec.feature 'Vacancy feedback' do
         expect(activity.key).to eq('vacancy.feedback.create')
         expect(activity.session_id).to eq(session_id)
       end
+
+      scenario 'triggers a job to write the feedback to a Spreadsheet' do
+        visit root_path
+        timestamp = Time.zone.now.iso8601
+        data = [timestamp.to_s, session_id, published_job.id, published_job.school.urn, 5, 'Perfect!']
+
+        expect(AuditFeedbackJob).to receive(:perform_later)
+          .with(data)
+
+        Timecop.freeze(timestamp) do
+          visit new_school_job_feedback_path(published_job.id)
+
+          choose 'Very satisfied'
+          fill_in 'feedback_comment', with: 'Perfect!'
+
+          click_on 'Submit feedback'
+        end
+      end
     end
   end
 end

--- a/spec/features/job_seekers_can_apply_for_a_vacancy_spec.rb
+++ b/spec/features/job_seekers_can_apply_for_a_vacancy_spec.rb
@@ -18,4 +18,19 @@ RSpec.feature 'Job seekers can apply for a vacancy' do
     expect(activity.key).to eq('vacancy.get_more_information')
     expect(activity.session_id).to eq(nil)
   end
+
+  scenario 'it triggers a job to write an express_interest_event to the audit Spreadsheet' do
+    vacancy = create(:vacancy, :published)
+    visit job_path(vacancy)
+
+    timestamp = Time.zone.now.iso8601
+    express_interest_event = [timestamp.to_s, vacancy.id, vacancy.school.urn, vacancy.application_link]
+
+    expect(AuditExpressInterestEventJob).to receive(:perform_later)
+      .with(express_interest_event)
+
+    Timecop.freeze(timestamp) do
+      click_on 'Get more information'
+    end
+  end
 end

--- a/spec/jobs/audit_express_interest_event_job_spec.rb
+++ b/spec/jobs/audit_express_interest_event_job_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe AuditExpressInterestEventJob, type: :job do
+  include ActiveJob::TestHelper
+
+  subject(:job) { described_class.perform_later(data) }
+  let(:data) { [Time.zone.now.to_s, 'a-vacancy-id', '01010101', 'http://link'] }
+
+  it 'queues the job' do
+    expect { job }.to change(ActiveJob::Base.queue_adapter.enqueued_jobs, :size).by(1)
+  end
+
+  it 'is in the audit_express_interest_event  queue' do
+    expect(job.queue_name).to eq('audit_express_interest_event')
+  end
+
+  it 'writes to the spreadsheet' do
+    stub_const('AUDIT_SPREADSHEET_ID', 'abc1-def2')
+    spreadsheet = double(:mock)
+    expect(Spreadsheet::Writer).to receive(:new)
+      .with('abc1-def2', AuditExpressInterestEventJob::WORKSHEET_POSITION).and_return(spreadsheet)
+    expect(spreadsheet).to receive(:append).with(data)
+
+    perform_enqueued_jobs { job }
+  end
+end

--- a/spec/jobs/audit_feedback_job_spec.rb
+++ b/spec/jobs/audit_feedback_job_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe AuditFeedbackJob, type: :job do
+  include ActiveJob::TestHelper
+
+  subject(:job) { described_class.perform_later(data) }
+  let(:data) { [Time.zone.now.to_s, 'vacancy-id', '010101', 5, 'feedback note'] }
+
+  it 'queues the job' do
+    expect { job }.to change(ActiveJob::Base.queue_adapter.enqueued_jobs, :size).by(1)
+  end
+
+  it 'is in the audit_feedback queue' do
+    expect(job.queue_name).to eq('audit_feedback')
+  end
+
+  it 'writes to the spreadsheet' do
+    stub_const('AUDIT_SPREADSHEET_ID', 'abc1-def2')
+    spreadsheet = double(:mock)
+    expect(Spreadsheet::Writer).to receive(:new)
+      .with('abc1-def2', AuditFeedbackJob::WORKSHEET_POSITION).and_return(spreadsheet)
+    expect(spreadsheet).to receive(:append).with(data)
+
+    perform_enqueued_jobs { job }
+  end
+end

--- a/spec/jobs/audit_search_event_job_spec.rb
+++ b/spec/jobs/audit_search_event_job_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe AuditSearchEventJob, type: :job do
+  include ActiveJob::TestHelper
+
+  subject(:job) { described_class.perform_later(data) }
+  let(:data) { [Time.zone.now.iso8601.to_s, 1, '', '20km', 'Physics', '', '', nil, nil, nil] }
+
+  it 'queues the job' do
+    expect { job }.to change(ActiveJob::Base.queue_adapter.enqueued_jobs, :size).by(1)
+  end
+
+  it 'is in the audit_search_event queue' do
+    expect(job.queue_name).to eq('audit_search_event')
+  end
+
+  it 'writes to the spreadsheet' do
+    stub_const('AUDIT_SPREADSHEET_ID', 'abc1-def2')
+    spreadsheet = double(:mock)
+    expect(Spreadsheet::Writer).to receive(:new)
+      .with('abc1-def2', AuditSearchEventJob::WORKSHEET_POSITION).and_return(spreadsheet)
+    expect(spreadsheet).to receive(:append).with(data)
+
+    perform_enqueued_jobs { job }
+  end
+end

--- a/spec/jobs/audit_sign_in_event_job_spec.rb
+++ b/spec/jobs/audit_sign_in_event_job_spec.rb
@@ -19,7 +19,8 @@ RSpec.describe AuditSignInEventJob, type: :job do
   it 'encrypts the data' do
     stub_const('AUDIT_SPREADSHEET_ID', 'abc1-def2')
     spreadsheet = double(:mock)
-    expect(Spreadsheet::Writer).to receive(:new).and_return(spreadsheet)
+    expect(Spreadsheet::Writer).to receive(:new)
+      .with('abc1-def2', AuditSignInEventJob::WORKSHEET_POSITION).and_return(spreadsheet)
     expect(spreadsheet).to receive(:append).with(data)
 
     perform_enqueued_jobs { job }

--- a/spec/jobs/audit_toc_acceptance_event_job_spec.rb
+++ b/spec/jobs/audit_toc_acceptance_event_job_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe AuditTocAcceptanceEventJob, type: :job do
+  include ActiveJob::TestHelper
+
+  subject(:job) { described_class.perform_later(data) }
+  let(:data) { [Time.zone.now.to_s, 'user-dsi-id', '010101'] }
+
+  it 'queues the job' do
+    expect { job }.to change(ActiveJob::Base.queue_adapter.enqueued_jobs, :size).by(1)
+  end
+
+  it 'is in the audit_toc_acceptance_event queue' do
+    expect(job.queue_name).to eq('audit_toc_acceptance_event')
+  end
+
+  it 'writes to the spreadsheet' do
+    stub_const('AUDIT_SPREADSHEET_ID', 'abc1-def2')
+    spreadsheet = double(:mock)
+    expect(Spreadsheet::Writer).to receive(:new)
+      .with('abc1-def2', AuditTocAcceptanceEventJob::WORKSHEET_POSITION).and_return(spreadsheet)
+    expect(spreadsheet).to receive(:append).with(data)
+
+    perform_enqueued_jobs { job }
+  end
+end


### PR DESCRIPTION
### Branched off PR  #621

## Trello card URL:
https://trello.com/c/2uYfPfoD/619-publish-events-to-audit-spreadsheet

## Changes in this PR:
Publishes audit events to spreadsheet
- [x] Express interest
- [x] Toc acceptance
- [x] Search events
- [x] Feedback

## Changes:
This is currently deployed on Edge.

**Spreadsheet link**
https://docs.google.com/spreadsheets/d/15KTqvwNZWPaDPSzGaoClYh0d2jUWz4C5mpwn7jLmt2E/edit#gid=0

## Next steps:
- [x] Terraform deployment required?
- [x] New development configuration to be shared?
