### PR TITLE
Republish an expired job

### DIFF
--- a/app/controllers/hiring_staff/vacancies/republish_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/republish_controller.rb
@@ -1,0 +1,42 @@
+class HiringStaff::Vacancies::RepublishController < HiringStaff::Vacancies::ApplicationController
+  def new
+    @republish_form = RepublishForm.new(vacancy_attributes)
+    @school = school
+    @republish_form.valid? if params[:source]&.eql?('republish')
+  end
+
+  def create
+    @republish_form = RepublishForm.new(republish_form)
+    @republish_form.id = vacancy_id
+    if @republish_form.valid?
+      update_vacancy(republish_form, vacancy)
+      redirect_to school_job_publish_path(vacancy.id, source: 'republish')
+    else
+      @school = school
+      render :new, source: 'republish'
+    end
+  end
+
+  private
+
+  def republish_form
+    params.require(:republish_form).permit(:starts_on_dd, :starts_on_mm,
+                                           :starts_on_yyyy, :ends_on_dd,
+                                           :ends_on_mm, :ends_on_yyyy,
+                                           :expires_on_dd, :expires_on_mm,
+                                           :expires_on_yyyy, :publish_on_dd,
+                                           :publish_on_mm, :publish_on_yyyy)
+  end
+
+  def vacancy_attributes
+    vacancy.attributes
+  end
+
+  def vacancy_id
+    params.permit(:job_id)[:job_id]
+  end
+
+  def vacancy
+    school.vacancies.published.find(vacancy_id)
+  end
+end

--- a/app/controllers/hiring_staff/vacancies_controller.rb
+++ b/app/controllers/hiring_staff/vacancies_controller.rb
@@ -73,7 +73,7 @@ class HiringStaff::VacanciesController < HiringStaff::Vacancies::ApplicationCont
   end
 
   def already_published_message
-    I18n.t('messages.vacancies.already_published')
+    I18n.t('jobs.already_published')
   end
 
   def clear_cache_and_step

--- a/app/form_models/application_details_form.rb
+++ b/app/form_models/application_details_form.rb
@@ -6,6 +6,7 @@ class ApplicationDetailsForm < VacancyForm
   attr_accessor :original_publish_on
 
   include VacancyApplicationDetailValidations
+  include VacancyDateValidations
 
   def disable_editing_publish_on?
     published? && vacancy.reload.publish_on.past?

--- a/app/form_models/job_specification_form.rb
+++ b/app/form_models/job_specification_form.rb
@@ -6,4 +6,5 @@ class JobSpecificationForm < VacancyForm
   # rubocop:enable Lint/AmbiguousOperator
 
   include VacancyJobSpecificationValidations
+  include VacancyDateValidations
 end

--- a/app/form_models/republish_form.rb
+++ b/app/form_models/republish_form.rb
@@ -1,0 +1,9 @@
+class RepublishForm < VacancyForm
+  delegate :expires_on_dd, :expires_on_mm, :expires_on_yyyy,
+           :publish_on_dd, :publish_on_mm, :publish_on_yyyy,
+           :starts_on_dd, :starts_on_mm, :starts_on_yyyy,
+           :ends_on_dd, :ends_on_mm, :ends_on_yyyy,
+           to: :vacancy
+
+  include VacancyDateValidations
+end

--- a/app/models/concerns/vacancy_application_detail_validations.rb
+++ b/app/models/concerns/vacancy_application_detail_validations.rb
@@ -29,14 +29,6 @@ module VacancyApplicationDetailValidations
     expires_on && publish_on && expires_on < publish_on
   end
 
-  def publish_on_in_past?
-    publish_on && publish_on < Time.zone.today
-  end
-
-  def publish_on_before_today_error
-    I18n.t('activerecord.errors.models.vacancy.attributes.publish_on.before_today')
-  end
-
   def expires_on_before_publish_on_error
     I18n.t('activerecord.errors.models.vacancy.attributes.expires_on.before_publish_date')
   end

