### PR TITLE
Add duplicate links to vacancy table

### DIFF
--- a/app/controllers/hiring_staff/vacancies/application_details_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/application_details_controller.rb
@@ -24,8 +24,6 @@ class HiringStaff::Vacancies::ApplicationDetailsController < HiringStaff::Vacanc
 
     @school = school
     @application_details_form = ApplicationDetailsForm.new(vacancy_attributes)
-    vacancy ||= school.vacancies.find(@application_details_form.id)
-    @application_details_form.original_publish_on = vacancy.publish_on
     @application_details_form.valid?
   end
 
@@ -35,7 +33,6 @@ class HiringStaff::Vacancies::ApplicationDetailsController < HiringStaff::Vacanc
     @application_details_form = ApplicationDetailsForm.new(application_details_form)
     @application_details_form.status = vacancy.status
     @application_details_form.id = vacancy.id
-    @application_details_form.original_publish_on = vacancy.publish_on
 
     if @application_details_form.valid?
       reset_session_vacancy!

--- a/app/controllers/hiring_staff/vacancies/copy_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/copy_controller.rb
@@ -1,16 +1,34 @@
 class HiringStaff::Vacancies::CopyController < HiringStaff::Vacancies::ApplicationController
+  def new
+    vacancy = Vacancy.find(vacancy_id)
+    @school = school
+    @copy_form = CopyVacancyForm.new(vacancy: vacancy)
+  end
+
   def create
     vacancy = Vacancy.find(vacancy_id)
-    vacancy_copy = CopyVacancy.new(vacancy: vacancy).copy
-    if vacancy_copy.save
-      Auditor::Audit.new(vacancy_copy, 'vacancy.copy', current_session_id).log
-      redirect_to review_path(vacancy_copy)
+    copy_form = CopyVacancyForm.new(vacancy: vacancy).apply_changes(copy_form_params)
+
+    if copy_form.vacancy.valid?
+      new_vacancy = CopyVacancy.new(original: vacancy, new: copy_form.vacancy).call
+      Auditor::Audit.new(new_vacancy, 'vacancy.copy', current_session_id).log
+      redirect_to review_path(new_vacancy)
     else
-      redirect_to school_path, notice: I18n.t('errors.jobs.unable_to_copy')
+      @school = school
+      @copy_form = CopyVacancyForm.new(vacancy: vacancy)
+      render 'new'
     end
   end
 
   private
+
+  def copy_form_params
+    params.require(:copy_vacancy_form).permit(:job_title,
+                                              :starts_on_dd, :starts_on_mm, :starts_on_yyyy,
+                                              :ends_on_dd, :ends_on_mm, :ends_on_yyyy,
+                                              :expires_on_dd, :expires_on_mm, :expires_on_yyyy,
+                                              :publish_on_dd, :publish_on_mm, :publish_on_yyyy)
+  end
 
   def vacancy_id
     params.permit(:job_id)[:job_id]

--- a/app/form_models/application_details_form.rb
+++ b/app/form_models/application_details_form.rb
@@ -3,16 +3,10 @@ class ApplicationDetailsForm < VacancyForm
            :publish_on_dd, :publish_on_mm, :publish_on_yyyy,
            :published?, :status, to: :vacancy
 
-  attr_accessor :original_publish_on
-
   include VacancyApplicationDetailValidations
 
   def disable_editing_publish_on?
     published? && vacancy.reload.publish_on.past?
-  end
-
-  def publish_on_change?
-    original_publish_on.present? ? !publish_on.eql?(original_publish_on) : false
   end
 
   def completed?

--- a/app/form_models/copy_vacancy_form.rb
+++ b/app/form_models/copy_vacancy_form.rb
@@ -1,0 +1,23 @@
+class CopyVacancyForm < VacancyForm
+  include ActiveModel::Model
+
+  delegate :starts_on_yyyy, :starts_on_mm, :starts_on_dd,
+           :ends_on_dd, :ends_on_mm, :ends_on_yyyy,
+           :expires_on_dd, :expires_on_mm, :expires_on_yyyy,
+           :publish_on_dd, :publish_on_mm, :publish_on_yyyy,
+           :errors, to: :vacancy
+
+  def initialize(vacancy:)
+    self.vacancy = vacancy
+    self.job_title = vacancy.job_title
+    self.starts_on = vacancy.starts_on
+    self.ends_on = vacancy.ends_on
+    self.expires_on = vacancy.expires_on
+    self.publish_on = vacancy.publish_on
+  end
+
+  def apply_changes(params = {})
+    vacancy.assign_attributes(params)
+    self
+  end
+end

--- a/app/models/concerns/vacancy_application_detail_validations.rb
+++ b/app/models/concerns/vacancy_application_detail_validations.rb
@@ -13,15 +13,11 @@ module VacancyApplicationDetailValidations
   end
 
   def validity_of_publish_on
-    errors.add(:publish_on, publish_on_before_today_error) if publish_on_in_past? && publish_on_check?
+    errors.add(:publish_on, publish_on_before_today_error) if publish_on_in_past?
   end
 
   def validity_of_expires_on
     errors.add(:expires_on, expires_on_before_publish_on_error) if expiry_date_less_than_publish_date?
