### PR TITLE
Remove N+1 queries from jobs API endpoint

### DIFF
--- a/app/controllers/api/vacancies_controller.rb
+++ b/app/controllers/api/vacancies_controller.rb
@@ -3,7 +3,7 @@ class Api::VacanciesController < Api::ApplicationController
   before_action :verify_json_or_csv_request, only: %w[index]
 
   def index
-    records = Vacancy.listed.where.not(status: :draft).where.not(status: :trashed)
+    records = Vacancy.includes(school: [:region]).listed.where.not(status: :draft).where.not(status: :trashed)
     @vacancies = VacanciesPresenter.new(records, searched: false)
 
     respond_to do |format|


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/r0fOeSju/723-remove-n1-queries-from-jobs-api-endpoint

## Changes in this PR:

Remove two n+1 queries from this endpoint, one for each vacancy's school and one for the school's region. We can wrap these up in a nested includes.

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
