### PR TITLE
[673] Refactor omniauth_openid_connect monkey patch to make it manageable

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -45,30 +45,29 @@ end
 
 class OmniAuth::Strategies::Dfe < OmniAuth::Strategies::OpenIDConnect; end
 
-Rails.application.config.middleware.use OmniAuth::Builder do
-  dfe_sign_in_issuer_uri    = URI(ENV.fetch('DFE_SIGN_IN_ISSUER', 'example'))
-  dfe_sign_in_identifier    = ENV.fetch('DFE_SIGN_IN_IDENTIFIER', 'example')
-  dfe_sign_in_secret        = ENV.fetch('DFE_SIGN_IN_SECRET', 'example')
-  dfe_sign_in_redirect_uri  = ENV.fetch('DFE_SIGN_IN_REDIRECT_URL', 'example')
+# Docker initialises the application (during `docker build`) in a context where
+# there are no environment variables. This guard clause is cleaner than multiple
+# `ENV.fetch` that sets up defaults.
+if ENV['DFE_SIGN_IN_ISSUER'].present?
+  dfe_sign_in_issuer_uri = URI.parse(ENV['DFE_SIGN_IN_ISSUER'])
+  options = {
+    name: :dfe,
+    discovery: true,
+    response_type: :code,
+    client_signing_alg: :RS256,
+    scope: %i[openid profile email organisation],
+    client_options: {
+      port: dfe_sign_in_issuer_uri.port,
+      scheme: dfe_sign_in_issuer_uri.scheme,
+      host: dfe_sign_in_issuer_uri.host,
+      identifier: ENV['DFE_SIGN_IN_IDENTIFIER'],
+      secret: ENV['DFE_SIGN_IN_SECRET'],
+      redirect_uri: ENV['DFE_SIGN_IN_REDIRECT_URL'],
+      authorization_endpoint: '/auth',
+      jwks_uri: '/certs',
+      userinfo_endpoint: '/me'
+    }
+  }
 
-  dfe_sign_in_issuer_url = "#{dfe_sign_in_issuer_uri}:#{dfe_sign_in_issuer_uri.port}" if dfe_sign_in_issuer_uri.port
-
-  provider :dfe,
-           name: :dfe,
-           discovery: true,
-           response_type: :code,
-           issuer: dfe_sign_in_issuer_url,
-           client_signing_alg: :RS256,
-           scope: %i[openid profile email organisation],
-           client_options: {
-             port: dfe_sign_in_issuer_uri.port,
-             scheme: dfe_sign_in_issuer_uri.scheme,
-             host: dfe_sign_in_issuer_uri.host,
-             identifier: dfe_sign_in_identifier,
-             secret: dfe_sign_in_secret,
-             redirect_uri: dfe_sign_in_redirect_uri,
-             authorization_endpoint: '/auth',
-             jwks_uri: '/certs',
-             userinfo_endpoint: '/me'
-           }
+  Rails.application.config.middleware.use OmniAuth::Strategies::OpenIDConnect, options
 end

--- a/spec/requests/dfe_sign_in_spec.rb
+++ b/spec/requests/dfe_sign_in_spec.rb
@@ -35,4 +35,14 @@ RSpec.describe 'DfE Sign-in', type: :request do
       expect(response).to redirect_to(new_dfe_path)
     end
   end
+
+  # Omniauth documentation says that any authentication failure with the provider
+  # will be caught and routed to /auth/failure: https://github.com/omniauth/omniauth/wiki
+  context 'when a request fails in omniauth or omniauth_openid_connect for any reason' do
+    it 'redirects to a styled 401 page' do
+      get '/auth/failure'
+
+      expect(response.status).to redirect_to('/401')
+    end
+  end
 end

--- a/spec/requests/dfe_sign_in_spec.rb
+++ b/spec/requests/dfe_sign_in_spec.rb
@@ -1,8 +1,18 @@
 require 'rails_helper'
 
 RSpec.describe 'DfE Sign-in', type: :request do
+  before(:each) do
+    OmniAuth.config.test_mode = true
+  end
+
+  after(:each) do
+    OmniAuth.config.test_mode = false
+    OmniAuth.config.mock_auth[:dfe] = nil
+  end
+
   context 'when DfE Sign-in respond with an OIDC payload for authentication purposes' do
-    context 'when that payload is unauthorised' do
+    context 'when that openid connect payload is unauthorised' do
+      before(:each) { OmniAuth.config.mock_auth[:dfe] = :invalid_credentials }
       it 'redirects the user to the not authorised page' do
         params = {
           'code': 'a-long-secret',
@@ -12,15 +22,17 @@ RSpec.describe 'DfE Sign-in', type: :request do
         get auth_dfe_callback_path, params: params
 
         expect(response.status).to eq(302)
-        expect(response.body).to eq('Redirecting to /401...')
       end
     end
   end
 
-  context 'when a user is linked back to our service with a redirect' do
+  context 'when a user is linked back to our service without an openid connect payload' do
     it 'routes the request back to the new sign-in page' do
-      request = get auth_dfe_callback_path
-      expect(request).to redirect_to(new_dfe_path)
+      OmniAuth.config.test_mode = false
+
+      get auth_dfe_callback_path
+
+      expect(response).to redirect_to(new_dfe_path)
     end
   end
 end


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/0fBiG9GY


## Changes in this PR:

This is a refactoring exercise to manage the use of our monkey patch, and bring us closer to a point where we can remove it.

Before going into this it wasn't clear that we were using it for 2 purposes:
1. stop password reset completions being incorrectly routed to the 401 page by DSI  (DfE Sign-in)
2. ensure that any authentication failures resulted in a styled and monitored 401 page

Trying to test this with feature specs was an absolute nightmare. It's easy to mock OmniAuth but it also wraps up the behaviour of the strategies, so I couldn't create a realistic simulation. The only feature test I did make, was actually a lie because of the Omniauth stubbing layer.
```
  context 'with invalid credentials' do
    before(:each) { OmniAuth.config.mock_auth[:dfe] = :invalid_credentials }

    scenario 'redirects the user to the not authorised page' do
      visit root_path
      click_on(I18n.t('nav.sign_in'))
      click_on(I18n.t('sign_in.link'))

      expect(page).to have_content(I18n.t('error_pages.unauthorised')) => this passes but isn't what actually happens as OmniAuth defers the callback phase to the strategy in omniauth_openid_connect!
      a_plain_401_rack_response = '401 Unauthorized'
      expect(page).not_to have_content(a_plain_401_rack_response)  => I could never make this appear in the first place via tests, only postman
    end
  end
```

My view is that it it is better to have a styled 401 page with GA tracking for monitoring, and to manage this code than it would be to remove it, serve a white 401 page and never know how much it was a problem for users.

Further details are on the commits. 

Next steps are to open a pull request on the omniauth_openid_connect gem to change their basic rack response with a redirect to /auth/failure.

## Screenshots of UI changes:

### Before
<img width="1268" alt="screenshot 2018-12-12 at 15 18 55" src="https://user-images.githubusercontent.com/912473/49879223-77acf680-fe21-11e8-9504-959a1943c888.png">

### After
<img width="1190" alt="screenshot 2018-12-12 at 15 20 54" src="https://user-images.githubusercontent.com/912473/49879261-88f60300-fe21-11e8-928f-3969db4ee8e9.png">

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