-  end
-
-  def publish_on_check?
-    published? && publish_on_change? || !published?
   end
 
   private

--- a/app/services/copy_vacancy.rb
+++ b/app/services/copy_vacancy.rb
@@ -1,19 +1,18 @@
 class CopyVacancy
-  def initialize(vacancy:)
-    @vacancy = vacancy
+  def initialize(original:, new:)
+    @original = original
+    @new = new
   end
 
-  def copy
-    @vacancy_copy = @vacancy.dup
-    update_fields
-    @vacancy_copy
-  end
-
-  private
-
-  def update_fields
-    @vacancy_copy.job_title = "#{I18n.t('jobs.copy_of')} #{@vacancy.job_title}"
-    @vacancy_copy.status = :draft
-    @vacancy_copy.publish_on = Time.zone.today if @vacancy_copy.publish_on <= Time.zone.today
+  def call
+    new_vacancy = @original.dup
+    new_vacancy.job_title = @new.job_title
+    new_vacancy.starts_on = @new.starts_on
+    new_vacancy.ends_on = @new.ends_on
+    new_vacancy.expires_on = @new.expires_on
+    new_vacancy.publish_on = @new.publish_on
+    new_vacancy.status = :draft
+    new_vacancy.save
+    new_vacancy
   end
 end

--- a/app/views/hiring_staff/schools/_vacancies_pending.html.haml
+++ b/app/views/hiring_staff/schools/_vacancies_pending.html.haml
@@ -9,7 +9,7 @@
                     %th.govuk-table__header= t('jobs.job_title')
                     %th.govuk-table__header= t('jobs.date_to_be_posted')
                     %th.govuk-table__header= t('jobs.expires_on')
-                    %th.govuk-table__header{ colspan: 2}= t('jobs.actions')
+                    %th.govuk-table__header{ colspan: 3}= t('jobs.actions')
             %tbody.govuk-table__body
                 - presenter.pending.each do |vacancy|
                     = render partial: 'vacancy_pending', locals: { vacancy: vacancy, school: presenter.school }

--- a/app/views/hiring_staff/schools/_vacancies_published.html.haml
+++ b/app/views/hiring_staff/schools/_vacancies_published.html.haml
@@ -8,7 +8,7 @@
                     %th.govuk-table__header= t('jobs.job_title')
                     %th.govuk-table__header= t('jobs.publish_on')
                     %th.govuk-table__header= t('jobs.expires_on')
-                    %th.govuk-table__header{ colspan: 2}= t('jobs.actions')
+                    %th.govuk-table__header{ colspan: 3}= t('jobs.actions')
             %tbody.govuk-table__body
                 - presenter.published.each do |vacancy|
                     = render partial: 'vacancy_published', locals: { vacancy: vacancy, school: presenter.school }

--- a/app/views/hiring_staff/schools/_vacancy_pending.html.haml
+++ b/app/views/hiring_staff/schools/_vacancy_pending.html.haml
@@ -3,5 +3,5 @@
   %td.govuk-table__cell= format_date(vacancy.publish_on)
   %td.govuk-table__cell= format_date(vacancy.expires_on)
   %td.govuk-table__cell= link_to t('jobs.edit_link'), edit_school_job_path(vacancy.id), class: 'govuk-link'
-  %td.govuk-table__cell= link_to t('jobs.copy_link'), school_job_copy_path(vacancy.id), class: 'govuk-link', method: :post
+  %td.govuk-table__cell= link_to t('jobs.copy_link'), new_school_job_copy_path(vacancy.id), class: 'govuk-link', method: :get
   %td.govuk-table__cell= link_to t('jobs.delete_link'), school_job_path(id: vacancy.id), class: 'govuk-link', method: :delete, data: { confirm: t('jobs.are_you_sure', job_title: vacancy.job_title) }

--- a/app/views/hiring_staff/schools/_vacancy_pending.html.haml
+++ b/app/views/hiring_staff/schools/_vacancy_pending.html.haml
@@ -3,4 +3,5 @@
   %td.govuk-table__cell= format_date(vacancy.publish_on)
   %td.govuk-table__cell= format_date(vacancy.expires_on)
   %td.govuk-table__cell= link_to t('jobs.edit_link'), edit_school_job_path(vacancy.id), class: 'govuk-link'
+  %td.govuk-table__cell= link_to t('jobs.duplicate_link'), school_job_copy_path(vacancy.id), class: 'govuk-link', method: :post
   %td.govuk-table__cell= link_to t('jobs.delete_link'), school_job_path(id: vacancy.id), class: 'govuk-link', method: :delete, data: { confirm: t('jobs.are_you_sure', job_title: vacancy.job_title) }

