### PR TITLE
[740] docker-compose only builds the application once instead of twice

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       context: .
       args:
         RAILS_ENV: "development"
+    image: local/tvs_web
     ports: ["3000:3000"]
     container_name: teacher-vacancy-service_web_1
     environment:
@@ -62,7 +63,7 @@ services:
     restart: on-failure
 
   sidekiq:
-    build: .
+    image: local/tvs_web
     env_file:
       - docker-compose.env
     command: bundle exec sidekiq -C config/sidekiq.yml


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/VHfjeNvj

## Changes in this PR:
* By using the `image` flag we can store the output of the first build as an input for the sidekiq process. This removes the need for the sidekiq service to have to duplicate the exact same build process so it has access to the same Rails app before it can start.
* Even with docker layer caching this should save us a good amount of time everytime we have to rebuild the service locally
* I’ve called it `local/tvs_web` rather than just ‘web’ as it will make it distinguishable amongst all images that  appear in the output of our machine’s `docker image ls` request, this may include other applications you’ve built over time.