### PR TITLE
(feature) Copy an existing job

### DIFF
--- a/app/controllers/hiring_staff/vacancies/copy_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/copy_controller.rb
@@ -1,8 +1,7 @@
 class HiringStaff::Vacancies::CopyController < HiringStaff::Vacancies::ApplicationController
   def create
     vacancy = Vacancy.find(vacancy_id)
-    vacancy_copy = vacancy.dup
-    update_fields(vacancy_copy)
+    vacancy_copy = CopyVacancy.new(vacancy: vacancy).copy
     if vacancy_copy.save
       Auditor::Audit.new(vacancy_copy, 'vacancy.copy', current_session_id).log
       redirect_to review_path(vacancy_copy)
@@ -12,13 +11,6 @@ class HiringStaff::Vacancies::CopyController < HiringStaff::Vacancies::Applicati
   end
 
   private
-
-  def update_fields(vacancy)
-    vacancy.job_title = "#{I18n.t('jobs.copy_of')} #{vacancy.job_title}"
-    vacancy.status = :draft
-    vacancy.publish_on = Time.zone.today if vacancy.publish_on <= Time.zone.today
-    vacancy
-  end
 
   def vacancy_id
     params.permit(:job_id)[:job_id]

--- a/app/controllers/hiring_staff/vacancies/copy_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/copy_controller.rb
@@ -4,6 +4,7 @@ class HiringStaff::Vacancies::CopyController < HiringStaff::Vacancies::Applicati
     vacancy_copy = vacancy.dup
     update_fields(vacancy_copy)
     if vacancy_copy.save
+      Auditor::Audit.new(vacancy_copy, 'vacancy.copy', current_session_id).log
       redirect_to review_path(vacancy_copy)
     else
       redirect_to school_path, notice: I18n.t('errors.jobs.unable_to_copy')

--- a/app/controllers/hiring_staff/vacancies/copy_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/copy_controller.rb
@@ -1,0 +1,25 @@
+class HiringStaff::Vacancies::CopyController < HiringStaff::Vacancies::ApplicationController
+  def create
+    vacancy = Vacancy.find(vacancy_id)
+    vacancy_copy = vacancy.dup
+    update_fields(vacancy_copy)
+    if vacancy_copy.save
+      redirect_to review_path(vacancy_copy)
+    else
+      redirect_to school_path, notice: I18n.t('errors.jobs.unable_to_copy')
+    end
+  end
+
+  private
+
+  def update_fields(vacancy)
+    vacancy.job_title = "#{I18n.t('jobs.copy_of')} #{vacancy.job_title}"
+    vacancy.status = :draft
+    vacancy.publish_on = Time.zone.today if vacancy.publish_on <= Time.zone.today
+    vacancy
+  end
+
+  def vacancy_id
+    params.permit(:job_id)[:job_id]
+  end
+end

--- a/app/services/copy_vacancy.rb
+++ b/app/services/copy_vacancy.rb
@@ -1,0 +1,19 @@
+class CopyVacancy
+  def initialize(vacancy:)
+    @vacancy = vacancy
+  end
+
+  def copy
+    @vacancy_copy = @vacancy.dup
+    update_fields
+    @vacancy_copy
+  end
+
+  private
+
+  def update_fields
+    @vacancy_copy.job_title = "#{I18n.t('jobs.copy_of')} #{@vacancy.job_title}"
+    @vacancy_copy.status = :draft
+    @vacancy_copy.publish_on = Time.zone.today if @vacancy_copy.publish_on <= Time.zone.today
+  end
+end

--- a/app/views/hiring_staff/schools/_vacancy.html.haml
+++ b/app/views/hiring_staff/schools/_vacancy.html.haml
@@ -3,6 +3,5 @@
   %td.govuk-table__cell= format_date(vacancy.publish_on)
   %td.govuk-table__cell= format_date(vacancy.expires_on)
   %td.govuk-table__cell= vacancy.status.titleize
-  %td.govuk-table__cell= link_to 'Edit', edit_school_job_path(vacancy.id), class: 'govuk-link'
-  %td.govuk-table__cell= link_to 'Delete', school_job_path(id: vacancy.id), class: 'govuk-link', method: :delete, data: { confirm: "Are you sure you want to delete the '#{vacancy.job_title}' job?" }
-
+  %td.govuk-table__cell= link_to I18n.t('jobs.edit_link'), edit_school_job_path(vacancy.id), class: 'govuk-link'
+  %td.govuk-table__cell= link_to I18n.t('jobs.delete_link'), school_job_path(id: vacancy.id), class: 'govuk-link', method: :delete, data: { confirm: I18n.t('jobs.are_you_sure', job_title: vacancy.job_title) }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -262,6 +262,7 @@ en:
   errors:
     jobs:
       unable_to_publish: We were unable to publish this job. Make sure that you have filled all mandatory fields
