### PR TITLE
[Feature] 1.2.1 Email alerts - New subscription page

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -1,0 +1,23 @@
+class SubscriptionsController < ApplicationController
+  def new
+    subscription = Subscription.new(search_criteria: search_criteria.to_json)
+    @subscription = SubscriptionPresenter.new(subscription)
+  end
+
+  def create
+    subscription = Subscription.new(subscription_params)
+    @subscription = SubscriptionPresenter.new(subscription)
+
+    render 'new' unless @subscription.valid?
+  end
+
+  private
+
+  def subscription_params
+    params.require(:subscription).permit(:email, :reference, :search_criteria)
+  end
+
+  def search_criteria
+    params.require(:search_criteria).permit(*VacancyFilters::AVAILABLE_FILTERS)
+  end
+end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -10,6 +10,10 @@ class Subscription < ApplicationRecord
 
   before_save :set_reference
 
+  def search_criteria_to_h
+    @search_criteria_hash = JSON.parse(search_criteria)
+  end
+
   def set_reference
     self.reference ||= loop do
       reference ||= SecureRandom.hex(8)

--- a/app/presenters/subscription_presenter.rb
+++ b/app/presenters/subscription_presenter.rb
@@ -1,0 +1,39 @@
+class SubscriptionPresenter < BasePresenter
+  include ApplicationHelper
+
+  def filtered_search_criteria
+    @filtered_search_criteria ||= search_criteria_to_h.each_with_object({}) do |(field, value), criteria|
+      search_field = add_search_criteria_field(field, value)
+      criteria.merge!(search_field) if search_field.present?
+    end.stringify_keys
+  end
+
+  private
+
+  def add_search_criteria_field(field, value)
+    return if field.eql?('radius')
+
+    return render_location_filter(value, search_criteria_to_h['radius']) if field.eql?('location')
+    return render_salary_filter(field, value) if field.ends_with?('_salary')
+    return render_nqt_filter(value) if field.eql?('newly_qualified_teacher')
+
+    field.eql?('working_pattern') ? render_working_pattern_filter(value) : { "#{field}": search_criteria_to_h[field] }
+  end
+
+  def render_location_filter(location, radius)
+    return if location.empty? || radius.empty?
+    { location: I18n.t('subscriptions.location_text', radius: radius, location: location) }
+  end
+
+  def render_salary_filter(field, value)
+    { "#{field}": number_to_currency(value) }
+  end
+
+  def render_nqt_filter(value)
+    { '': 'Suitable for NQTs' } if value.eql?('true')
+  end
+
+  def render_working_pattern_filter(value)
+    { working_pattern: value.humanize }
+  end
+end

--- a/app/views/subscriptions/new.html.haml
+++ b/app/views/subscriptions/new.html.haml
@@ -1,0 +1,39 @@
+- content_for :page_title_prefix do
+  = t('subscriptions.new')
+
+- content_for :page_description do
+  = t('subscriptions.new')
+
+.govuk-grid-row
+  .govuk-grid-column-full
+    %h1.govuk-heading-xl
+      = t('subscriptions.new')
+.govuk-grid-row
+  .govuk-grid-column-full
+    %p.govuk-body-l
+      = t('subscriptions.intro')
+
+    %div.govuk-inset-text
+      %ul.govuk-list
+        - @subscription.filtered_search_criteria.each_pair do |filter, value|
+          %li
+            - if filter.present?
+              %span{ class: 'govuk-!-font-weight-bold'} #{filter.humanize}:
+            = value
+
+.govuk-grid-row
+  .govuk-grid-column-one-half
+    = simple_form_for @subscription do |f|
+      = f.input :email, as: :email, input_html: { class: 'govuk-input' }, required: true
+      = f.input :reference, as: :string, input_html: { class: 'govuk-input' }
+
+      = f.input :search_criteria, as: :hidden
+
+      .govuk-warning-text
+        %span.govuk-warning-text__icon{'aria-hidden': "true"}
+          = '!'
+        %strong.govuk-warning-text__text
+          %span.govuk-warning-text__assistive Warning
+          = t('subscriptions.info')
+
+      = f.button :submit, 'Subscribe'

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -58,3 +58,11 @@ en:
           attributes:
             task:
               taken: must have a unique entry for a date
+  simple_form:
+    labels:
+      subscription:
+        email: 'Email address'
+        reference: 'Your reference'
+    hints:
+      defaults:
+        reference: You can provide your own reference to identify this alert or we'll automatically generate one for you, for example ca7f7b1627c7f530

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -222,6 +222,11 @@ en:
           - 'leadership level'
           - 'expected start date'
           - 'end date (for fixed-term jobs)'
