### PR TITLE
[Feature] 1.2.4 Email Alerts - A visitor can subscribe to a search

### DIFF
--- a/app/controllers/concerns/parameter_sanitiser.rb
+++ b/app/controllers/concerns/parameter_sanitiser.rb
@@ -1,0 +1,10 @@
+module ParameterSanitiser
+  extend ActiveSupport::Concern
+
+  def self.call(params = {})
+    sanitised_params = params.each_pair do |key, value|
+      params[key] = Sanitize.fragment(value)
+    end
+    ActionController::Parameters.new(sanitised_params)
+  end
+end

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -15,7 +15,6 @@ class SubscriptionsController < ApplicationController
       flash[:error] = I18n.t('errors.subscriptions.already_exists')
     elsif subscription.save
       Auditor::Audit.new(subscription, 'subscription.daily_alert.create', nil).log
-      flash[:notice] = I18n.t('messages.subscriptions.created')
       return render 'confirm'
     end
 

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -1,4 +1,6 @@
 class SubscriptionsController < ApplicationController
+  include ParameterSanitiser
+
   def new
     subscription = Subscription.new(search_criteria: search_criteria.to_json)
     @subscription = SubscriptionPresenter.new(subscription)
@@ -23,7 +25,9 @@ class SubscriptionsController < ApplicationController
   private
 
   def subscription_params
-    params.require(:subscription).permit(:email, :reference, :search_criteria)
+    ParameterSanitiser.call(
+      params.require(:subscription)
+    ).permit(:email, :reference, :search_criteria)
   end
 
   def daily_subscription_params

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -2,6 +2,7 @@ class SubscriptionsController < ApplicationController
   def new
     subscription = Subscription.new(search_criteria: search_criteria.to_json)
     @subscription = SubscriptionPresenter.new(subscription)
+    Auditor::Audit.new(nil, 'subscription.daily_alert.new', nil).log_without_association
   end
 
   def create

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -10,9 +10,7 @@ class SubscriptionsController < ApplicationController
     subscription = Subscription.new(daily_subscription_params)
     @subscription = SubscriptionPresenter.new(subscription)
 
-    if Subscription.ongoing.exists?(email: daily_subscription_params[:email],
-                                    search_criteria: daily_subscription_params[:search_criteria],
-                                    frequency: daily_subscription_params[:frequency])
+    if SubscriptionFinder.new(daily_subscription_params).exists?
       flash[:error] = I18n.t('errors.subscriptions.already_exists')
     elsif subscription.save
       Auditor::Audit.new(subscription, 'subscription.daily_alert.create', nil).log

--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -1,6 +1,6 @@
 class VacanciesController < ApplicationController
   include ParameterSanitiser
-  
+
   DEFAULT_RADIUS = 20
 
   helper_method :location,

--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -1,4 +1,6 @@
 class VacanciesController < ApplicationController
+  include ParameterSanitiser
+  
   DEFAULT_RADIUS = 20
 
   helper_method :location,
@@ -28,10 +30,7 @@ class VacanciesController < ApplicationController
   end
 
   def params
-    sanitised_params = super.each_pair do |key, value|
-      super[key] = Sanitize.fragment(value)
-    end
-    ActionController::Parameters.new(sanitised_params)
+    @params ||= ParameterSanitiser.call(super)
   end
 
   private

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -15,8 +15,9 @@ class Subscription < ApplicationRecord
   end
 
   def set_reference
-    self.reference ||= loop do
-      reference ||= SecureRandom.hex(8)
+    return if reference.present?
+    self.reference = loop do
+      reference = SecureRandom.hex(8)
       break reference unless self.class.exists?(email: email, reference: reference)
     end
   end

--- a/app/services/subscription_finder.rb
+++ b/app/services/subscription_finder.rb
@@ -1,13 +1,16 @@
 class SubscriptionFinder
   def initialize(params = {})
-    @email = params[:email]
-    @search_criteria = params[:search_criteria]
-    @frequency = params[:frequency]
+    @sanitised_params = params.each_pair do |key, value|
+      params[key] = Sanitize.fragment(value)
+    end
   end
 
   def exists?
-    Subscription.ongoing.exists?(email: @email,
-                                 search_criteria: @search_criteria,
-                                 frequency: @frequency)
+    Subscription
+      .ongoing
+      .where(email: @sanitised_params[:email],
+             search_criteria: @sanitised_params[:search_criteria],
+             frequency: @sanitised_params[:frequency])
+      .exists?
   end
 end

