### PR TITLE
JSON API results are paginated

### DIFF
--- a/app/controllers/api/vacancies_controller.rb
+++ b/app/controllers/api/vacancies_controller.rb
@@ -3,7 +3,7 @@ class Api::VacanciesController < Api::ApplicationController
   before_action :verify_json_or_csv_request, only: %w[index]
 
   def index
-    records = Vacancy.includes(school: [:region]).listed.where.not(status: :draft).where.not(status: :trashed)
+    records = Vacancy.includes(school: [:region]).listed.published.page(page_number)
     @vacancies = VacanciesPresenter.new(records, searched: false)
 
     respond_to do |format|
@@ -21,5 +21,9 @@ class Api::VacanciesController < Api::ApplicationController
 
   def id
     params[:id]
+  end
+
+  def page_number
+    params[:page] || 1
   end
 end

--- a/app/controllers/api/vacancies_controller.rb
+++ b/app/controllers/api/vacancies_controller.rb
@@ -1,13 +1,11 @@
 class Api::VacanciesController < Api::ApplicationController
-  before_action :verify_json_request, only: %w[show]
-  before_action :verify_json_or_csv_request, only: %w[index]
+  before_action :verify_json_request, only: %w[show index]
 
   def index
     records = Vacancy.includes(school: [:region]).listed.published.page(page_number)
     @vacancies = VacanciesPresenter.new(records, searched: false)
 
     respond_to do |format|
-      format.csv { send_data @vacancies.to_csv, filename: "#{Time.zone.now.iso8601}_jobs.csv", template: false }
       format.json
     end
   end

--- a/app/controllers/api/vacancies_controller.rb
+++ b/app/controllers/api/vacancies_controller.rb
@@ -1,8 +1,14 @@
 class Api::VacanciesController < Api::ApplicationController
   before_action :verify_json_request, only: %w[show index]
 
+  MAX_API_RESULTS_PER_PAGE = 50
+
   def index
-    records = Vacancy.includes(school: [:region]).listed.published.page(page_number)
+    records = Vacancy.includes(school: [:region])
+                     .listed
+                     .published
+                     .page(page_number)
+                     .per(MAX_API_RESULTS_PER_PAGE)
     @vacancies = VacanciesPresenter.new(records, searched: false)
 
     respond_to do |format|

--- a/app/presenters/vacancies_presenter.rb
+++ b/app/presenters/vacancies_presenter.rb
@@ -70,7 +70,8 @@ class VacanciesPresenter < BasePresenter
   def json_api_params
     {
       format: :json,
-      api_version: 1
+      api_version: 1,
+      protocol: 'https'
     }
   end
 

--- a/app/presenters/vacancies_presenter.rb
+++ b/app/presenters/vacancies_presenter.rb
@@ -1,4 +1,5 @@
 class VacanciesPresenter < BasePresenter
+  include Rails.application.routes.url_helpers
   include ActionView::Helpers::UrlHelper
   attr_reader :decorated_collection, :searched
   alias_method :user_search?, :searched
@@ -44,7 +45,34 @@ class VacanciesPresenter < BasePresenter
     end
   end
 
+  def current_api_url
+    api_jobs_url(json_api_params.merge(page: model.current_page))
+  end
+
+  def first_api_url
+    api_jobs_url(json_api_params.merge(page: 1))
+  end
+
+  def last_api_url
+    api_jobs_url(json_api_params.merge(page: model.total_pages))
+  end
+
+  def previous_api_url
+    api_jobs_url(json_api_params.merge(page: model.prev_page)) if model.prev_page
+  end
+
+  def next_api_url
+    api_jobs_url(json_api_params.merge(page: model.next_page)) if model.next_page
+  end
+
   private
+
+  def json_api_params
+    {
+      format: :json,
+      api_version: 1
+    }
+  end
 
   def total_count
     model.total_count

--- a/app/views/api/vacancies/index.json.jbuilder
+++ b/app/views/api/vacancies/index.json.jbuilder
@@ -25,3 +25,7 @@ json.links do
   json.prev  url_to_prev_page(@vacancies)
   json.next  url_to_next_page(@vacancies)
 end
+
+json.meta do
+  json.totalPages @vacancies.total_pages
+end

--- a/app/views/api/vacancies/index.json.jbuilder
+++ b/app/views/api/vacancies/index.json.jbuilder
@@ -17,3 +17,10 @@ json.openapi '3.0.0'
 json.data @vacancies.decorated_collection do |vacancy|
   json.partial! 'show.json.jbuilder', vacancy: vacancy
 end
+
+json.links do
+  json.first nil
+  json.last nil
+  json.prev nil
+  json.next nil
+end

