### PR TITLE
[727] Hiring staff can now copy expired vacancies

### DIFF
--- a/app/form_models/copy_vacancy_form.rb
+++ b/app/form_models/copy_vacancy_form.rb
@@ -12,7 +12,7 @@ class CopyVacancyForm < VacancyForm
     self.job_title = vacancy.job_title
     self.starts_on = vacancy.starts_on
     self.ends_on = vacancy.ends_on
-    self.expires_on = vacancy.expires_on
+    self.expires_on = vacancy.expires_on.future? ? vacancy.expires_on : nil
     self.publish_on = vacancy.publish_on
   end
 

--- a/app/form_models/copy_vacancy_form.rb
+++ b/app/form_models/copy_vacancy_form.rb
@@ -10,14 +10,20 @@ class CopyVacancyForm < VacancyForm
   def initialize(vacancy:)
     self.vacancy = vacancy
     self.job_title = vacancy.job_title
-    self.starts_on = vacancy.starts_on
-    self.ends_on = vacancy.ends_on
-    self.expires_on = vacancy.expires_on.future? ? vacancy.expires_on : nil
-    self.publish_on = vacancy.publish_on
+    reset_date_fields if vacancy.expires_on.past?
   end
 
   def apply_changes!(params = {})
     vacancy.assign_attributes(params)
     vacancy
+  end
+
+  private
+
+  def reset_date_fields
+    self.starts_on  = nil
+    self.ends_on    = nil
+    self.expires_on = nil
+    self.publish_on = nil
   end
 end

--- a/app/views/hiring_staff/schools/_vacancies_expired.html.haml
+++ b/app/views/hiring_staff/schools/_vacancies_expired.html.haml
@@ -9,7 +9,7 @@
                     %th.govuk-table__header= t('jobs.job_title')
                     %th.govuk-table__header= t('jobs.date_to_be_posted')
                     %th.govuk-table__header= t('jobs.expired_on')
-                    %th.govuk-table__header= t('jobs.actions')
+                    %th.govuk-table__header{ colspan: 2 }= t('jobs.actions')
             %tbody.govuk-table__body
                 - presenter.expired.each do |vacancy|
                     = render partial: 'vacancy_expired', locals: { vacancy: vacancy, school: presenter.school }

--- a/app/views/hiring_staff/schools/_vacancy_expired.html.haml
+++ b/app/views/hiring_staff/schools/_vacancy_expired.html.haml
@@ -2,4 +2,5 @@
   %td.govuk-table__cell= link_to vacancy.job_title, school_job_path(vacancy.id), class: 'govuk-link view-vacancy-link'
   %td.govuk-table__cell= format_date(vacancy.publish_on)
   %td.govuk-table__cell= format_date(vacancy.expires_on)
+  %td.govuk-table__cell= link_to t('jobs.copy_link'), new_school_job_copy_path(vacancy.id), class: 'govuk-link', method: :get
   %td.govuk-table__cell= link_to t('jobs.delete_link'), school_job_path(id: vacancy.id), class: 'govuk-link', method: :delete, data: { confirm: t('jobs.are_you_sure', job_title: vacancy.job_title) }

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -78,6 +78,7 @@ FactoryBot.define do
     end
 
     trait :expired do
+      to_create { |instance| instance.save(validate: false) }
       status { :published }
       sequence(:slug) { |n| "slug-#{n}" }
       publish_on { Faker::Time.between(Time.zone.today - 14.days, Time.zone.today - 7.days) }

--- a/spec/features/hiring_staff_can_copy_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_copy_a_vacancy_spec.rb
@@ -68,6 +68,34 @@ RSpec.feature 'Copying a vacancy' do
     end
   end
 
+  context 'when the original job has expired' do
+    scenario 'a job can be successfully copied' do
+      original_vacancy = FactoryBot.create(:vacancy, :expired, school: school)
+
+      new_vacancy = original_vacancy.dup
+      new_vacancy.job_title = 'A new job title'
+      new_vacancy.starts_on = 35.days.from_now
+      new_vacancy.ends_on = 100.days.from_now
+      new_vacancy.publish_on = 0.days.from_now
+      new_vacancy.expires_on = 30.days.from_now
+
+      visit school_path
+
+      click_on I18n.t('jobs.expired_jobs')
+      within('table.vacancies') do
+        click_on I18n.t('jobs.copy_link')
+      end
+
+      expect(page).to have_content(I18n.t('jobs.copy_page_title', job_title: original_vacancy.job_title))
+      within('form.copy-form') do
+        fill_in_copy_vacancy_form_fields(new_vacancy)
+        click_on I18n.t('buttons.save_and_continue')
+      end
+
+      expect(page).to have_content(I18n.t('jobs.review_heading', school: school.name))
+    end
+  end
+
   context 'when the publish on date is set in the past' do
     scenario 'it renders a form error instead of a 500 error' do
       original_vacancy = FactoryBot.build(:vacancy, :past_publish, school: school)

--- a/spec/form_models/copy_vacancy_form_spec.rb
+++ b/spec/form_models/copy_vacancy_form_spec.rb
@@ -13,6 +13,12 @@ RSpec.describe CopyVacancyForm, type: :model do
     expect(form_object.publish_on).to eq(original_vacancy.publish_on)
   end
 
+  it 'doesn’t copy the expiry date for expired vacancies' do
+    expired_vacancy = build(:vacancy, :expired)
+    form_object = described_class.new(vacancy: expired_vacancy)
+    expect(form_object.expires_on).to be_nil
+  end
+
   describe '#apply_changes!' do
     it 'updates the original vacancy with the users new preferences' do
       original_vacancy = build(:vacancy)

--- a/spec/form_models/copy_vacancy_form_spec.rb
+++ b/spec/form_models/copy_vacancy_form_spec.rb
@@ -13,10 +13,13 @@ RSpec.describe CopyVacancyForm, type: :model do
     expect(form_object.publish_on).to eq(original_vacancy.publish_on)
   end
 
-  it 'doesn’t copy the expiry date for expired vacancies' do
+  it 'doesn’t copy any dates for expired vacancies' do
     expired_vacancy = build(:vacancy, :expired)
     form_object = described_class.new(vacancy: expired_vacancy)
+    expect(form_object.starts_on).to be_nil
+    expect(form_object.ends_on).to be_nil
     expect(form_object.expires_on).to be_nil
+    expect(form_object.publish_on).to be_nil
   end
 
   describe '#apply_changes!' do


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/m2eHnBMQ/727-hiring-staff-ui-user-can-make-a-copy-of-an-existing-job-on-the-expired-jobs-page-front-end

## Changes in this PR:

- Amended the `expired` vacancy factory to allow saving without validation
- Added 'Copy' button to the expired vacancies view
- Added new context for copying expired vacancies to feature spec
- Prevent dates from being set on expired vacancies

## Screenshots of UI changes:

### Before

![screenshot 2019-02-13 at 16 58 53](https://user-images.githubusercontent.com/2804149/52729218-ac1f6900-2fb0-11e9-8071-9ca461a447fd.png)


### After

![screenshot 2019-02-13 at 16 58 11](https://user-images.githubusercontent.com/2804149/52729174-99a52f80-2fb0-11e9-9fe9-01df27b514e0.png)
