### PR TITLE
[690] (2) Hiring staff who start the sign in journey from www. can succeed

### DIFF
--- a/terraform/modules/core/core.tf
+++ b/terraform/modules/core/core.tf
@@ -267,6 +267,46 @@ resource "aws_lb_listener_rule" "redirect_old_teachingjobs_https_traffic" {
   }
 }
 
+resource "aws_lb_listener_rule" "redirect_old_teachingjobs_https_traffic_with_www_subdomain" {
+  listener_arn = "${aws_alb_listener.default_https.arn}"
+
+  action {
+    type = "redirect"
+
+    redirect {
+      host        = "${var.domain}"
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+
+  condition {
+    field  = "host-header"
+    values = ["www.teaching-jobs.service.gov.uk"]
+  }
+}
+
+resource "aws_lb_listener_rule" "redirect_https_traffic_with_www_subdomain" {
+  listener_arn = "${aws_alb_listener.default_https.arn}"
+
+  action {
+    type = "redirect"
+
+    redirect {
+      host        = "${var.domain}"
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+
+  condition {
+    field  = "host-header"
+    values = ["www.teaching-vacancies.service.gov.uk"]
+  }
+}
+
 resource "aws_alb_target_group" "alb_target_group" {
   name     = "${var.project_name}-${var.environment}-alb-tg"
   port     = 80

--- a/terraform/modules/core/core.tf
+++ b/terraform/modules/core/core.tf
@@ -210,8 +210,7 @@ resource "aws_alb_listener" "default" {
   depends_on = ["aws_alb_target_group.alb_target_group"]
 }
 
-resource "aws_lb_listener_rule" "redirect_old_teachingjobs_http_traffic" {
-  count = "${var.redirect_old_teachingjobs_traffic}"
+resource "aws_lb_listener_rule" "redirect_all_http_requests_to_https" {
   listener_arn = "${aws_alb_listener.default.arn}"
 
   action {
@@ -226,8 +225,8 @@ resource "aws_lb_listener_rule" "redirect_old_teachingjobs_http_traffic" {
   }
 
   condition {
-    field  = "host-header"
-    values = ["teaching-jobs.service.gov.uk"]
+    field  = "path-pattern"
+    values = ["/*"]
   }
 }
 
@@ -303,7 +302,7 @@ resource "aws_lb_listener_rule" "redirect_https_traffic_with_www_subdomain" {
 
   condition {
     field  = "host-header"
-    values = ["www.teaching-vacancies.service.gov.uk"]
+    values = ["www.${var.domain}"]
   }
 }
 


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/hPVQyQdk

## Changes in this PR:
* All requests to the service using the www. subdomain will be redirected to the bare domain
* This is the second attempt to solve this issue after the failed deployment of a configuration change to sessions: https://github.com/dxw/teacher-vacancy-service/pull/688 - this worked correctly in staging, but when on production prevented all hiring staff from signing in regardless of the URL visited
* After implementing this as a quick fix to allow all users to quickly sign in directly in AWS, and after discussions with bob about the impact of supporting the service as normal at www. we concluded that it would be best to make this redirect permanent
* There is are publicised opinions for not bothering with support for `www` at all [1] and no strong argument for keeping it so long as we **do** redirect any user who decides to use `www.` and in doing so continue to respond to that request which is the important part
* When changing this I discovered a very closely related problem with out existing redirection. www.teaching-jobs.service.gov.uk does not redirect to teaching-services.gov.uk so I've included a small copy and paste to ensure this is supported too any user who has a book mark for www.teaching-jobs.service.gov.uk will be unable to sign in too
* Refactoring of the listener rules so we aren't required to keep duplicating every new listener rule block against both HTTPS **and** HTTP listeners which should trim the code down and make it easier to manage if we need more rules in the future

[1] https://dropwww.com/, http://no-www.org/

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [x] Terraform deployment required?

- [ ] New development configuration to be shared?