--- a/app/views/hiring_staff/schools/_vacancy_pending.html.haml
+++ b/app/views/hiring_staff/schools/_vacancy_pending.html.haml
@@ -3,5 +3,5 @@
   %td.govuk-table__cell= format_date(vacancy.publish_on)
   %td.govuk-table__cell= format_date(vacancy.expires_on)
   %td.govuk-table__cell= link_to t('jobs.edit_link'), edit_school_job_path(vacancy.id), class: 'govuk-link'
-  %td.govuk-table__cell= link_to t('jobs.duplicate_link'), school_job_copy_path(vacancy.id), class: 'govuk-link', method: :post
+  %td.govuk-table__cell= link_to t('jobs.copy_link'), school_job_copy_path(vacancy.id), class: 'govuk-link', method: :post
   %td.govuk-table__cell= link_to t('jobs.delete_link'), school_job_path(id: vacancy.id), class: 'govuk-link', method: :delete, data: { confirm: t('jobs.are_you_sure', job_title: vacancy.job_title) }

--- a/app/views/hiring_staff/schools/_vacancy_published.html.haml
+++ b/app/views/hiring_staff/schools/_vacancy_published.html.haml
@@ -3,5 +3,5 @@
   %td.govuk-table__cell= format_date(vacancy.publish_on)
   %td.govuk-table__cell= format_date(vacancy.expires_on)
   %td.govuk-table__cell= link_to t('jobs.edit_link'), edit_school_job_path(vacancy.id), class: 'govuk-link'
-  %td.govuk-table__cell= link_to t('jobs.duplicate_link'), school_job_copy_path(vacancy.id), class: 'govuk-link', method: :post
+  %td.govuk-table__cell= link_to t('jobs.copy_link'), new_school_job_copy_path(vacancy.id), class: 'govuk-link', method: :get
   %td.govuk-table__cell= link_to t('jobs.delete_link'), school_job_path(id: vacancy.id), class: 'govuk-link', method: :delete, data: { confirm: t('jobs.are_you_sure', job_title: vacancy.job_title) }

--- a/app/views/hiring_staff/schools/_vacancy_published.html.haml
+++ b/app/views/hiring_staff/schools/_vacancy_published.html.haml
@@ -3,4 +3,5 @@
   %td.govuk-table__cell= format_date(vacancy.publish_on)
   %td.govuk-table__cell= format_date(vacancy.expires_on)
   %td.govuk-table__cell= link_to t('jobs.edit_link'), edit_school_job_path(vacancy.id), class: 'govuk-link'
+  %td.govuk-table__cell= link_to t('jobs.duplicate_link'), school_job_copy_path(vacancy.id), class: 'govuk-link', method: :post
   %td.govuk-table__cell= link_to t('jobs.delete_link'), school_job_path(id: vacancy.id), class: 'govuk-link', method: :delete, data: { confirm: t('jobs.are_you_sure', job_title: vacancy.job_title) }

--- a/app/views/hiring_staff/vacancies/copy/new.html.haml
+++ b/app/views/hiring_staff/vacancies/copy/new.html.haml
@@ -1,0 +1,51 @@
+- content_for :page_title_prefix, "#{@copy_form.errors.present? ? 'Error: ' : ''}Copy a job for #{@school.name}"
+
+%h1.govuk-heading-l
+  = t('jobs.copy_page_title', job_title: @copy_form.vacancy.job_title.downcase)
+  %span.govuk-caption-l
+    Step 1 of 2
+
+= render 'hiring_staff/vacancies/error_messages', errors: @copy_form.errors
+= simple_form_for @copy_form, html: { class: 'copy-form' }, action: :post, url: school_job_copy_path do |f|
+  %h2.govuk-heading-m
+    = t('jobs.job_specification')
+
+  .govuk-grid-row
+    .govuk-grid-column-one-half
+      = f.input :job_title,
+                label: t('jobs.job_title'),
+                hint: t('jobs.form_hints.job_title'),
+                wrapper_html: {id: 'job_title'},
+                input_html: {class: 'govuk-input'},
+                required: true
+
+      %div.govuk-form-group#starts_on
+        = f.gov_uk_date_field :starts_on,
+                              legend_text: "#{t('jobs.starts_on')} (optional)",
+                              legend_class: 'govuk-label',
+                              form_hint_text: t('jobs.form_hints.start_date',
+                                                date: l(Date.today + 3.months, format: :hinttext))
+      %div.govuk-form-group#ends_on
+        = f.gov_uk_date_field :ends_on,
+                              legend_text: "#{t('jobs.ends_on')} (optional)",
+                              legend_class: 'govuk-label',
+                              form_hint_text: t('jobs.form_hints.end_date',
+                                                date: l(Date.today + 6.months, format: :hinttext))
+      %h2.govuk-heading-m
+        = t('jobs.application_details')
+
+      %div.govuk-form-group#publish_on
+        = f.gov_uk_date_field :publish_on,
+                              legend_text: t('jobs.publication_date'),
+                              legend_class: 'govuk-label',
+                              form_hint_text: t('jobs.form_hints.publication_date',
+                                              date: l(Date.today, format: :hinttext))
+
+      %div.govuk-form-group#expires_on
+        = f.gov_uk_date_field :expires_on,
+                              legend_text: t('jobs.deadline_date'),
+                              legend_class: 'govuk-label',
+                              form_hint_text: t('jobs.form_hints.deadline_date',
+                                                date: l(Date.today + 2.months, format: :hinttext))
+
+      = f.button :submit, t('buttons.save_and_continue')