--- a/app/models/concerns/vacancy_application_detail_validations.rb
+++ b/app/models/concerns/vacancy_application_detail_validations.rb
@@ -8,8 +8,7 @@ module VacancyApplicationDetailValidations
     validates :application_link, url: true, if: proc { |v| v.application_link.present? }
 
     validates :publish_on, presence: true, if: proc { |v| !v.published? }
-    validate :validity_of_publish_on, :validity_of_expires_on
-    validates_with DateFormatValidator, fields: %i[publish_on expires_on]
+    validate :validity_of_publish_on
   end
 
   def validity_of_publish_on

--- a/app/models/concerns/vacancy_date_validations.rb
+++ b/app/models/concerns/vacancy_date_validations.rb
@@ -1,0 +1,71 @@
+module VacancyDateValidations
+  extend ActiveSupport::Concern
+  include ApplicationHelper
+
+  included do
+    validate :starts_on_in_future?, if: :starts_on?
+    validate :ends_on_in_future?, if: :ends_on?
+    validate :starts_on_before_ends_on?
+
+    validate :starts_on_before_closing_date, if: :starts_on?
+    validate :ends_on_before_closing_date, if: :ends_on?
+
+    validate :validity_of_expires_on
+
+    validates_with DateFormatValidator, fields: %i[starts_on ends_on publish_on expires_on]
+  end
+
+  def starts_on_before_ends_on?
+    errors.add(:starts_on, starts_on_after_ends_on_error) if starts_on? && ends_on? && starts_on > ends_on
+  end
+
+  def starts_on_after_ends_on_error
+    I18n.t('activerecord.errors.models.vacancy.attributes.starts_on.after_ends_on')
+  end
+
+  def starts_on_in_future?
+    errors.add(:starts_on, starts_on_past_error) if starts_on.past?
+  end
+
+  def starts_on_past_error
+    I18n.t('activerecord.errors.models.vacancy.attributes.starts_on.past')
+  end
+
+  def starts_on_before_closing_date
+    errors.add(:starts_on, starts_on_must_be_before_closing_date_error) if expires_on? && starts_on <= expires_on
+  end
+
+  def ends_on_before_closing_date
+    errors.add(:ends_on, ends_on_must_be_before_closing_date_error) if expires_on? && ends_on <= expires_on
+  end
+
+  def starts_on_must_be_before_closing_date_error
+    I18n.t('activerecord.errors.models.vacancy.attributes.starts_on.before_expires_on')
+  end
+
+  def ends_on_must_be_before_closing_date_error
+    I18n.t('activerecord.errors.models.vacancy.attributes.ends_on.before_expires_on')
+  end
+
+  def ends_on_in_future?
+    errors.add(:ends_on, ends_on_past_error) if ends_on.past?
+  end
+
+  def ends_on_past_error
+    I18n.t('activerecord.errors.models.vacancy.attributes.ends_on.past')
+  end
+
+  def validity_of_expires_on
+    errors.add(:expires_on, expires_on_before_publish_on_error) if expiry_date_less_than_publish_date?
+  end
+
+  private
+
+  def expiry_date_less_than_publish_date?
+    expires_on && publish_on && expires_on < publish_on
+  end
+
+  def expires_on_before_publish_on_error
+    I18n.t('activerecord.errors.models.vacancy.attributes.expires_on.before_publish_date')
+  end
+end

--- a/app/models/concerns/vacancy_date_validations.rb
+++ b/app/models/concerns/vacancy_date_validations.rb
@@ -10,7 +10,7 @@ module VacancyDateValidations
     validate :starts_on_before_closing_date, if: :starts_on?
     validate :ends_on_before_closing_date, if: :ends_on?
 
-    validate :validity_of_expires_on
+    validate :validity_of_expires_on, :validity_of_publish_on
 
     validates_with DateFormatValidator, fields: %i[starts_on ends_on publish_on expires_on]
   end
