### PR TITLE
[fix] Increase EC2 autoscaling trigger threshold to 45%

### DIFF
--- a/terraform/modules/core/core.tf
+++ b/terraform/modules/core/core.tf
@@ -384,7 +384,7 @@ resource "aws_cloudwatch_metric_alarm" "average-reserved-cpu-low" {
   namespace           = "AWS/ECS"
   period              = "60"
   statistic           = "Minimum"
-  threshold           = "25"
+  threshold           = "45"
 
   dimensions {
     ClusterName = "${var.ecs_cluster_name}"


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/vMXyOQQD/622-increase-ec2-autoscaling-trigger-threshold-to-45

## Changes in this PR:
Increases autoscaling threshold to 45%

## Screenshots:
### After
<img width="816" alt="tf-config" src="https://user-images.githubusercontent.com/159200/49515710-9c3c2800-f88f-11e8-8722-8b52169bd3e4.png">

## Next steps:
- [x] Terraform deployment required?