+  subscriptions:
+    intro: 'Your search criteria are as follows:'
+    new: Sign up for daily emails
+    info: When you click subscribe, you'll receive daily emails featuring jobs that match these criteria for 3 months. You can unsubscribe at any time following the unsubscribe link in your daily mail.
+    location_text: Within %{radius} miles of %{location}
   terms_and_conditions:
     page_title: 'Terms and Conditions'
     intro: 'Before listing any role at your school on Teaching Vacancies you must first read our Terms and Conditions and agree to abide by them.'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,8 @@ Rails.application.routes.draw do
     resources :interests, only: %i[new]
   end
 
+  resources :subscriptions, only: %i[new create]
+
   namespace :api do
     scope 'v:api_version', api_version: /[1]/ do
       resources :jobs, only: %i[index show], controller: 'vacancies'

--- a/spec/features/job_seekers_can_subscribe_to_a_job_alert_spec.rb
+++ b/spec/features/job_seekers_can_subscribe_to_a_job_alert_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.feature 'A job seeker can subscribe to a job alert' do
+  context 'A job seeker' do
+    scenario 'can access the new subscription page when search criteria have been specified' do
+      expect { visit(new_subscription_path) }.to raise_error(ActionController::ParameterMissing)
+
+      visit new_subscription_path(search_criteria: { some_parameters: 'none' })
+      expect(page).to have_content('Sign up for daily emails')
+    end
+
+    scenario 'can view the search criteria' do
+      visit new_subscription_path(search_criteria: { newly_qualified_teacher: 'true',
+                                                     keyword: 'teacher',
+                                                     location: 'EC2 9AN',
+                                                     radius: '10',
+                                                     working_pattern: 'full_time',
+                                                     minimum_salary: '20000',
+                                                     maximum_salary: '30000' })
+
+      expect(page).to have_content('Keyword: teacher')
+      expect(page).to have_content('Suitable for NQTs')
+      expect(page).to have_content('Location: Within 10 miles of EC2 9AN')
+      expect(page).to have_content('Working pattern: Full time')
+      expect(page).to have_content('Minimum salary: £20,000')
+      expect(page).to have_content('Maximum salary: £30,000')
+    end
+  end
+end

--- a/spec/presenters/subscription_presenter_spec.rb
+++ b/spec/presenters/subscription_presenter_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+RSpec.describe SubscriptionPresenter do
+  describe '#formatted_search_criteria' do
+    context 'formats and returns the search criteria' do
+      it 'with the location filter' do
+        subscription = Subscription.new(search_criteria: { location: 'EC2 9AN',
+                                                           radius: '10' }.to_json)
+        presenter = SubscriptionPresenter.new(subscription)
+
+        expect(presenter.filtered_search_criteria['location']).to eq('Within 10 miles of EC2 9AN')
+      end
+
+      it 'without location information unless both location and radius are set' do
+        subscription = Subscription.new(search_criteria: { radius: '10' }.to_json)
+        presenter = SubscriptionPresenter.new(subscription)
+
+        expect(presenter.filtered_search_criteria.key?('location')).to eq(false)
+        expect(presenter.filtered_search_criteria.key?('radius')).to eq(false)
+      end
+
+      it 'with the formatted salary filters' do
+        subscription = Subscription.new(search_criteria: { minimum_salary: '10',
+                                                           maximum_salary: '2000' }.to_json)
+        presenter = SubscriptionPresenter.new(subscription)
+
+        expect(presenter.filtered_search_criteria['minimum_salary']).to eq('£10')
+        expect(presenter.filtered_search_criteria['maximum_salary']).to eq('£2,000')
+      end
+
+      it 'with the formatted working_pattern filter' do
+        subscription = Subscription.new(search_criteria: { working_pattern: 'part_time' }.to_json)
+        presenter = SubscriptionPresenter.new(subscription)
+
+        expect(presenter.filtered_search_criteria['working_pattern']).to eq('Part time')
+      end
+
+      it 'with the formatted NQT filter' do
+        subscription = Subscription.new(search_criteria: { newly_qualified_teacher: 'true' }.to_json)
+        presenter = SubscriptionPresenter.new(subscription)
+
+        expect(presenter.filtered_search_criteria['']).to eq('Suitable for NQTs')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Pending merge of #656 

## Trello card URL:
https://trello.com/c/gykP6TKh/657-121-email-alerts-new-subscription-page

## Changes in this PR:
- Adds subscription page
- Formats search_criteria 
- Generates subscription reference
- Adds reusable email_address validator

## Screenshot

<img width="876" alt="image" src="https://user-images.githubusercontent.com/159200/49864693-f478aa00-fdfa-11e8-989c-df685e563237.png">