@@ -59,6 +59,14 @@ module VacancyDateValidations
     errors.add(:expires_on, expires_on_before_publish_on_error) if expiry_date_less_than_publish_date?
   end
 
+  def validity_of_publish_on
+    errors.add(:publish_on, publish_on_before_today_error) if publish_on_in_past?
+  end
+
+  def publish_on_in_past?
+    publish_on && publish_on < Time.zone.today
+  end
+
   private
 
   def expiry_date_less_than_publish_date?
@@ -67,5 +75,9 @@ module VacancyDateValidations
 
   def expires_on_before_publish_on_error
     I18n.t('activerecord.errors.models.vacancy.attributes.expires_on.before_publish_date')
+  end
+
+  def publish_on_before_today_error
+    I18n.t('activerecord.errors.models.vacancy.attributes.publish_on.before_today')
   end
 end

--- a/app/models/concerns/vacancy_job_specification_validations.rb
+++ b/app/models/concerns/vacancy_job_specification_validations.rb
@@ -12,54 +12,6 @@ module VacancyJobSpecificationValidations
     validate :maximum_salary_greater_than_minimum, if: :minimum_and_maximum_salary_present_and_valid?
     validates :working_pattern, presence: true
     validate :working_hours
-
-    validate :starts_on_in_future?, if: :starts_on?
-    validate :ends_on_in_future?, if: :ends_on?
-    validate :starts_on_before_ends_on?
-
-    validate :starts_on_before_closing_date, if: :starts_on?
-    validate :ends_on_before_closing_date, if: :ends_on?
-    validates_with DateFormatValidator, fields: %i[starts_on ends_on]
-  end
-
-  def starts_on_before_ends_on?
-    errors.add(:starts_on, starts_on_after_ends_on_error) if starts_on? && ends_on? && starts_on > ends_on
-  end
-
-  def starts_on_after_ends_on_error
-    I18n.t('activerecord.errors.models.vacancy.attributes.starts_on.after_ends_on')
-  end
-
-  def starts_on_in_future?
-    errors.add(:starts_on, starts_on_past_error) if starts_on.past?
-  end
-
-  def starts_on_past_error
-    I18n.t('activerecord.errors.models.vacancy.attributes.starts_on.past')
-  end
-
-  def starts_on_before_closing_date
-    errors.add(:starts_on, starts_on_must_be_before_closing_date_error) if expires_on? && starts_on <= expires_on
-  end
-
-  def ends_on_before_closing_date
-    errors.add(:ends_on, ends_on_must_be_before_closing_date_error) if expires_on? && ends_on <= expires_on
-  end
-
-  def starts_on_must_be_before_closing_date_error
-    I18n.t('activerecord.errors.models.vacancy.attributes.starts_on.before_expires_on')
-  end
-
-  def ends_on_must_be_before_closing_date_error
-    I18n.t('activerecord.errors.models.vacancy.attributes.ends_on.before_expires_on')
-  end
-
-  def ends_on_in_future?
-    errors.add(:ends_on, ends_on_past_error) if ends_on.past?
-  end
-
-  def ends_on_past_error
-    I18n.t('activerecord.errors.models.vacancy.attributes.ends_on.past')
   end
 
   def minimum_valid_and_maximum_salary_present?

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -8,6 +8,7 @@ class Vacancy < ApplicationRecord
   include VacancyJobSpecificationValidations
   include VacancyCandidateSpecificationValidations
   include VacancyApplicationDetailValidations
+  include VacancyDateValidations
 
   include Elasticsearch::Model
 

--- a/app/views/hiring_staff/schools/_vacancies.html.haml
+++ b/app/views/hiring_staff/schools/_vacancies.html.haml
@@ -74,7 +74,7 @@
             %th.govuk-table__header= t('jobs.job_title')
             %th.govuk-table__header= t('jobs.publish_on')
             %th.govuk-table__header= t('jobs.expired_on')
