### PR TITLE
[690] Sign in attempts can succeed when started from the www. subdomain

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,4 @@
 Rails.application.config.session_store :active_record_store,
                                        key: '_teachingvacancies_session',
-                                       expire_after: 8.hours
+                                       expire_after: 8.hours,
+                                       domain: :all


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/hPVQyQdk

## Changes in this PR:
* We have recently been made aware of a new error in Teaching Vacancies whereby we believe that any hiring staff who tries to sign in after first visiting the service using `www.` will get an uncaught (and unhelpful) error message meaning they are unable to access the service. https://teachingjobs.zendesk.com/agent/tickets/2173, https://teachingjobs.zendesk.com/agent/tickets/2331. 
* I have replicated the issue and am confident that this is happening because the first session (A) that was created for www.teaching-vacancies.service.gov.uk and used to store the secret in before the sign in handshake happens with DfE Sign-in. When DfE sign-in successfully authenticate this user and invoke the callback phase to us, they redirect to teaching-vacancies.service.gov.uk, Rails detects a different domain and creates a new session (B) which is used [here](https://github.com/dxw/teacher-vacancy-service/blob/5aeccbfae79f0f514cb804aa723c0912d91c9698/config/initializers/omniauth.rb#L18) meaning the correct secret stored in the session (A) is lost. The user is incorrectly unauthenticated as session A is never checked.
* As part of this this investigation we have deployed monitoring for this new error and have been able to replicate the problem ourselves. https://github.com/dxw/teacher-vacancy-service/pull/684
* This has been occurring with 6.5% of sign ins in the last 5 days or so https://rollbar.com/dxw/teacher-vacancies/items/249/ since some users are visiting the service with www. as the subdomain. This is setup as an alias to work for our users but DSI will redirect to a specific domain (without www) this causes false negatives, and users being told their unauthorised even when they aren’t.
* This should create our sessions in such a way that requests to our domain and via our subdomain one level up (www.) will not cause a new session to be created, and the correct secret can be found. https://blog.blogbins.com/2018/07/12/allow-rails-sessions-to-be-shared-across-subdomains/ since we manage the teaching-vacancies.service domain, we can trust that any subdomain is allowed meaning this should be a safe change to make.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
