### PR TITLE
[685] Iterate site banner copy

### DIFF
--- a/app/views/shared/_beta_banner.html.haml
+++ b/app/views/shared/_beta_banner.html.haml
@@ -1,2 +1,2 @@
 .flash.notice
-  .small= t('beta_banner.line_1', link: link_to('rolled out in phases', roll_out_blog_url, target: :_blank, class: 'govuk-link')).html_safe
+  .small= t('beta_banner.line_1', link: link_to(t('beta_banner.link'), roll_out_blog_url, target: :_blank, class: 'govuk-link')).html_safe

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -523,4 +523,5 @@ en:
           line_1: "You are free to reuse job listing data under the terms of the <a href='https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/' target='_blank' class='govuk-link'>Open Government Licence</a> for public sector information with the following exception:"
           list: you may not charge a school any fee or commission for contacting, interviewing or hiring a respondent to your advertisement or listing if it is based on Teaching Vacancies data that you have reused.
   beta_banner:
-    line_1: 'This service lists jobs in select areas of England. It will be %{link} to new areas, so check back regularly for new listings.'
+    line_1: This service lists jobs in select areas of England. %{link}, with national coverage by March.
+    link: It's being rolled out in phases

--- a/spec/features/support_links_spec.rb
+++ b/spec/features/support_links_spec.rb
@@ -36,7 +36,7 @@ RSpec.feature 'A visitor to the website can access the support links' do
   context 'the roll out blog link' do
     scenario 'on the service homepage' do
       visit root_path
-      expect(page).to have_selector "a[href='#{roll_out_blog_url}']", text: 'rolled out in phases'
+      expect(page).to have_selector "a[href='#{roll_out_blog_url}']", text: I18n.t('beta_banner.link')
     end
 
     scenario 'on the hiring staff sign in page' do


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/0Cejl05K

## Changes in this PR:
- Iterate the site banner copy with extra consideration to the amount screen space it consumes on mobile
- The link text needed changing and it was hardcoded in the specs so I have added this to the locale file to make it less fragile in future

## Screenshots of UI changes:

### Before
![screenshot 2019-01-28 at 11 40 46](https://user-images.githubusercontent.com/912473/51834227-9263fd80-22f1-11e9-93a3-6b8faf5fbddd.png)


### After
![screenshot 2019-01-28 at 12 15 43](https://user-images.githubusercontent.com/912473/51835817-7747bc80-22f6-11e9-90c1-e1fdca3cd3e5.png)

![screenshot 2019-01-28 at 11 59 25](https://user-images.githubusercontent.com/912473/51836005-fc32d600-22f6-11e9-8549-e9f11bca1d5d.png)
