### PR TITLE
[Feature] 1.2.2 Email alerts - Create subscription

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -13,7 +13,8 @@ class SubscriptionsController < ApplicationController
                                     search_criteria: daily_subscription_params[:search_criteria],
                                     frequency: daily_subscription_params[:frequency])
       flash[:error] = I18n.t('errors.subscriptions.already_exists')
-    elsif @subscription.save
+    elsif subscription.save
+      Auditor::Audit.new(subscription, 'subscription.daily_alert.create', nil).log
       flash[:notice] = I18n.t('messages.subscriptions.created')
       return render 'confirm'
     end

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -5,16 +5,31 @@ class SubscriptionsController < ApplicationController
   end
 
   def create
-    subscription = Subscription.new(subscription_params)
+    flash.clear
+    subscription = Subscription.new(daily_subscription_params)
     @subscription = SubscriptionPresenter.new(subscription)
 
-    render 'new' unless @subscription.valid?
+    if Subscription.ongoing.exists?(email: daily_subscription_params[:email],
+                                    search_criteria: daily_subscription_params[:search_criteria],
+                                    frequency: daily_subscription_params[:frequency])
+      flash[:error] = I18n.t('errors.subscriptions.already_exists')
+    elsif @subscription.save
+      flash[:notice] = I18n.t('messages.subscriptions.created')
+      return render 'confirm'
+    end
+
+    render 'new'
   end
 
   private
 
   def subscription_params
     params.require(:subscription).permit(:email, :reference, :search_criteria)
+  end
+
+  def daily_subscription_params
+    subscription_params.merge(expires_on: 3.months.from_now,
+                              frequency: :daily)
   end
 
   def search_criteria

--- a/app/views/subscriptions/new.html.haml
+++ b/app/views/subscriptions/new.html.haml
@@ -8,26 +8,34 @@
   .govuk-grid-column-full
     %h1.govuk-heading-xl
       = t('subscriptions.new')
-.govuk-grid-row
-  .govuk-grid-column-full
-    %p.govuk-body-l
-      = t('subscriptions.intro')
 
-    %div.govuk-inset-text
-      %ul.govuk-list
-        - @subscription.filtered_search_criteria.each_pair do |filter, value|
-          %li
-            - if filter.present?
-              %span{ class: 'govuk-!-font-weight-bold'} #{filter.humanize}:
-            = value
+.govuk-grid-row
+  .govuk-grid-column-one
+
+    - if @subscription.errors.any?
+      #errors.govuk-error-summary{role: 'alert', tabindex: '-1'}
+        %h2.govuk-heading-m.govuk-error-summary-heading
+          = t('errors.feedback.errors_present')
+        %ul.govuk-list.govuk-error-summary__list
+          - @subscription.errors.each do |attribute, error|
+            %li= @subscription.errors.full_message(attribute, error)
 
 .govuk-grid-row
   .govuk-grid-column-one-half
+    %p.govuk-body-l=t('subscriptions.intro')
+
     = simple_form_for @subscription do |f|
+      = f.input :search_criteria, as: :hidden
+      %div.govuk-inset-text
+        %ul.govuk-list
+          - @subscription.filtered_search_criteria.each_pair do |filter, value|
+            %li
+              - if filter.present?
+                %span{ class: 'govuk-!-font-weight-bold'} #{filter.humanize}:
+              = value
       = f.input :email, as: :email, input_html: { class: 'govuk-input' }, required: true
       = f.input :reference, as: :string, input_html: { class: 'govuk-input' }
 
-      = f.input :search_criteria, as: :hidden
 
       .govuk-warning-text
         %span.govuk-warning-text__icon{'aria-hidden': "true"}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -263,6 +263,8 @@ en:
       signed_out: You've been signed out.
     feedback:
       submitted: Your feedback has been successfully submitted
+    subscriptions:
+      created: Email subscription created successfully.
 
   errors:
     jobs:
@@ -275,6 +277,8 @@ en:
     feedback:
       errors_present: Please correct the following error
       already_submitted: Feedback for this job listing has already been submitted
+    subscriptions:
+      already_exists: You are already subscribed to a daily email with these search criteria
 
   error_pages:
     unauthorised: We were unable to authorise your request.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,9 @@ Rails.application.routes.draw do
     resources :interests, only: %i[new]
   end
 
-  resources :subscriptions, only: %i[new create]
+  resources :subscriptions, only: %i[new create] do
+    resource :confirmation, only: [:show]
+  end
 
   namespace :api do
     scope 'v:api_version', api_version: /[1]/ do

--- a/spec/factories/subscriptions.rb
+++ b/spec/factories/subscriptions.rb
@@ -2,5 +2,10 @@ FactoryBot.define do
   factory :subscription do
     expires_on { Time.zone.today.strftime('%Y-%m-%d') }
     email { Faker::Internet.email }
