### PR TITLE
(fix): Redis instances can be created on production

### DIFF
--- a/terraform/modules/elasticache-redis/main.tf
+++ b/terraform/modules/elasticache-redis/main.tf
@@ -44,7 +44,7 @@ resource "aws_elasticache_cluster" "redis" {
 }
 
 resource "aws_elasticache_cluster" "redis_cache" {
-  cluster_id           = "${var.cluster_id}-cache"
+  cluster_id           = "${var.cluster_id}Cache"
   engine               = "redis"
   engine_version       = "${var.engine_version}"
   maintenance_window   = "${var.maintenance_window}"
@@ -56,7 +56,7 @@ resource "aws_elasticache_cluster" "redis_cache" {
   security_group_ids   = ["${aws_security_group.redis.id}"]
 
   tags {
-    Name          = "${var.tag_name}-cache"
+    Name          = "${var.tag_name}Cache"
     environment   = "${var.tag_environment}"
     team          = "${var.tag_team}"
     application   = "${var.tag_application}"
@@ -66,7 +66,7 @@ resource "aws_elasticache_cluster" "redis_cache" {
 }
 
 resource "aws_elasticache_cluster" "redis_queue" {
-  cluster_id           = "${var.cluster_id}-queue"
+  cluster_id           = "${var.cluster_id}Queue"
   engine               = "redis"
   engine_version       = "${var.engine_version}"
   maintenance_window   = "${var.maintenance_window}"
@@ -78,7 +78,7 @@ resource "aws_elasticache_cluster" "redis_queue" {
   security_group_ids   = ["${aws_security_group.redis.id}"]
 
   tags {
-    Name          = "${var.tag_name}-queue"
+    Name          = "${var.tag_name}Queue"
     environment   = "${var.tag_environment}"
     team          = "${var.tag_team}"
     application   = "${var.tag_application}"


### PR DESCRIPTION
## Changes in this PR:
* When splitting our single redis instance into 2 [1] we found out there is a character limit when we tried deploying it to production as `tvs2-production-cache` is more than 20 characters!
* We considered removing tvs2 but that is a global prefix for the whole infrastructure and removing it would require a full rebuild. It also gives us the advantage of being able to identify all components of TVS inside the AWS console.
* We can’t easily shorten the ‘production’ as that matches directly to the Terraform Workspace name, I guess that changing this to ‘prod’ would also require a full rebuild of production
* The only things we could do is to camel case or to shorten the word from `cache` to `cach`, or remove the preceding hyphen. We’ve opted to to keep the word whole and meaningful by instead removing the hyphen and camel casing.

[1] https://github.com/dxw/teacher-vacancy-service/pull/701

- [x] Terraform deployment required?