--- a/app/views/hiring_staff/vacancies/review.html.haml
+++ b/app/views/hiring_staff/vacancies/review.html.haml
@@ -1,5 +1,5 @@
 - content_for :page_title_prefix, @vacancy.review_page_title
-=render partial: 'school_vacancy_breadcrumb'
+= render partial: 'school_vacancy_breadcrumb'
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -71,6 +71,7 @@ en:
     per_year: 'per year'
     per_year_pro_rata: 'per year pro rata'
     publish_heading: 'Publish a job for %{school}'
+    copy_page_title: 'Copy your %{job_title} job'
     review_page_title: 'Review the job details — Publish a job for %{school}'
     review_heading: 'Review the job for %{school}'
     edit_heading: 'Edit job for %{school}'
@@ -113,7 +114,7 @@ en:
     no_draft_jobs: You currently have no draft jobs
     no_pending_jobs: You currently have no pending jobs
     edit_link: Edit
-    duplicate_link: Duplicate
+    copy_link: Copy
     delete_link: Delete
     are_you_sure: Are you sure you want to delete the '%{job_title}' job?
     confirmation_page:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -85,6 +85,7 @@ en:
     publication_date: 'Date role will be listed'
     review: 'Review the job details and make any necessary changes before submitting it for publication below.'
     edit: 'Edit the job details.'
+    copy_of: 'Copy of'
     confirmation_summary: 'By submitting you are confirming that to the best of your knowledge, the details you are providing are correct.'
     submit: 'Confirm and submit job'
     apply: 'Get more information'
@@ -112,6 +113,7 @@ en:
     no_draft_jobs: You currently have no draft jobs
     no_pending_jobs: You currently have no pending jobs
     edit_link: Edit
+    duplicate_link: Duplicate
     delete_link: Delete
     are_you_sure: Are you sure you want to delete the '%{job_title}' job?
     confirmation_page:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,7 +55,7 @@ Rails.application.routes.draw do
                                      controller: 'hiring_staff/vacancies/application_details'
 
       resource :feedback, controller: 'hiring_staff/vacancies/feedback', only: %i[new create]
-      resource :copy, only: %i[create],
+      resource :copy, only: %i[new create],
                       controller: 'hiring_staff/vacancies/copy'
     end
 

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -93,6 +93,8 @@ FactoryBot.define do
       sequence(:slug) { |n| "slug-#{n}" }
       publish_on { Time.zone.yesterday }
       expires_on { Time.zone.today + 2.months }
+      starts_on  { Time.zone.today + 3.months }
+      ends_on { Time.zone.today + 4.months }
     end
 
     trait :job_schema do

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -22,6 +22,7 @@ FactoryBot.define do
     weekly_hours { '8.5' }
     benefits { Faker::Lorem.sentence }
     newly_qualified_teacher { true }
+    reference { SecureRandom.uuid }
 
     trait :fail_minimum_validation do
       job_title { Faker::Job.title[0..2] }

--- a/spec/features/hiring_staff_can_copy_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_copy_a_vacancy_spec.rb
@@ -7,80 +7,122 @@ RSpec.feature 'Copying a vacancy' do
   end
 
   scenario 'a job can be successfully copied and published' do
-    FactoryBot.create(:vacancy, school: school)
+    original_vacancy = FactoryBot.build(:vacancy, :past_publish, school: school)
+    original_vacancy.save(validate: false) # Validation prevents publishing on a past date
+
+    new_vacancy = original_vacancy.dup
+    new_vacancy.job_title = 'A new job title'
+    new_vacancy.starts_on = 35.days.from_now
+    new_vacancy.ends_on = 100.days.from_now
+    new_vacancy.publish_on = 0.days.from_now
+    new_vacancy.expires_on = 30.days.from_now
 
     visit school_path
 
-    click_on I18n.t('jobs.duplicate_link')
+    within('table.vacancies') do
+      click_on I18n.t('jobs.copy_link')
+    end
+
+    expect(page).to have_content(I18n.t('jobs.copy_page_title', job_title: original_vacancy.job_title))
+    within('form.copy-form') do
+      fill_in_copy_vacancy_form_fields(new_vacancy)
+      click_on I18n.t('buttons.save_and_continue')
+    end
+
+    expect(page).to have_content(I18n.t('jobs.review_heading', school: school.name))
     click_on I18n.t('jobs.submit')
 
     expect(page).to have_content(I18n.t('jobs.confirmation_page.submitted'))
