### PR TITLE
Remove rename explanation

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -523,4 +523,4 @@ en:
           line_1: "You are free to reuse job listing data under the terms of the <a href='https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/' target='_blank' class='govuk-link'>Open Government Licence</a> for public sector information with the following exception:"
           list: you may not charge a school any fee or commission for contacting, interviewing or hiring a respondent to your advertisement or listing if it is based on Teaching Vacancies data that you have reused.
   beta_banner:
-    line_1: 'Teaching Jobs was renamed Teaching Vacancies on 20 November. The service lists jobs in select areas of England. It will be %{link} to new areas, so check back regularly for new listings.'
+    line_1: 'This service lists jobs in select areas of England. It will be %{link} to new areas, so check back regularly for new listings.'


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/0Cejl05K/685-remove-the-rename-explanation-from-the-site-banner

## Changes in this PR:

Removed the reference to the name change. Also changed `The service` to `This service`, as it's no longer clear what `The service` refers to as the context has changed.

## Screenshots of UI changes:

### Before

![image](https://user-images.githubusercontent.com/109774/51310430-8e58f580-1a3e-11e9-9d6a-8d5d927dee06.png)

### After

![image](https://user-images.githubusercontent.com/109774/51310511-b5afc280-1a3e-11e9-9d6f-b417e94cbe7b.png)


## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
