### PR TITLE
(fix) Add Date year validation

### DIFF
--- a/app/models/concerns/vacancy_application_detail_validations.rb
+++ b/app/models/concerns/vacancy_application_detail_validations.rb
@@ -9,6 +9,7 @@ module VacancyApplicationDetailValidations
 
     validates :publish_on, presence: true, if: proc { |v| !v.published? }
     validate :validity_of_publish_on, :validity_of_expires_on
+    validates_with DateFormatValidator, fields: %i[publish_on expires_on]
   end
 
   def validity_of_publish_on

--- a/app/models/concerns/vacancy_job_specification_validations.rb
+++ b/app/models/concerns/vacancy_job_specification_validations.rb
@@ -19,6 +19,7 @@ module VacancyJobSpecificationValidations
 
     validate :starts_on_before_closing_date, if: :starts_on?
     validate :ends_on_before_closing_date, if: :ends_on?
+    validates_with DateFormatValidator, fields: %i[starts_on ends_on]
   end
 
   def starts_on_before_ends_on?

--- a/app/validators/date_format_validator.rb
+++ b/app/validators/date_format_validator.rb
@@ -1,0 +1,11 @@
+class DateFormatValidator < ActiveModel::Validator
+  def validate(record)
+    options[:fields].each do |field|
+      date = record.send(field)
+      next if date.blank?
+      match = date.strftime('%Y-%m-%d').match(/^(?<y>\d*)\-/)
+
+      record.errors.add(field, I18n.t('errors.messages.year_invalid')) if match[:y].length > 4
+    end
+  end
+end

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -12,7 +12,7 @@ en:
       salary:
         invalid_format: 'must be entered in one of the following formats: 25000 or 25000.00'
         lower_than_minimum_payscale: 'must be at least %{minimum_salary}'
-      year_invalid: year is invalid
+      year_invalid: must include a 4-digit year
   activerecord:
     errors:
       models:

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -12,6 +12,7 @@ en:
       salary:
         invalid_format: 'must be entered in one of the following formats: 25000 or 25000.00'
         lower_than_minimum_payscale: 'must be at least %{minimum_salary}'
+      year_invalid: year is invalid
   activerecord:
     errors:
       models:

--- a/spec/validators/date_format_validator_spec.rb
+++ b/spec/validators/date_format_validator_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe DateFormatValidator do
+  describe '#validate(record)' do
+    context 'a complete and correct record' do
+      let(:vacancy) { FactoryBot.build(:vacancy, :complete) }
+
+      it 'passes validations' do
+        expect(vacancy.valid?).to be_truthy
+      end
+    end
+
+    context 'a record with a malformed starts_on year' do
+      let(:vacancy) { FactoryBot.build(:vacancy, starts_on: Date.parse('12-01-202018')) }
+
+      it 'shows an invalid year error' do
+        vacancy.valid?
+        expect(vacancy.errors[:starts_on]).to include('year is invalid')
+      end
+    end
+
+    context 'a record with a malformed ends_on year' do
+      let(:vacancy) { FactoryBot.build(:vacancy, ends_on: Date.parse('12-01-202018')) }
+
+      it 'shows an invalid year error' do
+        vacancy.valid?
+        expect(vacancy.errors[:ends_on]).to include('year is invalid')
+      end
+    end
+
+    context 'a record with a malformed publish_on year' do
+      let(:vacancy) { FactoryBot.build(:vacancy, publish_on: Date.parse('12-01-202018')) }
+
+      it 'shows an invalid year error' do
+        vacancy.valid?
+        expect(vacancy.errors[:publish_on]).to include('year is invalid')
+      end
+    end
+
+    context 'a record with a malformed expires_on year' do
+      let(:vacancy) { FactoryBot.build(:vacancy, expires_on: Date.parse('12-01-202018')) }
+
+      it 'shows an invalid year error' do
+        vacancy.valid?
+        expect(vacancy.errors[:expires_on]).to include('year is invalid')
+      end
+    end
+  end
+end

--- a/spec/validators/date_format_validator_spec.rb
+++ b/spec/validators/date_format_validator_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe DateFormatValidator do
 
       it 'shows an invalid year error' do
         vacancy.valid?
-        expect(vacancy.errors[:starts_on]).to include('year is invalid')
+        expect(vacancy.errors[:starts_on]).to include(I18n.t('errors.messages.year_invalid'))
       end
     end
 
@@ -24,7 +24,7 @@ RSpec.describe DateFormatValidator do
 
       it 'shows an invalid year error' do
         vacancy.valid?
-        expect(vacancy.errors[:ends_on]).to include('year is invalid')
+        expect(vacancy.errors[:ends_on]).to include(I18n.t('errors.messages.year_invalid'))
       end
     end
 
@@ -33,7 +33,7 @@ RSpec.describe DateFormatValidator do
 
       it 'shows an invalid year error' do
         vacancy.valid?
-        expect(vacancy.errors[:publish_on]).to include('year is invalid')
+        expect(vacancy.errors[:publish_on]).to include(I18n.t('errors.messages.year_invalid'))
       end
     end
 
@@ -42,7 +42,7 @@ RSpec.describe DateFormatValidator do
 
       it 'shows an invalid year error' do
         vacancy.valid?
-        expect(vacancy.errors[:expires_on]).to include('year is invalid')
+        expect(vacancy.errors[:expires_on]).to include(I18n.t('errors.messages.year_invalid'))
       end
     end
   end


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/fheDlo9r/617-resolve-failed-date-format-validation-errors

## Changes in this PR:

The problem: People have been inputting years like "202018" into the date fields. A date like "01-01-202018" is a valid date, just very far into the future!

This breaks Elasticsearch because it doesn't know how to parse a year like 202018 - it expects a 2-digit year. Example: https://rollbar.com/dxw/teacher-vacancies/items/221/occurrences/59122563252/

I have added a DateFormatValidator which will prompt the user to correct the year in starts_on, ends_on, publish_on and expires_on.

## Screenshots of UI changes:

<img width="338" alt="screenshot 2018-11-29 at 12 45 10" src="https://user-images.githubusercontent.com/1089521/49222749-a4e6b700-f3d4-11e8-88f8-915066c33b46.png">
<img width="349" alt="screenshot 2018-11-29 at 12 44 35" src="https://user-images.githubusercontent.com/1089521/49222751-a4e6b700-f3d4-11e8-96ef-1a3e699bb026.png">
<img width="1038" alt="screenshot 2018-11-29 at 12 44 24" src="https://user-images.githubusercontent.com/1089521/49222752-a4e6b700-f3d4-11e8-9c85-06dc69a72265.png">