+    click_on('Preview your job listing')
+
+    expect(page).to have_content(new_vacancy.job_title)
+    expect(page).to have_content(new_vacancy.starts_on)
+    expect(page).to have_content(new_vacancy.ends_on)
+    expect(page).to have_content(new_vacancy.publish_on)
+    expect(page).to have_content(new_vacancy.expires_on)
+
+    expect(page).not_to have_content(original_vacancy.job_title)
+    expect(page).not_to have_content(original_vacancy.starts_on)
+    expect(page).not_to have_content(original_vacancy.ends_on)
+    expect(page).not_to have_content(original_vacancy.publish_on)
+    expect(page).not_to have_content(original_vacancy.expires_on)
   end
 
-  scenario 'hiring staff can see a Duplicate link on published jobs' do
-    FactoryBot.create(:vacancy, school: school)
-
-    visit school_path
-
-    expect(page).to have_selector('td', text: I18n.t('jobs.duplicate_link'))
-  end
-
-  scenario 'hiring staff can see a Duplicate link on pending jobs' do
-    vacancy = FactoryBot.build(:vacancy, :future_publish)
-    vacancy.school = school
-    vacancy.save
-
-    visit jobs_with_type_school_path(:pending)
-
-    expect(page).to have_selector('td', text: I18n.t('jobs.duplicate_link'))
-  end
-
-  scenario 'hiring staff can NOT see a Duplicate link on draft jobs' do
-    vacancy = FactoryBot.build(:vacancy, :draft)
-    vacancy.school = school
-    vacancy.save
-
-    visit jobs_with_type_school_path(:draft)
-
-    expect(page).to_not have_selector('td', text: I18n.t('jobs.duplicate_link'))
-  end
-
-  context 'review page' do
-    context 'copying a published job' do
-      scenario 'the job title is updated to show it is a copy' do
-        published = FactoryBot.create(:vacancy, school: school)
-
-        visit jobs_with_type_school_path(:published)
-        click_on I18n.t('jobs.duplicate_link')
-
-        expect(page).to have_content("#{I18n.t('jobs.copy_of')} #{published.job_title}")
-      end
-
-      scenario 'the publish_on date is updated to today' do
-        published = FactoryBot.build(:vacancy, :past_publish)
-        published.school = school
-        published.save(validate: false)
-
-        visit school_path
-        click_on I18n.t('jobs.duplicate_link')
-
-        dt_publish_on = page.find('dt#publish_on')
-        expect(dt_publish_on.sibling('dd.app-check-your-answers__answer')).to_not have_content(published.publish_on)
-        expect(dt_publish_on.sibling('dd.app-check-your-answers__answer')).to have_content(Time.zone.today)
-      end
-    end
-
-    context 'copying a pending job' do
-      scenario 'the job title is updated to show it is a copy' do
-        pending = FactoryBot.build(:vacancy, :future_publish)
-        pending.school = school
-        pending.save
-
-        visit jobs_with_type_school_path(:pending)
-        click_on I18n.t('jobs.duplicate_link')
-
-        expect(page).to have_content("#{I18n.t('jobs.copy_of')} #{pending.job_title}")
-      end
-    end
-  end
+  # scenario 'a job can be successfully copied and published' do
+  #   FactoryBot.create(:vacancy, school: school)
+  #
+  #   visit school_path
+  #
+  #   click_on I18n.t('jobs.duplicate_link')
+  #   click_on I18n.t('jobs.submit')
+  #
+  #   expect(page).to have_content(I18n.t('jobs.confirmation_page.submitted'))
+  # end
+  #
+  # scenario 'hiring staff can see a Duplicate link on published jobs' do
+  #   FactoryBot.create(:vacancy, school: school)
+  #
+  #   visit school_path
+  #
+  #   expect(page).to have_selector('td', text: I18n.t('jobs.duplicate_link'))
+  # end
+  #
+  # scenario 'hiring staff can see a Duplicate link on pending jobs' do
+  #   vacancy = FactoryBot.build(:vacancy, :future_publish)
+  #   vacancy.school = school
+  #   vacancy.save
+  #
+  #   visit jobs_with_type_school_path(:pending)
+  #
+  #   expect(page).to have_selector('td', text: I18n.t('jobs.duplicate_link'))
+  # end
+  #
+  # scenario 'hiring staff can NOT see a Duplicate link on draft jobs' do
+  #   vacancy = FactoryBot.build(:vacancy, :draft)
+  #   vacancy.school = school
+  #   vacancy.save
+  #
+  #   visit jobs_with_type_school_path(:draft)
+  #
+  #   expect(page).to_not have_selector('td', text: I18n.t('jobs.duplicate_link'))
+  # end
+  #
+  # context 'review page' do
+  #   context 'copying a published job' do
+  #     scenario 'the job title is updated to show it is a copy' do
+  #       published = FactoryBot.create(:vacancy, school: school)
+  #
+  #       visit jobs_with_type_school_path(:published)
+  #       click_on I18n.t('jobs.duplicate_link')
+  #
+  #       expect(page).to have_content("#{I18n.t('jobs.copy_of')} #{published.job_title}")
+  #     end
+  #
+  #     scenario 'the publish_on date is updated to today' do
+  #       published = FactoryBot.build(:vacancy, :past_publish)
+  #       published.school = school
+  #       published.save(validate: false)
+  #
+  #       visit school_path
+  #       click_on I18n.t('jobs.duplicate_link')
+  #
+  #       dt_publish_on = page.find('dt#publish_on')
+  #       expect(dt_publish_on.sibling('dd.app-check-your-answers__answer')).to_not have_content(published.publish_on)
+  #       expect(dt_publish_on.sibling('dd.app-check-your-answers__answer')).to have_content(Time.zone.today)
+  #     end
+  #   end
+  #
+  #   context 'copying a pending job' do
+  #     scenario 'the job title is updated to show it is a copy' do
+  #       pending = FactoryBot.build(:vacancy, :future_publish)
+  #       pending.school = school
+  #       pending.save
+  #
+  #       visit jobs_with_type_school_path(:pending)
+  #       click_on I18n.t('jobs.duplicate_link')
+  #
+  #       expect(page).to have_content("#{I18n.t('jobs.copy_of')} #{pending.job_title}")
+  #     end
+  #   end
+  # end
 end

