### PR TITLE
[739] Local Redis instances split to mirror production

### DIFF
--- a/docker-compose.env.sample
+++ b/docker-compose.env.sample
@@ -1,7 +1,8 @@
 GOOGLE_MAPS_API_KEY=
 ELASTICSEARCH_URL=http://elasticsearch:9200
 DATABASE_URL=postgres://postgres@db:5432/tvs_development?template=template0&pool=5&encoding=unicode
-REDIS_URL=redis://redis:6379
+REDIS_QUEUE_URL=redis://redis_queue:6379
+REDIS_CACHE_URL=redis://redis_cache:6379
 DFE_SIGN_IN_ISSUER=
 DFE_SIGN_IN_REDIRECT_URL=
 DFE_SIGN_IN_IDENTIFIER=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,8 @@ services:
     depends_on:
       - db
       - elasticsearch
-      - redis
+      - redis_queue
+      - redis_cache
       - sidekiq
     tty: true
     stdin_open: true
@@ -50,7 +51,12 @@ services:
       - elasticsearch:/usr/share/elasticsearch/data
     restart: on-failure
 
-  redis:
+  redis_cache:
+    image: redis:latest
+    command: redis-server
+    restart: on-failure
+
+  redis_queue:
     image: redis:latest
     command: redis-server
     restart: on-failure
@@ -61,7 +67,7 @@ services:
       - docker-compose.env
     command: bundle exec sidekiq -C config/sidekiq.yml
     depends_on:
-      - redis
+      - redis_queue
     restart: on-failure
 
 volumes:


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/FDEa9zod

## Changes in this PR:
* Recently we deployed a change to Redis and split the responsibility of caching and queuing into 2 instances as advised by sidekiq for performance, reliability and improved diagnosis [1]. This change was made successfully but I forgot to update our local docker-compose setup to imitate it so it subsequently fails as the new variables REDIS_CACHE_URL and REDIS_QUEUE_URL are unavailable. This changes copies the production setup for local development and allows Sidekiq to start, and the cache for geolocation to be used.

[1] https://github.com/dxw/teacher-vacancy-service/pull/701

## Screenshots of UI changes:

### Before
Starting the service locally and carrying out any search of the service returned this error:
```
Completed 500 Internal Server Error in 96419ms (ActiveRecord: 3.5ms)
ArgumentError (invalid uri scheme ''):
app/controllers/vacancies_controller.rb:50:in `audit_search_event'
```
This is because Rails was unable to connect to Redis via Sidekiq https://github.com/dxw/teacher-vacancy-service/blob/develop/config/initializers/sidekiq.rb as the new environment variables that are now being used in production are not present `REDIS_CACHE_URL` and `REDIS_QUEUE_URL`.

We can also see that the Sidekiq process is restarting continuously in the background as it is failing to start.

### After

A user can carry out any search using the web service and sidekiq is able to initialise and process events.

## Next steps:

- [x] New development configuration to be shared?
