### PR TITLE
[646] Draft jobs are shown with their last updated_at and created_at

### DIFF
--- a/app/views/hiring_staff/schools/_vacancies_draft.html.haml
+++ b/app/views/hiring_staff/schools/_vacancies_draft.html.haml
@@ -6,7 +6,8 @@
             %thead.govuk-table__head
                 %tr.govuk-table__row
                     %th.govuk-table__header= t('jobs.job_title')
-                    %th.govuk-table__header= t('jobs.date_drafted')
+                    %th.govuk-table__header= t('jobs.draft.time_created')
+                    %th.govuk-table__header= t('jobs.draft.time_updated')
                     %th.govuk-table__header{ colspan: 2}= t('jobs.actions')
             %tbody.govuk-table__body
                 - presenter.draft.each do |vacancy|

--- a/app/views/hiring_staff/schools/_vacancy_draft.html.haml
+++ b/app/views/hiring_staff/schools/_vacancy_draft.html.haml
@@ -1,5 +1,6 @@
 %tr.govuk-table__row.vacancy[vacancy]
   %td.govuk-table__cell= link_to vacancy.job_title, school_job_path(vacancy.id), class: 'govuk-link view-vacancy-link'
+  %td.govuk-table__cell= format_date(vacancy.created_at)
   %td.govuk-table__cell= format_date(vacancy.updated_at)
   %td.govuk-table__cell= link_to t('jobs.edit_link'), edit_school_job_path(vacancy.id), class: 'govuk-link'
   %td.govuk-table__cell= link_to t('jobs.delete_link'), school_job_path(id: vacancy.id), class: 'govuk-link', method: :delete, data: { confirm: t('jobs.are_you_sure', job_title: vacancy.job_title) }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -98,7 +98,6 @@ en:
     already_published: 'This job has already been published'
     draft: 'This job is currently a draft version.'
     date_to_be_posted: Date to be published
-    date_drafted: Date drafted
     share_url: 'This job is publicly visible at:'
     view_public_link: 'View the public page for this job'
     copy_public_url: 'copy the public URL to the clipboard'
@@ -114,6 +113,9 @@ en:
     edit_link: Edit
     delete_link: Delete
     are_you_sure: Are you sure you want to delete the '%{job_title}' job?
+    draft:
+      time_created: Date drafted
+      time_updated: Date last updated
     confirmation_page:
       submitted: 'The job listing has been completed'
       page_title: 'The job listing for %{school} has been completed'

--- a/spec/features/hiring_staff_can_see_their_vacancies_spec.rb
+++ b/spec/features/hiring_staff_can_see_their_vacancies_spec.rb
@@ -78,8 +78,8 @@ RSpec.feature 'Hiring staff can see their vacancies' do
       end
 
       within('table.vacancies') do
-        expect(page).to have_content(I18n.t('jobs.date_drafted'))
-        expect(page).to have_content(I18n.t('jobs.date_drafted'))
+        expect(page).to have_content(I18n.t('jobs.draft.time_created'))
+        expect(page).to have_content(format_date(draft_vacancy.created_at))
         expect(page).to have_content(format_date(draft_vacancy.updated_at))
         expect(page).to have_content(draft_vacancy.job_title)
         expect(page).to have_css('tbody tr', count: 1)
@@ -115,6 +115,26 @@ RSpec.feature 'Hiring staff can see their vacancies' do
         expect(page).to have_content(format_date(expired_vacancy.expires_on))
         expect(page).to have_content(format_date(expired_vacancy.publish_on))
         expect(page).to have_css('tbody tr', count: 1)
+      end
+    end
+
+    context 'when a draft vacancy has been updated' do
+      let!(:draft_vacancy) do
+        create(:vacancy, :draft, school: school, created_at: 3.days.ago, updated_at: 1.day.ago)
+      end
+
+      scenario 'shows the last updated at' do
+        draft_vacancy
+        visit school_path
+
+        within('.tab-list') do
+          click_on(I18n.t('jobs.draft_jobs'))
+        end
+
+        within('table.vacancies') do
+          expect(page).to have_content(format_date(draft_vacancy.created_at))
+          expect(page).to have_content(format_date(draft_vacancy.updated_at))
+        end
       end
     end
   end


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/FJE5XW0Y

## Changes in this PR:
* The locale file is getting very long and hard to find relevant copy. Nesting draft vacancies under the `jobs.draft.` namespace. Would be good to keep picking away at this file.
* The existing date was actually the updated_at field labelled incorrectly as 'Date drafted' - this change includes both created at and updated_at timestamps.

## Screenshots of UI changes:

### Before
![screenshot 2019-01-31 at 18 39 27](https://user-images.githubusercontent.com/912473/52076896-a032b080-2587-11e9-9f36-a70acb4a0f12.png)

### After
![screenshot 2019-01-31 at 18 37 23](https://user-images.githubusercontent.com/912473/52076819-6bbef480-2587-11e9-916b-e46664d9dbb5.png)