--- a/spec/features/hiring_staff_can_copy_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_copy_a_vacancy_spec.rb
@@ -2,10 +2,6 @@ require 'rails_helper'
 RSpec.feature 'Copying a vacancy' do
   let(:school) { create(:school) }
 
-  before do
-    skip 'Renable these tests once the hiring staff tabs are in place'
-  end
-
   before(:each) do
     stub_hiring_staff_auth(urn: school.urn)
   end
@@ -34,7 +30,7 @@ RSpec.feature 'Copying a vacancy' do
     vacancy.school = school
     vacancy.save
 
-    visit school_path
+    visit jobs_with_type_school_path(:pending)
 
     expect(page).to have_selector('td', text: I18n.t('jobs.duplicate_link'))
   end
@@ -44,7 +40,7 @@ RSpec.feature 'Copying a vacancy' do
     vacancy.school = school
     vacancy.save
 
-    visit school_path
+    visit jobs_with_type_school_path(:draft)
 
     expect(page).to_not have_selector('td', text: I18n.t('jobs.duplicate_link'))
   end
@@ -54,7 +50,7 @@ RSpec.feature 'Copying a vacancy' do
       scenario 'the job title is updated to show it is a copy' do
         published = FactoryBot.create(:vacancy, school: school)
 
-        visit school_path
+        visit jobs_with_type_school_path(:published)
         click_on I18n.t('jobs.duplicate_link')
 
         expect(page).to have_content("#{I18n.t('jobs.copy_of')} #{published.job_title}")
@@ -80,7 +76,7 @@ RSpec.feature 'Copying a vacancy' do
         pending.school = school
         pending.save
 
-        visit school_path
+        visit jobs_with_type_school_path(:pending)
         click_on I18n.t('jobs.duplicate_link')
 
         expect(page).to have_content("#{I18n.t('jobs.copy_of')} #{pending.job_title}")

--- a/spec/features/hiring_staff_can_copy_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_copy_a_vacancy_spec.rb
@@ -48,81 +48,23 @@ RSpec.feature 'Copying a vacancy' do
     expect(page).not_to have_content(original_vacancy.expires_on)
   end
 
-  # scenario 'a job can be successfully copied and published' do
-  #   FactoryBot.create(:vacancy, school: school)
-  #
-  #   visit school_path
-  #
-  #   click_on I18n.t('jobs.duplicate_link')
-  #   click_on I18n.t('jobs.submit')
-  #
-  #   expect(page).to have_content(I18n.t('jobs.confirmation_page.submitted'))
-  # end
-  #
-  # scenario 'hiring staff can see a Duplicate link on published jobs' do
-  #   FactoryBot.create(:vacancy, school: school)
-  #
-  #   visit school_path
-  #
-  #   expect(page).to have_selector('td', text: I18n.t('jobs.duplicate_link'))
-  # end
-  #
-  # scenario 'hiring staff can see a Duplicate link on pending jobs' do
-  #   vacancy = FactoryBot.build(:vacancy, :future_publish)
-  #   vacancy.school = school
-  #   vacancy.save
-  #
-  #   visit jobs_with_type_school_path(:pending)
-  #
-  #   expect(page).to have_selector('td', text: I18n.t('jobs.duplicate_link'))
-  # end
-  #
-  # scenario 'hiring staff can NOT see a Duplicate link on draft jobs' do
-  #   vacancy = FactoryBot.build(:vacancy, :draft)
-  #   vacancy.school = school
-  #   vacancy.save
-  #
-  #   visit jobs_with_type_school_path(:draft)
-  #
-  #   expect(page).to_not have_selector('td', text: I18n.t('jobs.duplicate_link'))
-  # end
-  #
-  # context 'review page' do
-  #   context 'copying a published job' do
-  #     scenario 'the job title is updated to show it is a copy' do
-  #       published = FactoryBot.create(:vacancy, school: school)
-  #
-  #       visit jobs_with_type_school_path(:published)
-  #       click_on I18n.t('jobs.duplicate_link')
-  #
-  #       expect(page).to have_content("#{I18n.t('jobs.copy_of')} #{published.job_title}")
-  #     end
-  #
-  #     scenario 'the publish_on date is updated to today' do
-  #       published = FactoryBot.build(:vacancy, :past_publish)
-  #       published.school = school
-  #       published.save(validate: false)
-  #
-  #       visit school_path
-  #       click_on I18n.t('jobs.duplicate_link')
-  #
-  #       dt_publish_on = page.find('dt#publish_on')
-  #       expect(dt_publish_on.sibling('dd.app-check-your-answers__answer')).to_not have_content(published.publish_on)
-  #       expect(dt_publish_on.sibling('dd.app-check-your-answers__answer')).to have_content(Time.zone.today)
-  #     end
-  #   end
-  #
-  #   context 'copying a pending job' do
-  #     scenario 'the job title is updated to show it is a copy' do
-  #       pending = FactoryBot.build(:vacancy, :future_publish)
-  #       pending.school = school
-  #       pending.save
-  #
-  #       visit jobs_with_type_school_path(:pending)
-  #       click_on I18n.t('jobs.duplicate_link')
-  #
-  #       expect(page).to have_content("#{I18n.t('jobs.copy_of')} #{pending.job_title}")
-  #     end
-  #   end
-  # end
+  context 'when the original job is pending/scheduled/future_publish' do
+    scenario 'a job can be successfully copied' do
+      original_vacancy = FactoryBot.create(:vacancy, :future_publish, school: school)
+
+      visit school_path
+
+      click_on I18n.t('jobs.pending_jobs')
+      within('table.vacancies') do
+        click_on I18n.t('jobs.copy_link')
+      end
+
+      expect(page).to have_content(I18n.t('jobs.copy_page_title', job_title: original_vacancy.job_title))
+      within('form.copy-form') do
+        click_on I18n.t('buttons.save_and_continue')
+      end
+
+      expect(page).to have_content(I18n.t('jobs.review_heading', school: school.name))
+    end
+  end
 end