-            %th.govuk-table__header= t('jobs.actions')
+            %th.govuk-table__header{ colspan: 2}= t('jobs.actions')
         %tbody.govuk-table__body
           %tr.govuk-table__row
             - @expired_vacancies.each do |vacancy|

--- a/app/views/hiring_staff/schools/_vacancy_expired.html.haml
+++ b/app/views/hiring_staff/schools/_vacancy_expired.html.haml
@@ -2,4 +2,5 @@
   %td.govuk-table__cell= link_to vacancy.job_title, school_job_path(vacancy.id), class: 'govuk-link view-vacancy-link'
   %td.govuk-table__cell= format_date(vacancy.publish_on)
   %td.govuk-table__cell= format_date(vacancy.expires_on)
+  %td.govuk-table__cell= link_to t('jobs.republish_link'), new_school_job_republish_path(vacancy.id), class: 'govuk-link'
   %td.govuk-table__cell= link_to t('jobs.delete_link'), school_job_path(id: vacancy.id), class: 'govuk-link', method: :delete, data: { confirm: t('jobs.are_you_sure', job_title: vacancy.job_title) }

--- a/app/views/hiring_staff/vacancies/republish/new.html.haml
+++ b/app/views/hiring_staff/vacancies/republish/new.html.haml
@@ -1,0 +1,46 @@
+- content_for :page_title_prefix, "#{@republish_form.errors.present? ? t('errors.error')  : ''}#{t('jobs.edit_dates')}"
+
+%h1.govuk-heading-l
+  = t('jobs.republish_heading', school: @school.name)
+.vacancy
+  .govuk-grid-row
+    .govuk-grid-column-full
+      .banner-warning
+        = t('jobs.republish_instructions')
+= render 'hiring_staff/vacancies/error_messages', errors: @republish_form.errors
+= simple_form_for @republish_form, html: { class: 'vacancy-form' }, method: :post, url: school_job_republish_path(@republish_form.id) do |f|
+  %h2.govuk-heading-m
+    = t('jobs.application_details')
+
+  .govuk-grid-row
+    .govuk-grid-column-one-half
+      %div.govuk-form-group#publish_on
+        = f.gov_uk_date_field :publish_on,
+          legend_text: t('jobs.publication_date'),
+          legend_class: 'govuk-label',
+          form_hint_text: t('jobs.form_hints.publication_date',
+                          date: l(Date.today, format: :hinttext))
+
+      %div.govuk-form-group#deadline
+        = f.gov_uk_date_field :expires_on,
+                              legend_text: t('jobs.deadline_date'),
+                              legend_class: 'govuk-label',
+                              form_hint_text: t('jobs.form_hints.deadline_date',
+                                                date: l(Date.today + 2.months, format: :hinttext))
+
+      %div.govuk-form-group#starts_on
+        = f.gov_uk_date_field :starts_on,
+              legend_text: "#{t('jobs.starts_on')} (optional)",
+              legend_class: 'govuk-label',
+              form_hint_text: t('jobs.form_hints.start_date',
+                                date: l(Date.today + 3.months, format: :hinttext))
+
+
+      %div.govuk-form-group#ends_on
+        = f.gov_uk_date_field :ends_on,
+              legend_text: "#{t('jobs.ends_on')} (optional)",
+              legend_class: 'govuk-label',
+              form_hint_text: t('jobs.form_hints.end_date',
+                                date: l(Date.today + 6.months, format: :hinttext))
+
+      = f.button :submit, t('buttons.save_and_continue')

--- a/app/views/hiring_staff/vacancies/review.html.haml
+++ b/app/views/hiring_staff/vacancies/review.html.haml
@@ -225,4 +225,4 @@
     %h2.govuk-heading-m Now submit your job
     %p= t('jobs.confirmation_summary')
 
-    = link_to t('jobs.submit'), school_job_publish_path(@vacancy.id), method: :post, class: "govuk-button"
+    = link_to t('jobs.submit'), school_job_publish_path(@vacancy.id, source: params[:source]), method: :post, class: "govuk-button"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -85,6 +85,7 @@ en:
     publication_date: 'Date role will be listed'
     review: 'Review the job details and make any necessary changes before submitting it for publication below.'
     edit: 'Edit the job details.'
