### PR TITLE
Strip leading and trailing spaces from salaries

### DIFF
--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -168,6 +168,14 @@ class Vacancy < ApplicationRecord
     send(:set_slug)
   end
 
+  def minimum_salary=(salary)
+    self[:minimum_salary] = salary.to_s.strip
+  end
+
+  def maximum_salary=(salary)
+    self[:maximum_salary] = salary.to_s.strip
+  end
+
   private
 
   def slug_candidates

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -480,4 +480,16 @@ RSpec.describe Vacancy, type: :model do
       expect(vacancy.education).to eq(sanitized_education)
     end
   end
+
+  context 'salary trimming' do
+    it 'trims the minimum salary' do
+      job = build(:vacancy, minimum_salary: " #{SalaryValidator::MIN_SALARY_ALLOWED} ")
+      expect(job.minimum_salary).to eq(SalaryValidator::MIN_SALARY_ALLOWED)
+    end
+
+    it 'trims the maximum salary' do
+      job = build(:vacancy, maximum_salary: " #{SalaryValidator::MIN_SALARY_ALLOWED} ")
+      expect(job.maximum_salary).to eq(SalaryValidator::MIN_SALARY_ALLOWED)
+    end
+  end
 end


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/1O3Tbvj1/682-bug-user-unable-to-create-job-when-a-salary-field-has-extra-spaces-because-of-the-salary-format-validation

## Changes in this PR:

This trims any leading / trailing spaces for min/max salaries when a job is submitted. The requires the salaries to be cast as strings, but they'll be strings anyway when coming as params, so this is more of a guard so the model tests don't blow up

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