--- a/app/views/api/vacancies/index.json.jbuilder
+++ b/app/views/api/vacancies/index.json.jbuilder
@@ -19,8 +19,9 @@ json.data @vacancies.decorated_collection do |vacancy|
 end
 
 json.links do
-  json.first nil
-  json.last nil
-  json.prev nil
-  json.next nil
+  json.self  api_jobs_url(page: @vacancies.current_page)
+  json.first api_jobs_url
+  json.last  api_jobs_url(page: @vacancies.total_pages)
+  json.prev  url_to_prev_page(@vacancies)
+  json.next  url_to_next_page(@vacancies)
 end

--- a/app/views/api/vacancies/index.json.jbuilder
+++ b/app/views/api/vacancies/index.json.jbuilder
@@ -19,11 +19,11 @@ json.data @vacancies.decorated_collection do |vacancy|
 end
 
 json.links do
-  json.self  api_jobs_url(page: @vacancies.current_page)
-  json.first api_jobs_url
-  json.last  api_jobs_url(page: @vacancies.total_pages)
-  json.prev  url_to_prev_page(@vacancies)
-  json.next  url_to_next_page(@vacancies)
+  json.self  @vacancies.current_api_url
+  json.first @vacancies.first_api_url
+  json.last  @vacancies.last_api_url
+  json.prev  @vacancies.previous_api_url
+  json.next  @vacancies.next_api_url
 end
 
 json.meta do

--- a/app/views/api/vacancies/index.json.jbuilder
+++ b/app/views/api/vacancies/index.json.jbuilder
@@ -10,7 +10,7 @@ json.info do
     json.name 'Open Government License'
     json.url 'https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/'
   end
-  json.version '0.0.1'
+  json.version '0.1.0'
 end
 json.openapi '3.0.0'
 

--- a/spec/controllers/api/vacancies_controller_spec.rb
+++ b/spec/controllers/api/vacancies_controller_spec.rb
@@ -112,6 +112,10 @@ RSpec.describe Api::VacanciesController, type: :controller do
           prev: api_jobs_url
         )
       end
+
+      it 'includes the total pages' do
+        expect(json[:meta]).to include(totalPages: 4)
+      end
     end
 
     it 'does not retrieve incomplete or deleted vacancies' do

--- a/spec/controllers/api/vacancies_controller_spec.rb
+++ b/spec/controllers/api/vacancies_controller_spec.rb
@@ -90,11 +90,11 @@ RSpec.describe Api::VacanciesController, type: :controller do
 
       it 'includes the correct pagination links' do
         expect(links_object).to include(
-          self: 'http://localhost:3000/api/v1/jobs.json?page=2',
-          first: 'http://localhost:3000/api/v1/jobs.json?page=1',
-          last: 'http://localhost:3000/api/v1/jobs.json?page=4',
-          next: 'http://localhost:3000/api/v1/jobs.json?page=3',
-          prev: 'http://localhost:3000/api/v1/jobs.json?page=1'
+          self: 'https://localhost:3000/api/v1/jobs.json?page=2',
+          first: 'https://localhost:3000/api/v1/jobs.json?page=1',
+          last: 'https://localhost:3000/api/v1/jobs.json?page=4',
+          next: 'https://localhost:3000/api/v1/jobs.json?page=3',
+          prev: 'https://localhost:3000/api/v1/jobs.json?page=1'
         )
       end
 

--- a/spec/controllers/api/vacancies_controller_spec.rb
+++ b/spec/controllers/api/vacancies_controller_spec.rb
@@ -90,11 +90,11 @@ RSpec.describe Api::VacanciesController, type: :controller do
 
       it 'includes the correct pagination links' do
         expect(links_object).to include(
-          self: api_jobs_url(page: 2),
-          first: api_jobs_url,
-          last: api_jobs_url(page: 4),
-          next: api_jobs_url(page: 3),
-          prev: api_jobs_url
+          self: 'http://localhost:3000/api/v1/jobs.json?page=2',
+          first: 'http://localhost:3000/api/v1/jobs.json?page=1',
+          last: 'http://localhost:3000/api/v1/jobs.json?page=4',
+          next: 'http://localhost:3000/api/v1/jobs.json?page=3',
+          prev: 'http://localhost:3000/api/v1/jobs.json?page=1'
         )
       end
 

--- a/spec/controllers/api/vacancies_controller_spec.rb
+++ b/spec/controllers/api/vacancies_controller_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Api::VacanciesController, type: :controller do
 
     context 'when there are more vacancies than the per-page limit' do
       before do
