### PR TITLE
(fix) Fix bug in Vacancies#live and Vacancies#expired

### DIFF
--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -99,7 +99,7 @@ class Vacancy < ApplicationRecord
   scope :published_on_count, (->(date) { published.where('date(publish_on) = ?', date).count })
   scope :pending, (-> { published.where('publish_on > ?', Time.zone.today) })
   scope :expired, (-> { published.where('expires_on < ?', Time.zone.today) })
-  scope :live, (-> { published.where('publish_on <= ?', Time.zone.today).where('expires_on > ?', Time.zone.today) })
+  scope :live, (-> { published.where('publish_on <= ?', Time.zone.today).where('expires_on >= ?', Time.zone.today) })
 
   paginates_per 10
 

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -360,22 +360,26 @@ RSpec.describe Vacancy, type: :model do
         expired = build(:vacancy, :expired)
         expired.send :set_slug
         expired.save(validate: false)
+        expires_today = create(:vacancy, expires_on: Time.zone.today)
 
         expect(Vacancy.expired.count).to eq(1)
+        expect(Vacancy.expired).to_not include(expires_today)
       end
     end
 
     describe '#live' do
       it 'retrieves vacancies that have a status of :published, a past publish_on date & a future expires_on date' do
         live = create_list(:vacancy, 5, :published)
+        expires_today = create(:vacancy, expires_on: Time.zone.today)
         expired = build(:vacancy, :expired)
         expired.send :set_slug
         expired.save(validate: false)
         create_list(:vacancy, 3, :future_publish)
         create_list(:vacancy, 4, :trashed)
 
-        expect(Vacancy.live.count).to eq(live.count)
-        expect(live).to_not include(expired)
+        expect(Vacancy.live.count).to eq(live.count + 1)
+        expect(Vacancy.live).to include(expires_today)
+        expect(Vacancy.live).to_not include(expired)
       end
     end
 


### PR DESCRIPTION

## Trello card URL:

https://trello.com/c/DLzTBoLc/675-bug-manage-jobs-does-not-display-published-jobs-expiring-today

## Changes in this PR:

Vacancies#live should include vacancies expiring today
Vacancies#expired should NOT include vacancies expiring today