--- a/spec/form_models/copy_vacancy_form_spec.rb
+++ b/spec/form_models/copy_vacancy_form_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe CopyVacancyForm, type: :model do
+  it 'copies the vacancy attributes to the form object' do
+    original_vacancy = build(:vacancy)
+
+    form_object = described_class.new(vacancy: original_vacancy)
+
+    expect(form_object.job_title).to eq(original_vacancy.job_title)
+    expect(form_object.starts_on).to eq(original_vacancy.starts_on)
+    expect(form_object.ends_on).to eq(original_vacancy.ends_on)
+    expect(form_object.expires_on).to eq(original_vacancy.expires_on)
+    expect(form_object.publish_on).to eq(original_vacancy.publish_on)
+  end
+
+  it 'updates the original vacancy with the users new preferences' do
+    original_vacancy = build(:vacancy)
+
+    new_choices = {
+      job_title: 'Foo',
+      starts_on: 20.days.from_now.to_date,
+      ends_on: 30.days.from_now.to_date,
+      expires_on: 5.days.from_now.to_date,
+      publish_on: 0.days.from_now.to_date,
+    }
+
+    form_object = described_class.new(vacancy: original_vacancy)
+                                 .apply_changes(new_choices)
+
+    expect(form_object.job_title).to eq(new_choices[:job_title])
+    expect(form_object.starts_on).to eq(new_choices[:starts_on])
+    expect(form_object.ends_on).to eq(new_choices[:ends_on])
+    expect(form_object.expires_on).to eq(new_choices[:expires_on])
+    expect(form_object.publish_on).to eq(new_choices[:publish_on])
+  end
+end

--- a/spec/services/copy_vacancy_spec.rb
+++ b/spec/services/copy_vacancy_spec.rb
@@ -7,24 +7,62 @@ RSpec.describe CopyVacancy do
       original_vacancy.save
       new_vacancy = original_vacancy.dup
 
-        expect(vacancy_copy.publish_on).to eq(Time.zone.today)
+      result = described_class.new(original: original_vacancy, new: new_vacancy)
+                              .call
+
+      expect(result).to be_kind_of(Vacancy)
+      expect(Vacancy.count).to eq(2)
+      expect(Vacancy.find(result.id).status).to eq('draft')
+    end
+
+    it 'does not change the original vacancy' do
+      # Needed to compare a FactoryBot object fields for updated_at and created_at
+      # and against the record it creates in Postgres.
+      Timecop.freeze(Time.zone.local(2008, 9, 1, 12, 0, 0))
+
+      original_vacancy = FactoryBot.create(:vacancy, job_title: 'Maths teacher')
+      new_vacancy = original_vacancy.dup
+
+      described_class.new(original: original_vacancy, new: new_vacancy)
+                     .call
+
+      expect(Vacancy.find(original_vacancy.id).attributes == original_vacancy.attributes)
+        .to eq(true)
+
+      Timecop.return
+    end
+
+    context 'when a new job_title is provided' do
+      it 'creates a new vacancy with a new job title' do
+        original_vacancy = FactoryBot.create(:vacancy, job_title: 'Maths teacher')
+        new_vacancy = original_vacancy.dup
+        new_vacancy.job_title = 'English teacher'
+
+        result = described_class.new(original: original_vacancy, new: new_vacancy)
+                                .call
+
+        expect(Vacancy.find(result.id).job_title).to eq('English teacher')
       end
     end
 