+    edit_dates: 'Edit the Job dates'
     confirmation_summary: 'By submitting you are confirming that to the best of your knowledge, the details you are providing are correct.'
     submit: 'Confirm and submit job'
     apply: 'Get more information'
@@ -113,6 +114,9 @@ en:
     no_pending_jobs: You currently have no pending jobs
     edit_link: Edit
     delete_link: Delete
+    republish_heading: Republish the job for %{school}
+    republish_link: Republish
+    republish_instructions: These fields need to be updated before republishing the job
     are_you_sure: Are you sure you want to delete the '%{job_title}' job?
     confirmation_page:
       submitted: 'The job listing has been completed'
@@ -275,6 +279,7 @@ en:
       submitted: Your feedback has been successfully submitted
 
   errors:
+    error: Error
     jobs:
       unable_to_publish: We were unable to publish this job. Make sure that you have filled all mandatory fields
     sign_in:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,8 @@ Rails.application.routes.draw do
                                          controller: 'hiring_staff/vacancies/candidate_specification'
       resource :application_details, only: %i[edit update],
                                      controller: 'hiring_staff/vacancies/application_details'
+      resource :republish, only: %i[new create],
+                           controller: 'hiring_staff/vacancies/republish'
 
       resource :feedback, controller: 'hiring_staff/vacancies/feedback', only: %i[new create]
     end

--- a/spec/features/hiring_staff_can_republish_an_expired_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_republish_an_expired_vacancy_spec.rb
@@ -1,0 +1,108 @@
+require 'rails_helper'
+RSpec.feature 'Republishing an expired vacancy' do
+  let(:school) { create(:school) }
+  let(:session_id) { SecureRandom.uuid }
+  let(:vacancy) do
+    build(:vacancy,
+          school: school,
+          status: 'published',
+          expires_on: Faker::Time.backward(6),
+          publish_on: Faker::Time.backward(10))
+  end
+
+  before(:each) do
+    stub_hiring_staff_auth(urn: school.urn, session_id: session_id)
+    vacancy.send :set_slug
+    vacancy.save(validate: false)
+  end
+
+  scenario 'hiring staff can see a Republish link for an expired vacancy' do
+    visit school_path
+
+    table = page.find('section#expired-jobs table')
+    expect(table).to have_selector('td', text: vacancy.job_title)
+    expect(table).to have_selector('td', text: 'Republish')
+  end
+
+  scenario 'the republish form pre-fills dates in the job listing' do
+    visit new_school_job_republish_path(vacancy.id)
+    expires_on = vacancy.expires_on
+    expires_on_dd = page.find('input#republish_form_expires_on_dd')
+    expires_on_mm = page.find('input#republish_form_expires_on_mm')
+    expires_on_yyyy = page.find('input#republish_form_expires_on_yyyy')
+
+    expect(expires_on_dd.value).to eq(expires_on.strftime('%-d'))
+    expect(expires_on_mm.value).to eq(expires_on.strftime('%-m'))
+    expect(expires_on_yyyy.value).to eq(expires_on.strftime('%Y'))
+  end
+
+  scenario 'the republish form has instructions to the hiring staff' do
+    visit new_school_job_republish_path(vacancy.id)
+
+    expect(page).to have_content(I18n.t('jobs.republish_instructions'))
+  end
+
+  context 'the hiring staff enters invalid dates' do
+    scenario 'the republish form shows validation errors if publish_on is before today' do
+      visit new_school_job_republish_path(vacancy.id)
+
+      yesterday = Time.zone.yesterday
+      tomorrow = Time.zone.tomorrow
+
+      fill_in('republish_form[publish_on_dd]', with: yesterday.day)
+      fill_in('republish_form[publish_on_mm]', with: yesterday.month)
+      fill_in('republish_form[publish_on_yyyy]', with: yesterday.year)
+
+      fill_in('republish_form[expires_on_dd]', with: tomorrow.day)
+      fill_in('republish_form[expires_on_mm]', with: tomorrow.month)
+      fill_in('republish_form[expires_on_yyyy]', with: tomorrow.year)
+
+      click_on('Save and continue')
+
+      expect(page).to have_content(I18n.t('activerecord.errors.models.vacancy.attributes.publish_on.before_today'))
+    end
+
+    scenario 'the republish form shows validation errors if expires_on is before publish_on' do
+      visit new_school_job_republish_path(vacancy.id)
+
+      today = Time.zone.today
+      tomorrow = Time.zone.tomorrow
+
+      fill_in('republish_form[publish_on_dd]', with: tomorrow.day)
+      fill_in('republish_form[publish_on_mm]', with: tomorrow.month)
+      fill_in('republish_form[publish_on_yyyy]', with: tomorrow.year)
+
+      fill_in('republish_form[expires_on_dd]', with: today.day)
+      fill_in('republish_form[expires_on_mm]', with: today.month)
+      fill_in('republish_form[expires_on_yyyy]', with: today.year)
+
+      click_on('Save and continue')
+
+      expect(page).to have_content(
+        I18n.t('activerecord.errors.models.vacancy.attributes.expires_on.before_publish_date')
+      )
+    end
+  end
+
+  context 'the hiring staff enters valid dates' do
+    scenario 'the hiring staff can republish the job successfully' do
+      visit new_school_job_republish_path(vacancy.id)
+
+      today = Time.zone.today
+      tomorrow = Time.zone.tomorrow
+
+      fill_in('republish_form[publish_on_dd]', with: today.day)
+      fill_in('republish_form[publish_on_mm]', with: today.month)
+      fill_in('republish_form[publish_on_yyyy]', with: today.year)
+
+      fill_in('republish_form[expires_on_dd]', with: tomorrow.day)
+      fill_in('republish_form[expires_on_mm]', with: tomorrow.month)
+      fill_in('republish_form[expires_on_yyyy]', with: tomorrow.year)
+
+      click_on('Save and continue')
+
+      expect(page).to_not have_content(I18n.t('jobs.already_published'))
+      expect(page).to have_content(I18n.t('jobs.confirmation_page.submitted'))
+    end
+  end
+end


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/aiP8rVnL/650-republish-an-expired-job