+
+    factory :daily_subscription do
+      frequency { :daily }
+      expires_on { 3.months.from_now }
+    end
   end
 end

--- a/spec/features/job_seekers_can_subscribe_to_a_job_alert_spec.rb
+++ b/spec/features/job_seekers_can_subscribe_to_a_job_alert_spec.rb
@@ -26,6 +26,15 @@ RSpec.feature 'A job seeker can subscribe to a job alert', wip: true do
       expect(page).to have_content('Maximum salary: £30,000')
     end
 
+    scenario 'subscribing to a search creates a new daily subscription audit' do
+      visit new_subscription_path(search_criteria: { keyword: 'test' })
+      fill_in 'subscription[email]', with: 'jane.doe@example.com'
+      click_on 'Subscribe'
+
+      activity = PublicActivity::Activity.last
+      expect(activity.key).to eq('subscription.daily_alert.create')
+    end
+
     context 'can create a new subscription' do
       scenario 'when the email address is valid' do
         visit new_subscription_path(search_criteria: { keyword: 'test' })

--- a/spec/features/job_seekers_can_subscribe_to_a_job_alert_spec.rb
+++ b/spec/features/job_seekers_can_subscribe_to_a_job_alert_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'A job seeker can subscribe to a job alert' do
+RSpec.feature 'A job seeker can subscribe to a job alert', wip: true do
   context 'A job seeker' do
     scenario 'can access the new subscription page when search criteria have been specified' do
       expect { visit(new_subscription_path) }.to raise_error(ActionController::ParameterMissing)
@@ -24,6 +24,63 @@ RSpec.feature 'A job seeker can subscribe to a job alert' do
       expect(page).to have_content('Working pattern: Full time')
       expect(page).to have_content('Minimum salary: £20,000')
       expect(page).to have_content('Maximum salary: £30,000')
+    end
+
+    context 'can create a new subscription' do
+      scenario 'when the email address is valid' do
+        visit new_subscription_path(search_criteria: { keyword: 'test' })
+        fill_in 'subscription[email]', with: 'jane.doe@example.com'
+        click_on 'Subscribe'
+
+        expect(page).to have_content('Email subscription created successfully')
+      end
+
+      scenario 'when the email address is associated with other active subscriptions' do
+        create(:daily_subscription, email: 'jane.doe@example.com',
+                                    search_criteria: { keyword: 'teacher' }.to_json)
+
+        visit new_subscription_path(search_criteria: { keyword: 'math teacher' })
+        fill_in 'subscription[email]', with: 'jane.doe@example.com'
+        click_on 'Subscribe'
+
+        expect(page).to have_content('Email subscription created successfully')
+      end
+
+      scenario 'when the email address is associated with the same inactive subscriptions' do
+        create(:daily_subscription, email: 'jane.doe@example.com',
+                                    expires_on: 1.day.ago,
+                                    search_criteria: { keyword: 'teacher' }.to_json)
+
+        visit new_subscription_path(search_criteria: { keyword: 'teacher' })
+        fill_in 'subscription[email]', with: 'jane.doe@example.com'
+        click_on 'Subscribe'
+
+        expect(page).to have_content('Email subscription created successfully')
+      end
+    end
+
+    context 'is not able to create a new subscription' do
+      scenario 'when the email address is invalid' do
+        visit new_subscription_path(search_criteria: { keyword: 'test' })
+        fill_in 'subscription[email]', with: 'jane.doe@example'
+        click_on 'Subscribe'
+
+        expect(page).to have_content('Please correct the following error')
+        expect(page).to have_content('Email is not a valid email address')
+      end
+
+      scenario 'when an active subcsription with the same search_criteria exists' do
+        search_criteria = { location: 'EC2 9AN', radius: '10' }
+
+        create(:daily_subscription, email: 'jane.doe@example.com',
+                                    search_criteria: search_criteria.to_json)
+
+        visit new_subscription_path(search_criteria: search_criteria)
+        fill_in 'subscription[email]', with: 'jane.doe@example.com'
+        click_on 'Subscribe'
+
+        expect(page).to have_content('You are already subscribed to a daily email with these search criteria')
+      end
     end
   end
 end


### PR DESCRIPTION
Pending merge of #657 

## Trello card URL:
https://trello.com/c/5oJ6NTzf/656-111-email-alerts-subscription-model

## Changes in this PR:
- Creates a subscription
- Ensures uniqueness of active subscription for frequency/search_criteria
- Audits subscription creation
- Revisits new subscription page & renders error messages

<img width="796" alt="image" src="https://user-images.githubusercontent.com/159200/49891549-b4d3b180-fe3e-11e8-809b-302d4b952cdf.png">
