### PR TITLE
`bin/dstart` no longer requires elasticsearch reindex in dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,18 +32,22 @@ services:
 
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:6.0.1
-    hostname: "{{.Node.Hostname}}-elasticsearch"
     depends_on:
       - db
     ports:
       - "9200:9200"
     environment:
-      - discovery.type=single-node
       - cluster.name=docker-dev-cluster
       - node.name={{.Node.Hostname}}-elasticsearch
       - network.host=0.0.0.0
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
     volumes:
-      - elasticsearch:/usr/share/elasticsearch/teaching_jobs_dev/data
+      - elasticsearch:/usr/share/elasticsearch/data
     restart: on-failure
 
   redis:
@@ -62,5 +66,6 @@ services:
 
 volumes:
   pg_data: {}
-  elasticsearch: {}
+  elasticsearch:
+    driver: local
   node_modules:


### PR DESCRIPTION
* I reviewed our docker-compose config given the problem was very likely that the data persistance was being reset. When compared against the official documentation we had a number of things different and changing them fixes the issues
* The documentation references the latest 6.6.0 es image however since we are using `6.0` in production I have left it as that in development for greater parity. It seems to work all the same

I'd be grateful for more testing on other dev environments to double check I didn't do something else without realising!

To replicate the issue before this change:
1. start the server locally using `bin/dstart`
2. reindex elastic search using `bin/drake elasticsearch:vacancies:index` (or leave it to fail after the next step)
3. visit the root path https://localhost:3000
4. term the `bin/dstart` process we started in step 1 with ^c
5. visit the root path https://localhost:3000
6. start the server locally again using `bin/dstart` and observe an elastic search error telling us it's missing indexes 

After this change: 
- Follow the same steps except this time step 6 should not render an error