-    context 'a published vacancy with a publish_on date in the future' do
-      it 'does not update the vacancy\'s publish_on field' do
-        vacancy = FactoryBot.build(:vacancy, :future_publish)
-        vacancy_copy = CopyVacancy.new(vacancy: vacancy).copy
+    context 'when new dates are provided' do
+      it 'creates a new vacancy with the new dates' do
+        original_vacancy = FactoryBot.create(:vacancy, job_title: 'Maths teacher')
+        new_vacancy = original_vacancy.dup
+        new_vacancy.starts_on = 60.days.from_now
+        new_vacancy.ends_on = 100.days.from_now
+        new_vacancy.publish_on = 0.days.from_now
+        new_vacancy.expires_on = 50.days.from_now
 
-        expect(vacancy_copy.publish_on).to eq(vacancy.publish_on)
+        result = described_class.new(original: original_vacancy, new: new_vacancy)
+                                .call
+
+        created_vacancy = Vacancy.find(result.id)
+        expect(created_vacancy.starts_on).to eq(new_vacancy.starts_on)
+        expect(created_vacancy.ends_on).to eq(new_vacancy.ends_on)
+        expect(created_vacancy.publish_on).to eq(new_vacancy.publish_on)
+        expect(created_vacancy.expires_on).to eq(new_vacancy.expires_on)
       end
-    end
-
-    it 'sets the copied vacancy\'s status to draft' do
-      vacancy = FactoryBot.build(:vacancy, :published)
-      vacancy_copy = CopyVacancy.new(vacancy: vacancy).copy
-
-      expect(vacancy_copy.status).to eq('draft')
     end
   end
 end

--- a/spec/services/copy_vacancy_spec.rb
+++ b/spec/services/copy_vacancy_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe CopyVacancy do
-  describe '#update_fields' do
-    context 'a published vacancy with a publish_on date in the past' do
-      it 'updates the vacancy\'s publish_on field to enable it to be published' do
-        vacancy = FactoryBot.build(:vacancy, :past_publish)
-        vacancy_copy = CopyVacancy.new(vacancy: vacancy).copy
+  describe '#call' do
+    it 'creates a new vacancy as draft' do
+      original_vacancy = FactoryBot.build(:vacancy, job_title: 'Maths teacher')
+      original_vacancy.save
+      new_vacancy = original_vacancy.dup
 
         expect(vacancy_copy.publish_on).to eq(Time.zone.today)
       end

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -40,6 +40,22 @@ module VacancyHelpers
     fill_in 'application_details_form[publish_on_yyyy]', with: vacancy.publish_on.year
   end
 
+  def fill_in_copy_vacancy_form_fields(vacancy)
+    fill_in 'copy_vacancy_form[job_title]', with: vacancy.job_title
+    fill_in 'copy_vacancy_form[starts_on_dd]', with: vacancy.starts_on.day
+    fill_in 'copy_vacancy_form[starts_on_mm]', with: vacancy.starts_on.strftime('%m')
+    fill_in 'copy_vacancy_form[starts_on_yyyy]', with: vacancy.starts_on.year
+    fill_in 'copy_vacancy_form[ends_on_dd]', with: vacancy.ends_on.day
+    fill_in 'copy_vacancy_form[ends_on_mm]', with: vacancy.ends_on.strftime('%m')
+    fill_in 'copy_vacancy_form[ends_on_yyyy]', with: vacancy.ends_on.year
+    fill_in 'copy_vacancy_form[expires_on_dd]', with: vacancy.expires_on.day
+    fill_in 'copy_vacancy_form[expires_on_mm]', with: vacancy.expires_on.strftime('%m')
+    fill_in 'copy_vacancy_form[expires_on_yyyy]', with: vacancy.expires_on.year
+    fill_in 'copy_vacancy_form[publish_on_dd]', with: vacancy.publish_on.day
+    fill_in 'copy_vacancy_form[publish_on_mm]', with: vacancy.publish_on.strftime('%m')
+    fill_in 'copy_vacancy_form[publish_on_yyyy]', with: vacancy.publish_on.year
+  end
+
   def verify_all_vacancy_details(vacancy)
     expect(page).to have_content(vacancy.job_title)
     expect(page.html).to include(vacancy.job_description)


### PR DESCRIPTION
## Trello card URL:

## Changes in this PR:

This add the UI changes necessary for jobs to be duplicated. This was previously blocked by the issues with the GDS design system tabs, which was fixed by #698 

## Screenshots of UI changes:

### Before

![image](https://user-images.githubusercontent.com/109774/51924665-60cc5e80-23e5-11e9-807e-9d1b15f51772.png)

### After

![image](https://user-images.githubusercontent.com/109774/51924692-6de94d80-23e5-11e9-904f-18dc3f5a1450.png)

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