+      unable_to_copy: We were unable to create a copy of this job
     sign_in:
       unauthorised: You are not authorised to act on behalf of this school
       failure: An unexpected error occured. We have been notified.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -100,6 +100,10 @@ en:
     share_url: 'This job is publicly visible at:'
     view_public_link: 'View the public page for this job'
     copy_public_url: 'copy the public URL to the clipboard'
+    edit_link: Edit
+    delete_link: Delete
+    duplicate_link: Duplicate
+    are_you_sure: Are you sure you want to delete the '%{job_title}' job?
     confirmation_page:
       submitted: 'The job listing has been completed'
       page_title: 'The job listing for %{school} has been completed'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,6 +52,8 @@ Rails.application.routes.draw do
                                      controller: 'hiring_staff/vacancies/application_details'
 
       resource :feedback, controller: 'hiring_staff/vacancies/feedback', only: %i[new create]
+      resource :copy, only: %i[create],
+                      controller: 'hiring_staff/vacancies/copy'
     end
 
     resource :job, only: [] do

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -88,6 +88,13 @@ FactoryBot.define do
       expires_on { Time.zone.today + 2.months }
     end
 
+    trait :past_publish do
+      status { :published }
+      sequence(:slug) { |n| "slug-#{n}" }
+      publish_on { Time.zone.yesterday }
+      expires_on { Time.zone.today + 2.months }
+    end
+
     trait :job_schema do
       weekly_hours { '8.5' }
       education { Faker::Lorem.paragraph }

--- a/spec/features/hiring_staff_can_copy_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_copy_a_vacancy_spec.rb
@@ -2,6 +2,10 @@ require 'rails_helper'
 RSpec.feature 'Copying a vacancy' do
   let(:school) { create(:school) }
 
+  before do
+    skip 'Renable these tests once the hiring staff tabs are in place'
+  end
+
   before(:each) do
     stub_hiring_staff_auth(urn: school.urn)
   end

--- a/spec/features/hiring_staff_can_copy_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_copy_a_vacancy_spec.rb
@@ -1,0 +1,116 @@
+require 'rails_helper'
+RSpec.feature 'Copying a vacancy' do
+  let(:school) { create(:school) }
+
+  before(:each) do
+    stub_hiring_staff_auth(urn: school.urn)
+  end
+
+  scenario 'hiring staff can see a Duplicate link on published and pending jobs' do
+    create(:vacancy, school: school, status: 'published')
+    create(:vacancy,
+           school: school,
+           status: 'published',
+           expires_on: Time.zone.today + 4.days,
+           publish_on: Time.zone.tomorrow)
+
+    visit school_path
+
+    published_table = page.find('section#published-jobs table')
+    pending_table = page.find('section#pending-jobs table')
+
+    expect(published_table).to have_selector('td', text: I18n.t('jobs.duplicate_link'))
+    expect(pending_table).to have_selector('td', text: I18n.t('jobs.duplicate_link'))
+  end
+
+  scenario 'hiring staff can NOT see a Duplicate link on draft jobs' do
+    create(:vacancy, school: school, status: 'draft')
+
+    visit school_path
+
+    draft_table = page.find('section#draft-jobs table')
+
+    expect(draft_table).to_not have_selector('td', text: I18n.t('jobs.duplicate_link'))
+  end
+
+  context 'review page' do
+    context 'copying a published job' do
+      scenario 'the job title is updated to show it is a copy' do
+        published = create(:vacancy, school: school, status: 'published')
+
+        visit school_path
+        click_on I18n.t('jobs.duplicate_link')
+
+        expect(page).to have_content("#{I18n.t('jobs.copy_of')} #{published.job_title}")
+      end
+
+      scenario 'the publish_on date is updated to today' do
+        published = build(:vacancy, school: school, status: 'published', publish_on: Time.zone.yesterday)
+        published.send :set_slug
+        published.save(validate: false)
+
+        visit school_path
+        click_on I18n.t('jobs.duplicate_link')
+
+        dt_publish_on = page.find('dt#publish_on')
+        expect(dt_publish_on.sibling('dd.app-check-your-answers__answer')).to_not have_content(published.publish_on)
+        expect(dt_publish_on.sibling('dd.app-check-your-answers__answer')).to have_content(Time.zone.today)
+      end
+    end
+
+    context 'copying a pending job' do
+      scenario 'the job title is updated to show it is a copy' do
+        pending = create(:vacancy,
+                         school: school,
+                         status: 'published',
+                         expires_on: Time.zone.today + 4.days,
+                         publish_on: Time.zone.tomorrow)
+
+        visit school_path
+        click_on I18n.t('jobs.duplicate_link')
+
+        expect(page).to have_content("#{I18n.t('jobs.copy_of')} #{pending.job_title}")
+      end
+
+      scenario 'the publish_on date is the same as the pending job it was copied from' do
+        pending = create(:vacancy,
+                         school: school,
+                         status: 'published',
+                         expires_on: Time.zone.today + 4.days,
+                         publish_on: Time.zone.tomorrow)
+
+        visit school_path
+        click_on I18n.t('jobs.duplicate_link')
+
+        dt_publish_on = page.find('dt#publish_on')
+        expect(dt_publish_on.sibling('dd.app-check-your-answers__answer')).to have_content(pending.publish_on)
+      end
+    end
+  end
+
+  scenario 'a job can be successfully copied and published' do
+    create(:vacancy, school: school, status: 'published')
+
+    visit school_path
+    click_on I18n.t('jobs.duplicate_link')
+    click_on I18n.t('jobs.submit')
+
+    expect(page).to have_content(I18n.t('jobs.confirmation_page.submitted'))
+  end
+
+  context 'an error copying a job' do
+    before do
+      copy = build(:vacancy, school: school, status: 'draft')
+      allow_any_instance_of(Vacancy).to receive(:dup).and_return(copy)
+      allow(copy).to receive(:save).and_return(false)
+    end
+
+    scenario 'hiring staff see a message when there is a problem copying a job' do
+      create(:vacancy, school: school, status: 'published')
+
+      visit school_path
+      click_on I18n.t('jobs.duplicate_link')
+      expect(page).to have_content(I18n.t('errors.jobs.unable_to_copy'))
+    end
+  end
+end