--- a/app/services/subscription_finder.rb
+++ b/app/services/subscription_finder.rb
@@ -1,0 +1,13 @@
+class SubscriptionFinder
+  def initialize(params = {})
+    @email = params[:email]
+    @search_criteria = params[:search_criteria]
+    @frequency = params[:frequency]
+  end
+
+  def exists?
+    Subscription.ongoing.exists?(email: @email,
+                                 search_criteria: @search_criteria,
+                                 frequency: @frequency)
+  end
+end

--- a/app/services/vacancy_filters.rb
+++ b/app/services/vacancy_filters.rb
@@ -30,6 +30,10 @@ class VacancyFilters
     }
   end
 
+  def only_active_to_hash
+    to_hash.delete_if { |_, v| v.blank? }
+  end
+
   def any?
     filters = to_hash
     filters.delete_if { |k, v| k.eql?(:radius) || v.nil? }

--- a/app/services/vacancy_filters.rb
+++ b/app/services/vacancy_filters.rb
@@ -20,7 +20,7 @@ class VacancyFilters
   def to_hash
     {
       location: location,
-      radius: "#{radius}km",
+      radius: radius.to_s,
       keyword: keyword,
       minimum_salary: minimum_salary,
       maximum_salary: maximum_salary,

--- a/app/views/subscriptions/confirm.html.haml
+++ b/app/views/subscriptions/confirm.html.haml
@@ -1,0 +1,26 @@
+- content_for :page_title_prefix, 'Subscription confirmation'
+
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    .govuk-panel.govuk-panel--confirmation
+      %h1.govuk-panel__title= t('subscriptions.confirmation.header')
+      .govuk-panel__body
+        = t('subscriptions.reference')
+        %br
+        %strong= @subscription.reference
+
+    %p.govuk-body=t('subscriptions.confirmation.receipt_confirmation')
+
+    %h3.govuk-heading-m=t('subscriptions.confirmation.next_step')
+    %p.govuk-body=t('subscriptions.confirmation.next_step_details', email: @subscription.email, date: l(@subscription.expires_on))
+    %div.govuk-inset-text
+      %ul.govuk-list
+        - @subscription.filtered_search_criteria.each_pair do |filter, value|
+          %li
+            - if filter.present?
+              %span{ class: 'govuk-!-font-weight-bold'} #{filter.humanize}:
+            = value
+
+    %p.govuk-body= t('subscriptions.confirmation.unsubscribe')
+    %p.govuk-body
+      = link_to t('subscriptions.back_to_search_results'), root_path(@subscription.search_criteria_to_h), class: 'govuk-link'

--- a/app/views/vacancies/index.html.haml
+++ b/app/views/vacancies/index.html.haml
@@ -11,6 +11,8 @@
     %p.govuk-heading-m.mt0.mb1.inline-block= @vacancies.total_count_message
     - if @vacancies.user_search?
       %span.clear-search.nobreak= link_to t('jobs.filters.clear_filters'), root_path, class: 'govuk-link'
+      %p.govuk-body
+        = link_to t('subscriptions.button'), new_subscription_path(search_criteria: @filters.only_active_to_hash), class: 'govuk-link'
     - if @vacancies.any?
       %div.sortable-links
         = t('jobs.sort_by')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -231,6 +231,7 @@ en:
           - 'expected start date'
           - 'end date (for fixed-term jobs)'
   subscriptions:
+    button: 'Subscribe to email notifications for this search'
     intro: 'Your search criteria are as follows:'
     new: Sign up for daily emails
     info: When you click subscribe, you'll receive daily emails featuring jobs that match these criteria for 3 months. You can unsubscribe at any time following the unsubscribe link in your daily mail.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,6 +2,10 @@ en:
   date:
     formats:
       hinttext: "%d %-m %Y"
+      default: '%e %B %Y'
+  datetime:
+    formats:
+      default: '%e %B %Y %H:%M'
   number:
     currency:
       format:
@@ -231,6 +235,14 @@ en:
     new: Sign up for daily emails
     info: When you click subscribe, you'll receive daily emails featuring jobs that match these criteria for 3 months. You can unsubscribe at any time following the unsubscribe link in your daily mail.
     location_text: Within %{radius} miles of %{location}
+    reference: Your reference
+    confirmation:
+      header: Your email subscription has started
+      receipt_confirmation: We have sent you a confirmation email
+      next_step: 'What happens next'
+      unsubscribe: "You can unsubscribe from this subscription at any time by following the 'stop receiving emails for this search' link in the email."
+      next_step_details: 'We will run a search matching your search criteria and send a daily email with the results to %{email} for the next 3 months, until %{date}.'
+    back_to_search_results: 'Return to your search results'
   terms_and_conditions:
     page_title: 'Terms and Conditions'
     intro: 'Before listing any role at your school on Teaching Vacancies you must first read our Terms and Conditions and agree to abide by them.'

--- a/spec/controllers/subscriptions_controller_spec.rb
+++ b/spec/controllers/subscriptions_controller_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe SubscriptionsController, type: :controller do
+  describe '#create' do
+    it 'persists only sanitised params' do
+      params = {
+        subscription: {
+          email: '<script>foo@email.com</script>',
+          search_criteria: "<body onload=alert('test1')>Text</script>",
+          frequency: "<img src='http://url.to.file.which/not.exist' onerror=alert(document.cookie);>"
+        }
+      }
+
+      post :create, params: params
+
+      subscription = Subscription.last
+      expect(subscription.email).to eql('foo@email.com')
+      expect(subscription.search_criteria).to eql('Text')
+      expect(subscription.frequency).to eql('daily')
+    end
+  end
+end

--- a/spec/features/job_seekers_can_filter_vacancies_spec.rb
+++ b/spec/features/job_seekers_can_filter_vacancies_spec.rb
@@ -263,7 +263,7 @@ RSpec.feature 'Filtering vacancies' do
 
       Vacancy.__elasticsearch__.client.indices.flush
 
-      data = [timestamp.to_s, 3, '', '20km', 'Physics', '', '', nil, nil, 'true']
+      data = [timestamp.to_s, 3, '', '20', 'Physics', '', '', nil, nil, 'true']
 
       expect(AuditSearchEventJob).to receive(:perform_later)
         .with(data)
@@ -285,7 +285,7 @@ RSpec.feature 'Filtering vacancies' do
 
       Vacancy.__elasticsearch__.client.indices.flush
 
-      data = [timestamp.to_s, 12, '', '20km', 'Math', '', '', nil, nil, 'true']
+      data = [timestamp.to_s, 12, '', '20', 'Math', '', '', nil, nil, 'true']
 
       expect(AuditSearchEventJob).to receive(:perform_later)
         .with(data)

--- a/spec/features/job_seekers_can_subscribe_to_a_job_alert_spec.rb
+++ b/spec/features/job_seekers_can_subscribe_to_a_job_alert_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'A job seeker can subscribe to a job alert', wip: true do
+RSpec.feature 'A job seeker can subscribe to a job alert' do
   context 'A job seeker' do
     scenario 'can access the new subscription page when search criteria have been specified' do
       expect { visit(new_subscription_path) }.to raise_error(ActionController::ParameterMissing)
@@ -41,7 +41,7 @@ RSpec.feature 'A job seeker can subscribe to a job alert', wip: true do
         fill_in 'subscription[email]', with: 'jane.doe@example.com'
         click_on 'Subscribe'
 
-        expect(page).to have_content('Email subscription created successfully')
+        expect(page).to have_content(I18n.t('subscriptions.confirmation.header'))
       end
 
       scenario 'when the email address is associated with other active subscriptions' do
@@ -52,7 +52,7 @@ RSpec.feature 'A job seeker can subscribe to a job alert', wip: true do
         fill_in 'subscription[email]', with: 'jane.doe@example.com'
         click_on 'Subscribe'
 
-        expect(page).to have_content('Email subscription created successfully')
+        expect(page).to have_content(I18n.t('subscriptions.confirmation.header'))
       end
 
       scenario 'when the email address is associated with the same inactive subscriptions' do
@@ -64,7 +64,41 @@ RSpec.feature 'A job seeker can subscribe to a job alert', wip: true do
         fill_in 'subscription[email]', with: 'jane.doe@example.com'
         click_on 'Subscribe'
 
-        expect(page).to have_content('Email subscription created successfully')
+        expect(page).to have_content(I18n.t('subscriptions.confirmation.header'))
+      end
+
+      context 'and is redirected to the confirmation page' do
+        scenario 'without setting a reference number' do
+          visit new_subscription_path(search_criteria: { keyword: 'teacher' })
+          fill_in 'subscription[email]', with: 'jane.doe@example.com'
+          click_on 'Subscribe'
+
+          expect(page).to have_content(I18n.t('subscriptions.confirmation.header'))
+          expect(page).to have_content('jane.doe@example.com')
+          expect(page).to have_content(/Your reference [a-z]*/)
+          expect(page).to have_content('Keyword: teacher')
+        end
+
+        scenario 'when setting a reference number' do
+          visit new_subscription_path(search_criteria: { keyword: 'teacher' })
+          fill_in 'subscription[email]', with: 'jane.doe@example.com'
+          fill_in 'subscription[reference]', with: 'Daily alert reference'
+          click_on 'Subscribe'
+
+          expect(page).to have_content(/Your reference Daily alert reference/)
+        end
+
+        scenario 'where they can go back to the filtered search' do
+          visit new_subscription_path(search_criteria: { keyword: 'teacher',
+                                                         newly_qualified_teacher: 'true' })
+          fill_in 'subscription[email]', with: 'jane.doe@example.com'
+          click_on 'Subscribe'
+
+          click_on 'Return to your search results'
+
+          expect(page.find('#keyword').value).to eq('teacher')
+          expect(page.find('#newly_qualified_teacher').checked?).to eq(true)
+        end
       end
     end
 

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Vacancy, type: :model do
           .with(:info,
                 'A search returned 0 results',
                 location: nil,
-                radius: 'km',
+                radius: '',
                 keyword: 'a-non-matching-search-term',
                 minimum_salary: nil,
                 maximum_salary: nil,

--- a/spec/services/publish_vacancy_spec.rb
+++ b/spec/services/publish_vacancy_spec.rb
@@ -1,4 +1,6 @@
-RSpec.describe PublishVacancy do
+require 'rails_helper'
+
+RSpec.describe VacancySearchBuilder do
   let(:vacancy) { create(:vacancy, :draft) }
 
   describe '#call' do

--- a/spec/services/subscription_finder_spec.rb
+++ b/spec/services/subscription_finder_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe SubscriptionFinder do
+  describe '.new' do
+    it 'should be initialised with a hash of params' do
+      service = described_class.new(email: 'foo', search_criteria: 'bar', frequency: 'daily')
+      expect(service).to be_an_instance_of(described_class)
+    end
+  end
+
+  describe '#exists?' do
+    let(:params) { { email: 'foo@email.com', search_criteria: 'bar', frequency: 'daily' } }
+    context 'when there are no existing subscriptions' do
+      it 'returns false' do
+        service = described_class.new(params)
+        expect(service.exists?).to eq(false)
+      end
+    end
+
+    context 'when an existing subscription exists with email, search_criteria and frequency' do
+      before(:each) do
+        create(
+          :daily_subscription,
+          email: 'foo@email.com',
+          search_criteria: 'bar',
+          frequency: 'daily'
+        )
+      end
+
+      it 'returns true' do
+        service = described_class.new(params)
+        expect(service.exists?).to eq(true)
+      end
+    end
+  end
+end

--- a/spec/services/subscription_finder_spec.rb
+++ b/spec/services/subscription_finder_spec.rb
@@ -32,5 +32,28 @@ RSpec.describe SubscriptionFinder do
         expect(service.exists?).to eq(true)
       end
     end
+
+    context 'when malicious arguments are passed in' do
+      it 'sanitises the string inputs before passing them to `where`' do
+        harmful_params = {
+          email: '<script>foo@email.com</script>',
+          search_criteria: "<body onload=alert('test1')>Text</script>",
+          frequency: "<img src='http://url.to.file.which/not.exist' onerror=alert(document.cookie);>"
+        }
+        empty_active_record_relation = Subscription.none
+
+        relation = double
+        expect(Subscription).to receive(:ongoing).and_return(relation)
+        expect(relation).to receive(:where)
+          .with(
+            email: 'foo@email.com',
+            search_criteria: 'Text',
+            frequency: ''
+          )
+          .and_return(empty_active_record_relation)
+
+        described_class.new(harmful_params).exists?
+      end
+    end
   end
 end

--- a/spec/services/vacancy_filters_spec.rb
+++ b/spec/services/vacancy_filters_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe VacancyFilters do
       expect(result).to eql(
         location: 'location',
         keyword: 'keyword',
-        radius: '20km',
+        radius: '20',
         minimum_salary: 'minimum_salary',
         maximum_salary: 'maximum_salary',
         newly_qualified_teacher: false,


### PR DESCRIPTION
Pull Request template

## Trello card URL:
https://trello.com/c/OFbNOs2j/660-124-email-alerts-a-visitor-can-subscribe-to-a-search

## Changes in this PR:
- Audits entry to subscription page
- Links to new subscription when filters have been applied to the listed vacancies
- End to end scenario verification

## Screenshots of UI changes:

When a user has performed a search the subscription link is rendered
<img width="788" alt="filters" src="https://user-images.githubusercontent.com/159200/50018097-11150d80-ffc6-11e8-812c-62736ef60b12.png">

No search, all results are listed and subscription link is not rendered
<img width="786" alt="no_filters" src="https://user-images.githubusercontent.com/159200/50018098-11150d80-ffc6-11e8-80ee-096cc779395a.png">