## Changes in this PR:

Enable a hiring staff to republish an expired job, i.e. extend the closing date to re-list an expired job on the site. This does *NOT* create a new record in the database; it is the same job with extended `publish_on` & `expires_on` dates.

As an explainer for `republish_controller#new`, the validations are not run on initial page load, so the user does not see validation errors when they first come to the Republish form. Technically the job is not valid on load of this page (because the `expires_on` date is before today) but we don't want to scare the user with error messages on first load.

Additionally I've refactored some of the validations, putting the date-related validations in their own file for re-use.

## Screenshots of UI changes:

<img width="1264" alt="screenshot 2018-12-13 at 11 07 04" src="https://user-images.githubusercontent.com/1089521/49934947-a4b3e480-fec7-11e8-8077-1c78e5a7f4ad.png">

**User does NOT see validation errors on first page load**

<img width="1311" alt="screenshot 2018-12-13 at 11 07 19" src="https://user-images.githubusercontent.com/1089521/49934955-a8476b80-fec7-11e8-9ce7-45f180f9b0d9.png">

Validations are run on submit

<img width="1273" alt="screenshot 2018-12-13 at 11 07 30" src="https://user-images.githubusercontent.com/1089521/49934962-ab425c00-fec7-11e8-872b-9ef49b0453b2.png">

Job successfully re-listed

<img width="1284" alt="screenshot 2018-12-13 at 11 07 43" src="https://user-images.githubusercontent.com/1089521/49934969-ae3d4c80-fec7-11e8-861f-cc0f6368feb7.png">