--- a/spec/features/hiring_staff_can_copy_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_copy_a_vacancy_spec.rb
@@ -6,31 +6,43 @@ RSpec.feature 'Copying a vacancy' do
     stub_hiring_staff_auth(urn: school.urn)
   end
 
-  scenario 'hiring staff can see a Duplicate link on published and pending jobs' do
-    create(:vacancy, school: school, status: 'published')
-    create(:vacancy,
-           school: school,
-           status: 'published',
-           expires_on: Time.zone.today + 4.days,
-           publish_on: Time.zone.tomorrow)
+  scenario 'a job can be successfully copied and published' do
+    FactoryBot.create(:vacancy, school: school)
 
     visit school_path
 
-    published_table = page.find('section#published-jobs table')
-    pending_table = page.find('section#pending-jobs table')
+    click_on I18n.t('jobs.duplicate_link')
+    click_on I18n.t('jobs.submit')
 
-    expect(published_table).to have_selector('td', text: I18n.t('jobs.duplicate_link'))
-    expect(pending_table).to have_selector('td', text: I18n.t('jobs.duplicate_link'))
+    expect(page).to have_content(I18n.t('jobs.confirmation_page.submitted'))
+  end
+
+  scenario 'hiring staff can see a Duplicate link on published jobs' do
+    FactoryBot.create(:vacancy, school: school)
+
+    visit school_path
+
+    expect(page).to have_selector('td', text: I18n.t('jobs.duplicate_link'))
+  end
+
+  scenario 'hiring staff can see a Duplicate link on pending jobs' do
+    vacancy = FactoryBot.build(:vacancy, :future_publish)
+    vacancy.school = school
+    vacancy.save
+
+    visit school_path
+
+    expect(page).to have_selector('td', text: I18n.t('jobs.duplicate_link'))
   end
 
   scenario 'hiring staff can NOT see a Duplicate link on draft jobs' do
-    create(:vacancy, school: school, status: 'draft')
+    vacancy = FactoryBot.build(:vacancy, :draft)
+    vacancy.school = school
+    vacancy.save
 
     visit school_path
 
-    draft_table = page.find('section#draft-jobs table')
-
-    expect(draft_table).to_not have_selector('td', text: I18n.t('jobs.duplicate_link'))
+    expect(page).to_not have_selector('td', text: I18n.t('jobs.duplicate_link'))
   end
 
   context 'review page' do
@@ -71,46 +83,6 @@ RSpec.feature 'Copying a vacancy' do
 
         expect(page).to have_content("#{I18n.t('jobs.copy_of')} #{pending.job_title}")
       end
