### PR TITLE
[673] Refactor DfE Sign-in to handle password resets without a monk…

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,74 +1,46 @@
-module OmniAuth
-  module Strategies
-    class OpenIDConnect
-      # rubocop:disable Metrics/AbcSize
-      # rubocop:disable Metrics/CyclomaticComplexity
-      # rubocop:disable Metrics/PerceivedComplexity
-      # rubocop:disable Metrics/LineLength
-      # rubocop:disable Style/GuardClause
-      # Please refer to this commit to read why this has been copied from: https://github.com/m0n9oose/omniauth_openid_connect/blob/master/lib/omniauth/strategies/openid_connect.rb
-      def callback_phase
-        error = request.params['error_reason'] || request.params['error']
-        if error
-          raise CallbackError.new(request.params['error'], request.params['error_description'] || request.params['error_reason'], request.params['error_uri'])
-        elsif request.params.blank? && request.path == '/auth/dfe/callback'
-          response = Rack::Response.new
-          response.redirect('/dfe/sessions/new')
-          response.finish
-        elsif request.params['state'].to_s.empty? || request.params['state'] != stored_state
-          return redirect('/401')
-        elsif !request.params['code']
-          return fail!(:missing_code, OmniAuth::OpenIDConnect::MissingCodeError.new(request.params['error']))
-        else
-          options.issuer = issuer if options.issuer.blank?
-          discover! if options.discovery
-          client.redirect_uri = redirect_uri
-          client.authorization_code = authorization_code
-          access_token
-          super
-        end
-      rescue CallbackError => e
-        fail!(:invalid_credentials, e)
-      rescue ::Timeout::Error, ::Errno::ETIMEDOUT => e
-        fail!(:timeout, e)
-      rescue ::SocketError => e
-        fail!(:failed_to_connect, e)
+# Docker build will fail without this guard
+DFE_SIGNIN_ENABLED = ENV['DFE_SIGN_IN_ISSUER'].present?
+
+if DFE_SIGNIN_ENABLED
+  dfe_sign_in_url = URI.parse(ENV['DFE_SIGN_IN_ISSUER'])
+  options = {
+    name: :dfe,
+    discovery: true,
+    response_type: :code,
+    client_signing_alg: :RS256,
+    scope: %i[openid profile email organisation],
+    client_options: {
+      port: dfe_sign_in_url.port,
+      scheme: dfe_sign_in_url.scheme,
+      host: dfe_sign_in_url.host,
+      identifier: ENV['DFE_SIGN_IN_IDENTIFIER'],
+      secret: ENV['DFE_SIGN_IN_SECRET'],
+      redirect_uri: ENV['DFE_SIGN_IN_REDIRECT_URL'],
+      authorization_endpoint: '/auth',
+      jwks_uri: '/certs',
+      userinfo_endpoint: '/me'
+    }
+  }
+
+  Rails.application.config.middleware.use OmniAuth::Strategies::OpenIDConnect, options
+
+  class DfeSignIn
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      request = Rack::Request.new(env)
+
+      if request.path == '/auth/dfe/callback' && request.params.empty? && !OmniAuth.config.test_mode
+        response = Rack::Response.new
+        response.redirect('/dfe/sessions/new')
+        response.finish
+      else
+        @app.call(env)
       end
-      # rubocop:enable Metrics/AbcSize
-      # rubocop:enable Metrics/CyclomaticComplexity
-      # rubocop:enable Metrics/PerceivedComplexity
-      # rubocop:enable Metrics/LineLength
-      # rubocop:enable Style/GuardClause
     end
   end
-end
 
-class OmniAuth::Strategies::Dfe < OmniAuth::Strategies::OpenIDConnect; end
-
-Rails.application.config.middleware.use OmniAuth::Builder do
-  dfe_sign_in_issuer_uri    = URI(ENV.fetch('DFE_SIGN_IN_ISSUER', 'example'))
-  dfe_sign_in_identifier    = ENV.fetch('DFE_SIGN_IN_IDENTIFIER', 'example')
-  dfe_sign_in_secret        = ENV.fetch('DFE_SIGN_IN_SECRET', 'example')
-  dfe_sign_in_redirect_uri  = ENV.fetch('DFE_SIGN_IN_REDIRECT_URL', 'example')
-
-  dfe_sign_in_issuer_url = "#{dfe_sign_in_issuer_uri}:#{dfe_sign_in_issuer_uri.port}" if dfe_sign_in_issuer_uri.port
-
-  provider :dfe,
-           name: :dfe,
-           discovery: true,
-           response_type: :code,
-           issuer: dfe_sign_in_issuer_url,
-           client_signing_alg: :RS256,
-           scope: %i[openid profile email organisation],
-           client_options: {
-             port: dfe_sign_in_issuer_uri.port,
-             scheme: dfe_sign_in_issuer_uri.scheme,
-             host: dfe_sign_in_issuer_uri.host,
-             identifier: dfe_sign_in_identifier,
-             secret: dfe_sign_in_secret,
-             redirect_uri: dfe_sign_in_redirect_uri,
-             authorization_endpoint: '/auth',
-             jwks_uri: '/certs',
-             userinfo_endpoint: '/me'
-           }
+  Rails.application.config.middleware.insert_before OmniAuth::Strategies::OpenIDConnect, DfeSignIn
 end

--- a/spec/requests/dfe_sign_in_spec.rb
+++ b/spec/requests/dfe_sign_in_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'DfE Sign-in', type: :request do
   context 'when DfE Sign-in respond with an OIDC payload for authentication purposes' do
-    context 'when that payload is unauthorised' do
+    context 'when that openid connect payload is unauthorised' do
       it 'redirects the user to the not authorised page' do
         params = {
           'code': 'a-long-secret',
@@ -11,16 +11,16 @@ RSpec.describe 'DfE Sign-in', type: :request do
 
         get auth_dfe_callback_path, params: params
 
-        expect(response.status).to eq(302)
-        expect(response.body).to eq('Redirecting to /401...')
+        expect(response.status).to eq(401)
       end
     end
   end
 
-  context 'when a user is linked back to our service with a redirect' do
+  context 'when a user is linked back to our service without an openid connect payload' do
     it 'routes the request back to the new sign-in page' do
-      request = get auth_dfe_callback_path
-      expect(request).to redirect_to(new_dfe_path)
+      get auth_dfe_callback_path
+
+      expect(response).to redirect_to(new_dfe_path)
     end
   end
 end


### PR DESCRIPTION
…ey patch

* CCS came up with a more elgant approach and enables us to completely remove the monkey patch for the OpenIDConnect gem: https://github.com/Crown-Commercial-Service/crown-marketplace/commit/2d169633f7e6c7ba5c9ff3425c47b87e3651a40b
* I was also able to refactor several bits of configuration away
* I simplified the guard clauses on every ENV fetch to a single line at the top of the file. It clearly explains that Docker is the reason we need to handle the scenario where ENV is not available, as it isn’t using the `docker build` phase.
* To remind us of why we need to do this. At the end of a password reset journey using DfE Sign-in, that service redirects services back to our service. They use the same URL as the one used during the authentication phase, however this time it doesn’t have a valid payload. Omniauth promptly treats this request as unauthorised instead of linking the user to the sign in page. Since we cannot configure 2 callback URL’s within DSI, we are checking the payload in a before step, when it doesn’t exist at all we redirect that use to the sign in step.

## Trello card URL:
https://trello.com/c/0fBiG9GY/673-replace-dfe-sign-in-monkey-patch

## Changes in this PR:

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
