### PR TITLE
[fix][642] log `total_count` of returned search results to audit spreadsheet

### DIFF
--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -48,7 +48,7 @@ class VacanciesController < ApplicationController
 
   def audit_search_event(records, filters)
     AuditSearchEventJob.perform_later([Time.zone.now.iso8601.to_s,
-                                       records.count,
+                                       records.total_count,
                                        *filters.to_hash.values])
   end
 

--- a/spec/features/job_seekers_can_filter_vacancies_spec.rb
+++ b/spec/features/job_seekers_can_filter_vacancies_spec.rb
@@ -255,25 +255,49 @@ RSpec.feature 'Filtering vacancies' do
     end
   end
 
-  scenario 'Searching triggers a job to write a search_event to the audit Spreadsheet' do
-    create(:vacancy, :published, job_title: 'Physics', newly_qualified_teacher: true)
-    create(:vacancy, :published, newly_qualified_teacher: false)
-    timestamp = Time.zone.now.iso8601
+  context 'Searching triggers a job to write a search_event to the audit Spreadsheet' do
+    scenario 'correctly logs the number of non-paginated results' do
+      create_list(:vacancy, 3, :published, job_title: 'Physics', newly_qualified_teacher: true)
+      create(:vacancy, :published, newly_qualified_teacher: false)
+      timestamp = Time.zone.now.iso8601
 
-    Vacancy.__elasticsearch__.client.indices.flush
+      Vacancy.__elasticsearch__.client.indices.flush
 
-    data = [timestamp.to_s, 1, '', '20km', 'Physics', '', '', nil, nil, 'true']
+      data = [timestamp.to_s, 3, '', '20km', 'Physics', '', '', nil, nil, 'true']
 
-    expect(AuditSearchEventJob).to receive(:perform_later)
-      .with(data)
+      expect(AuditSearchEventJob).to receive(:perform_later)
+        .with(data)
 
-    visit jobs_path
+      visit jobs_path
 
-    Timecop.freeze(timestamp) do
-      within '.filters-form' do
-        check 'newly_qualified_teacher'
-        fill_in 'keyword', with: 'Physics'
-        page.find('.govuk-button[type=submit]').click
+      Timecop.freeze(timestamp) do
+        within '.filters-form' do
+          check 'newly_qualified_teacher'
+          fill_in 'keyword', with: 'Physics'
+          page.find('.govuk-button[type=submit]').click
+        end
+      end
+    end
+
+    scenario 'correctly logs the total results when pagination is used' do
+      create_list(:vacancy, 12,  :published, job_title: 'Math', newly_qualified_teacher: true)
+      timestamp = Time.zone.now.iso8601
+
+      Vacancy.__elasticsearch__.client.indices.flush
+
+      data = [timestamp.to_s, 12, '', '20km', 'Math', '', '', nil, nil, 'true']
+
+      expect(AuditSearchEventJob).to receive(:perform_later)
+        .with(data)
+
+      visit jobs_path
+
+      Timecop.freeze(timestamp) do
+        within '.filters-form' do
+          check 'newly_qualified_teacher'
+          fill_in 'keyword', with: 'Math'
+          page.find('.govuk-button[type=submit]').click
+        end
       end
     end
   end


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/KS4TUSSJ/642-bug-audit-spreadsheet-search-incorrectly-maps-page-results-count-rather-than-all-results-count

## Changes in this PR:
Search audit now correctly logs total count of results, rather than the displayed page count.