### PR TITLE
(fix) Latest Docker version requires a container name to be set

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -9,6 +9,7 @@ services:
       RAILS_ENV: "test"
       DATABASE_URL: "postgres://postgres@db-test:5432/tvs_test?template=template0&pool=5&encoding=unicode"
       ELASTICSEARCH_URL: "http://elasticsearch-test:9200"
+    container_name: teacher-vacancy-service_test_1
     env_file:
       - docker-compose.env
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       args:
         RAILS_ENV: "development"
     ports: ["3000:3000"]
+    container_name: teacher-vacancy-service_web_1
     environment:
       RAILS_ENV: "development"
     env_file:


### PR DESCRIPTION
## Trello card URL:

N/A (Should I create one?)

## Changes in this PR:

After updating to the latest version of Docker (Docker version 18.09.0, build 4d60db4) I had an issue where Docker could not find the web container:

```
Error: No such container: teacher-vacancy-service_web_1
```

Specifying the container name in `docker-compose.yml` has resolved this.