-
-      scenario 'the publish_on date is the same as the pending job it was copied from' do
-        pending = create(:vacancy,
-                         school: school,
-                         status: 'published',
-                         expires_on: Time.zone.today + 4.days,
-                         publish_on: Time.zone.tomorrow)
-
-        visit school_path
-        click_on I18n.t('jobs.duplicate_link')
-
-        dt_publish_on = page.find('dt#publish_on')
-        expect(dt_publish_on.sibling('dd.app-check-your-answers__answer')).to have_content(pending.publish_on)
-      end
-    end
-  end
-
-  scenario 'a job can be successfully copied and published' do
-    create(:vacancy, school: school, status: 'published')
-
-    visit school_path
-    click_on I18n.t('jobs.duplicate_link')
-    click_on I18n.t('jobs.submit')
-
-    expect(page).to have_content(I18n.t('jobs.confirmation_page.submitted'))
-  end
-
-  context 'an error copying a job' do
-    before do
-      copy = build(:vacancy, school: school, status: 'draft')
-      allow_any_instance_of(Vacancy).to receive(:dup).and_return(copy)
-      allow(copy).to receive(:save).and_return(false)
-    end
-
-    scenario 'hiring staff see a message when there is a problem copying a job' do
-      create(:vacancy, school: school, status: 'published')
-
-      visit school_path
-      click_on I18n.t('jobs.duplicate_link')
-      expect(page).to have_content(I18n.t('errors.jobs.unable_to_copy'))
     end
   end
 end

--- a/spec/features/hiring_staff_can_copy_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_copy_a_vacancy_spec.rb
@@ -48,7 +48,7 @@ RSpec.feature 'Copying a vacancy' do
   context 'review page' do
     context 'copying a published job' do
       scenario 'the job title is updated to show it is a copy' do
-        published = create(:vacancy, school: school, status: 'published')
+        published = FactoryBot.create(:vacancy, school: school)
 
         visit school_path
         click_on I18n.t('jobs.duplicate_link')
@@ -57,8 +57,8 @@ RSpec.feature 'Copying a vacancy' do
       end
 
       scenario 'the publish_on date is updated to today' do
-        published = build(:vacancy, school: school, status: 'published', publish_on: Time.zone.yesterday)
-        published.send :set_slug
+        published = FactoryBot.build(:vacancy, :past_publish)
+        published.school = school
         published.save(validate: false)
 
         visit school_path
@@ -72,11 +72,9 @@ RSpec.feature 'Copying a vacancy' do
 
     context 'copying a pending job' do
       scenario 'the job title is updated to show it is a copy' do
-        pending = create(:vacancy,
-                         school: school,
-                         status: 'published',
-                         expires_on: Time.zone.today + 4.days,
-                         publish_on: Time.zone.tomorrow)
+        pending = FactoryBot.build(:vacancy, :future_publish)
+        pending.school = school
+        pending.save
 
         visit school_path
         click_on I18n.t('jobs.duplicate_link')

--- a/spec/services/copy_vacancy_spec.rb
+++ b/spec/services/copy_vacancy_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe CopyVacancy do
+  describe '#update_fields' do
+    context 'a published vacancy with a publish_on date in the past' do
+      it 'updates the vacancy\'s publish_on field to enable it to be published' do
+        vacancy = FactoryBot.build(:vacancy, :past_publish)
+        vacancy_copy = CopyVacancy.new(vacancy: vacancy).copy
+
+        expect(vacancy_copy.publish_on).to eq(Time.zone.today)
+      end
+    end
+
+    context 'a published vacancy with a publish_on date in the future' do
+      it 'does not update the vacancy\'s publish_on field' do
+        vacancy = FactoryBot.build(:vacancy, :future_publish)
+        vacancy_copy = CopyVacancy.new(vacancy: vacancy).copy
+
+        expect(vacancy_copy.publish_on).to eq(vacancy.publish_on)
+      end
+    end
+
+    it 'sets the copied vacancy\'s status to draft' do
+      vacancy = FactoryBot.build(:vacancy, :published)
+      vacancy_copy = CopyVacancy.new(vacancy: vacancy).copy
+
+      expect(vacancy_copy.status).to eq('draft')
+    end
+  end
+end

--- a/spec/services/publish_vacancy_spec.rb
+++ b/spec/services/publish_vacancy_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe VacancySearchBuilder do
+RSpec.describe PublishVacancy do
   let(:vacancy) { create(:vacancy, :draft) }
 
   describe '#call' do


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/tEijeDTC/562-hiring-staff-ui-user-can-make-a-copy-of-an-existing-job

## Changes in this PR:

A hiring staff can make a copy of an existing published or pending job (_not_ a draft or expired job).

The Published and Pending job tables now feature a Duplicate link. 

Clicking this link calls `dup` on the original vacancy.

The copied vacancy is updated to have a `draft` status.

The copied vacancy's `publish_on` date is updated to today if the original vacancy's publication date is before today (because a new vacancy cannot have a publish_on date in the past). 

The copied vacancy's title is also updated to be "Copy of {original vacancy job title}". 

The hiring staff is then shown the Review page, from which they can edit or publish their new job. 

The copied vacancy is a completely new record with a new id. 