### PR TITLE
(chore) reduce staging logging level to info

### DIFF
--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -72,7 +72,7 @@ Rails.application.configure do
   config.active_support.deprecation = :notify
 
   # Logging
-  config.log_level = :debug
+  config.log_level = :info
   config.log_tags = [:request_id] # Prepend all log lines with the following tags.
   config.logger = ActiveSupport::Logger.new(STDOUT)
 


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/Dcx4XV73/623-investigate-logging-usage-being-higher-on-all-non-live-environments#

## Changes in this PR:
Reduce non-production environment logging level to `info`