### PR TITLE
[654] No results being shown when empty pagination

### DIFF
--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -15,7 +15,7 @@ class VacanciesController < ApplicationController
   def index
     @filters = VacancyFilters.new(search_params)
     @sort = VacancySort.new.update(column: sort_column, order: sort_order)
-    records = Vacancy.public_search(filters: @filters, sort: @sort).page(params[:page]).records
+    records = Vacancy.public_search(filters: @filters, sort: @sort).page(page_number).records
     audit_search_event(records, @filters) if @filters.any?
 
     @vacancies = VacanciesPresenter.new(records, searched: @filters.any?)
@@ -56,7 +56,9 @@ class VacanciesController < ApplicationController
     params[:id]
   end
 
-  def page
+  def page_number
+    return Vacancy.page.total_pages if Vacancy.page(params[:page]).out_of_range?
+
     params[:page]
   end
 

--- a/app/presenters/vacancies_presenter.rb
+++ b/app/presenters/vacancies_presenter.rb
@@ -1,6 +1,7 @@
 class VacanciesPresenter < BasePresenter
   include ActionView::Helpers::UrlHelper
   attr_reader :decorated_collection, :searched
+  alias_method :user_search?, :searched
 
   CSV_ATTRIBUTES = %w[title description jobBenefits datePosted educationRequirements qualifications
                       experienceRequirements employmentType jobLocation.addressLocality

--- a/app/views/vacancies/index.html+phone.haml
+++ b/app/views/vacancies/index.html+phone.haml
@@ -7,7 +7,7 @@
   .govuk-grid-column-two-thirds
     %p.govuk-heading-m.mt0
       %p.govuk-heading-m.mb0= @vacancies.total_count_message
-      - if @vacancies.searched
+      - if @vacancies.user_search?
         %span.clear-search.nobreak= link_to t('jobs.filters.clear_filters'), root_path, class: 'govuk-link'
       .mt1
         = link_to 'Refine your search?', '#filters', class: 'govuk-link'

--- a/app/views/vacancies/index.html.haml
+++ b/app/views/vacancies/index.html.haml
@@ -9,7 +9,7 @@
     = render 'filters'
   .govuk-grid-column-two-thirds
     %p.govuk-heading-m.mt0.mb1.inline-block= @vacancies.total_count_message
-    - if @vacancies.searched
+    - if @vacancies.user_search?
       %span.clear-search.nobreak= link_to t('jobs.filters.clear_filters'), root_path, class: 'govuk-link'
     - if @vacancies.any?
       %div.sortable-links
@@ -21,7 +21,7 @@
         - @vacancies.each do |vacancy|
           = render partial: 'vacancy', locals: { vacancy: vacancy }
 
-    - elsif @vacancies.searched
+    - elsif @vacancies.user_search?
       %div.empty
         - t('jobs.no_jobs').each do |list_item|
           %p= list_item


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/JKCRFTmR

## Changes in this PR:
- user a more informative method in the job listing view for when a user has searched
- start using the idol `page` method in the VacanciesController and use it to intercept higher page requests than we can currently serve results for
