### PR TITLE
(fix): Old redis instance does not share the name of one of the newer…

### DIFF
--- a/terraform/modules/elasticache-redis/main.tf
+++ b/terraform/modules/elasticache-redis/main.tf
@@ -34,7 +34,7 @@ resource "aws_elasticache_cluster" "redis" {
   security_group_ids   = ["${aws_security_group.redis.id}"]
 
   tags {
-    Name          = "${var.tag_name}-cache"
+    Name          = "${var.tag_name}"
     environment   = "${var.tag_environment}"
     team          = "${var.tag_team}"
     application   = "${var.tag_application}"


### PR DESCRIPTION
… instances

- Noticed this proposed change by Terraform during the deployment of https://github.com/dxw/teacher-vacancy-service/pull/701. Unsure how this was missed during tests on the testing environment. The redis instances on testing all have unique names.
- I predict that the TF deployment won't succeed, may cause unexpected issues and will make it hard to identify in the AWS console as the 'old' one


![screenshot 2019-02-06 at 11 35 35](https://user-images.githubusercontent.com/912473/52338868-76eca700-2a03-11e9-80b7-7a8bc4b80120.png)

## Next steps:

- [x] Terraform deployment required?