-        allow(Vacancy).to receive(:default_per_page).and_return(per_page)
+        stub_const('Api::VacanciesController::MAX_API_RESULTS_PER_PAGE', per_page)
         create_list(:vacancy, 16)
         Vacancy.__elasticsearch__.refresh_index!
 

--- a/spec/controllers/api/vacancies_controller_spec.rb
+++ b/spec/controllers/api/vacancies_controller_spec.rb
@@ -63,6 +63,12 @@ RSpec.describe Api::VacanciesController, type: :controller do
       expect(info_object[:contact][:email]).to eq(I18n.t('help.email'))
     end
 
+    it 'returns a links object' do
+      get :index, params: { api_version: 1 }
+
+      expect(json[:links].keys).to include(:first, :last, :prev, :next)
+    end
+
     it 'retrieves all available vacancies' do
       skip_vacancy_publish_on_validation
       published_vacancy = create(:vacancy)

--- a/spec/controllers/api/vacancies_controller_spec.rb
+++ b/spec/controllers/api/vacancies_controller_spec.rb
@@ -15,21 +15,6 @@ RSpec.describe Api::VacanciesController, type: :controller do
     end
   end
 
-  describe 'GET /api/v1/jobs.csv' do
-    it 'responds with :ok' do
-      get :index, params: { api_version: 1 }, format: :csv
-
-      expect(response.status).to eq(Rack::Utils.status_code(:ok))
-    end
-
-    context 'sets headers' do
-      before(:each) { get :index, params: { api_version: 1 }, format: :csv }
-
-      it_behaves_like 'X-Robots-Tag'
-      it_behaves_like 'Content-Type CSV'
-    end
-  end
-
   describe 'GET /api/v1/jobs.json', elasticsearch: true, json: true do
     render_views
 

--- a/spec/presenters/vacancies_presenter_spec.rb
+++ b/spec/presenters/vacancies_presenter_spec.rb
@@ -89,4 +89,46 @@ RSpec.describe VacanciesPresenter do
                                       'School', vacancy.school.name, vacancy.school.urn])
     end
   end
+
+  describe '#previous_api_url' do
+    let(:vacancies_presenter) { VacanciesPresenter.new(vacancies, searched: false) }
+    let(:vacancies) { double(:vacancies, map: [], prev_page: prev_page) }
+
+    context 'when there is a previous page' do
+      let(:prev_page) { 4 }
+
+      it 'returns the full url of the next page' do
+        expect(vacancies_presenter.previous_api_url).to eq('http://localhost:3000/api/v1/jobs.json?page=4')
+      end
+    end
+
+    context 'when there is no previous page' do
+      let(:prev_page) { nil }
+
+      it 'returns nil' do
+        expect(vacancies_presenter.previous_api_url).to be_nil
+      end
+    end
+  end
+
+  describe '#next_api_url' do
+    let(:vacancies_presenter) { VacanciesPresenter.new(vacancies, searched: false) }
+    let(:vacancies) { double(:vacancies, map: [], next_page: next_page) }
+
+    context 'when there is a next page' do
+      let(:next_page) { 2 }
+
+      it 'returns the full url of the next page' do
+        expect(vacancies_presenter.next_api_url).to eq('http://localhost:3000/api/v1/jobs.json?page=2')
+      end
+    end
+
+    context 'when there is no next page' do
+      let(:next_page) { nil }
+
+      it 'returns nil' do
+        expect(vacancies_presenter.next_api_url).to be_nil
+      end
+    end
+  end
 end

--- a/spec/presenters/vacancies_presenter_spec.rb
+++ b/spec/presenters/vacancies_presenter_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe VacanciesPresenter do
       let(:prev_page) { 4 }
 
       it 'returns the full url of the next page' do
-        expect(vacancies_presenter.previous_api_url).to eq('http://localhost:3000/api/v1/jobs.json?page=4')
+        expect(vacancies_presenter.previous_api_url).to eq('https://localhost:3000/api/v1/jobs.json?page=4')
       end
     end
 
@@ -119,7 +119,7 @@ RSpec.describe VacanciesPresenter do
       let(:next_page) { 2 }
 
       it 'returns the full url of the next page' do
-        expect(vacancies_presenter.next_api_url).to eq('http://localhost:3000/api/v1/jobs.json?page=2')
+        expect(vacancies_presenter.next_api_url).to eq('https://localhost:3000/api/v1/jobs.json?page=2')
       end
     end
 


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/GPCJmltJ/736-json-api-results-are-paginated

## Changes in this PR:

- Remove the CSV endpoint for now
- Paginate the JSON results to 50 per page
- Include a `links` top-level object for pagination links
- Include a `meta` top-level object that in includes `totalPages`
