### PR TITLE
[655] Double the available memory for worker containers to prevent OOM…

### DIFF
--- a/terraform/container-definitions/worker_container_definition.json
+++ b/terraform/container-definitions/worker_container_definition.json
@@ -2,7 +2,8 @@
   {
     "name": "${task_name}",
     "image": "${image}:latest",
-    "memory": 512,
+    "memory": 1024,
+    "memoryReservation": 512,
     "networkMode": "bridge",
     "command": ${worker_command},
     "logConfiguration": {

--- a/terraform/modules/ecs/ecs.tf
+++ b/terraform/modules/ecs/ecs.tf
@@ -381,7 +381,7 @@ resource "aws_ecs_task_definition" "worker" {
   requires_compatibilities = ["EC2"]
   network_mode             = "bridge"
   cpu                      = "256"
-  memory                   = "512"
+  memory                   = "1024"
   execution_role_arn       = "${aws_iam_role.ecs_execution_role.arn}"
   task_role_arn            = "${aws_iam_role.ecs_execution_role.arn}"
 }


### PR DESCRIPTION
… and Thread errors

## Trello card URL:
https://trello.com/c/qUeQS5xc


## Changes in this PR:

* We have been witnessing lots of ThreadErrors caused by the `AuditSearchEvent` worker over the past few weeks and were content that any failing job was successful on the next retry https://rollbar.com/dxw/teacher-vacancies/items/230/?item_page=0&item_count=100&#instances
* Today 11:17am a PG connection error occurred for the first time https://rollbar.com/dxw/teacher-vacancies/items/248/?person_page=0&#traceback whilst there was nothing abnormal going on with RDS connections. There are no application logs https://papertrailapp.com/groups/9147051/events?focus=1019978396425482240 of this 500 having occurred leading me to believe this happened within a worker process rather than a web process that may have lead the user to seeing an error

<img width="940" alt="screenshot 2019-01-10 at 13 09 56" src="https://user-images.githubusercontent.com/912473/50970473-5fd89900-14d9-11e9-844a-42cc53c60086.png">

* We have also now noticed worker containers consistently running out of memory in production, failures seem to correlate to the asynchronous jobs that communicate with Google Sheets to record statistics for `AuditSearchEvent`
* There is high usage on the worker service in ECS whilst the overall cluster is operating around 30%, I've attached screenshots where we can see the usage on the service together with an example error of ECS marking tasks as failed due to OOM before it restarts new ones *every few minutes* https://eu-west-2.console.aws.amazon.com/ecs/home?region=eu-west-2#/clusters/tvs2-cluster-production/services/tvs2_production_worker/events

<img width="1235" alt="screenshot 2019-01-10 at 11 36 28" src="https://user-images.githubusercontent.com/912473/50969487-8fd26d00-14d6-11e9-952b-b80b731eeb8a.png">

<img width="1226" alt="screenshot 2019-01-10 at 11 35 18" src="https://user-images.githubusercontent.com/912473/50969492-982aa800-14d6-11e9-9594-24e0e1d52619.png">

* The idea is to double the maximum _available_ memory by doubling it from the previous value of 512 to see if we can vertically scale out of the problem, this will allow the system to use 1024mb if it needs to. By setting the ‘memoryReservation’ it will tell ECS what the soft limit[1] should be so that it only goes above 512 if it really needs to
* I am reasonably confident in the decision to double the value as we can see these jobs are succeeding in the majority of cases (albeit after taking some time) and it is the minority of cases where they fail, perhaps when both workers are taking on similar jobs or when the Google API is simply busy. I've checked that production has enough spare memory for both workers to run at maximum, however autoscaling will kick in and add a third instance to keep us safe

[1] “When system memory is under contention, Docker attempts to keep the container memory to this soft limit; however, your container can consume more memory when needed, up to either the hard limit specified with the memory parameter (if applicable)” - https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [x] Terraform deployment required?

- [ ] New development configuration to be shared?
