### PR TITLE
[687] Log when a user gets a generic 401 during sign in

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -16,6 +16,10 @@ module OmniAuth
           response.redirect('/dfe/sessions/new')
           response.finish
         elsif request.params['state'].to_s.empty? || request.params['state'] != stored_state
+          Rollbar.log(:error,
+                      'A sign-in callback was unauthorised',
+                      session_id: session.id,
+                      received_state: request.params['state'],)
           return redirect('/401')
         elsif !request.params['code']
           return fail!(:missing_code, OmniAuth::OpenIDConnect::MissingCodeError.new(request.params['error']))


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/glHo4Yhs

## Changes in this PR:
* A couple of users are reporting this issue and we aren’t tracking the event in Rollbar so it's new to us! They are seeing the generic /401 page shortly after the openid_connect 'callback_phase' begins. We do do a redirection that would explain this behaviour, which is the focus of this PR https://github.com/dxw/teacher-vacancy-service/blob/a78ce66c3acb73228b065f3e5eb539a91668787c/config/initializers/omniauth.rb#L19. The majority of users are able to sign-in as normal.

https://teachingjobs.zendesk.com/agent/tickets/2173
https://teachingjobs.zendesk.com/agent/tickets/2331

* Treating this is a new unexpected event and track it with Rollbar rather than adding extra logging to stdout. This will allow us to review the full extent of the issue with grouping, remove the need to crawl through the Papertrail logs and enable us to keep an eye on any progress we make in fixing it easily (it'll flag in Slack if the error reoccurs)
* I think we need to log a few bits of information like the session id and the state we receive from DSI to confirm that we are checking the **right** session_id and that DSI **is** returning a state at all. With these 2 bits of information we can hopefully rule out problems with our session management eg. it’s getting reset 
* I chose not to log the state stored in the user's session as well as it seems sensible to limit monkey patching the stored_state method within the omniauth_openid_connect gem. Since it reads the value only once for a comparison and in doing so deletes it from the session we can instead work out if the value was a mismatch so long as there was a value that passes the presence condition on this line https://github.com/dxw/teacher-vacancy-service/blob/a78ce66c3acb73228b065f3e5eb539a91668787c/config/initializers/omniauth.rb#L18
* You can test this locally by setting `config.enabled = true` in the rollbar initializer, adding the ROLLBACK_ACCESS_TOKEN into env and by adding `session['omniauth.state'] = 'foo!'` as a new line directly below `def callback_phase` in omniauth.rb - this will fake the error state to cause the error

## Screenshots of UI changes:

### Before

### After
![screenshot 2019-01-09 at 16 45 06](https://user-images.githubusercontent.com/912473/50914226-f485bd00-142d-11e9-80e3-652862138b86.png)

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
