### PR TITLE
(chore) Increase Cloudfront caching on API endpoints

### DIFF
--- a/terraform/modules/cloudfront/cloudfront.tf
+++ b/terraform/modules/cloudfront/cloudfront.tf
@@ -115,8 +115,8 @@ resource "aws_cloudfront_distribution" "default" {
       }
     }
 
-    min_ttl     = 60
-    default_ttl = 900
+    min_ttl     = 900
+    default_ttl = 3600
     max_ttl     = 86400
 
     viewer_protocol_policy = "redirect-to-https"


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/K5FzYKT7/735-increase-cloudfront-caching-on-api-endpoints

## Changes in this PR:

These can be long slow running queries so to avoid a denial of service
we should change the minimum caching time from 1 minute to 15 minutes.
This should help allievate pressure on the main service.

## Next steps:

- [x] Terraform deployment required?

- [ ] New development configuration to be shared?
