### PR TITLE
[741] Remove roll out banner from the service

### DIFF
--- a/app/views/shared/_beta_banner.html.haml
+++ b/app/views/shared/_beta_banner.html.haml
@@ -1,2 +1,0 @@
-.flash.notice
-  .small= t('beta_banner.line_1', link: link_to(t('beta_banner.link'), roll_out_blog_url, target: :_blank, class: 'govuk-link')).html_safe

--- a/app/views/vacancies/_show.html+phone.haml
+++ b/app/views/vacancies/_show.html+phone.haml
@@ -112,6 +112,3 @@
       - if @vacancy.application_link.present?
         %p.govuk-body-s=t('jobs.aria_labels.apply_link')
         = link_to t('jobs.apply'), new_job_interest_path(@vacancy.id), target: '_blank', class: 'govuk-button vacancy-apply-link', 'aria-label': t('jobs.aria_labels.apply_link')
-
-.mt1
-  = render partial: 'shared/beta_banner'

--- a/app/views/vacancies/index.html+phone.haml
+++ b/app/views/vacancies/index.html+phone.haml
@@ -25,5 +25,3 @@
 
   .govuk-grid-column-one-third#filters
     = render 'filters'
-
-= render partial: 'shared/beta_banner'

--- a/app/views/vacancies/index.html.haml
+++ b/app/views/vacancies/index.html.haml
@@ -1,7 +1,5 @@
 - content_for :page_title_prefix, t('jobs.heading')
 
-= render partial: 'shared/beta_banner'
-
 %h1.govuk-heading-xl
   = t('jobs.heading')
 .govuk-grid-row

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -537,6 +537,3 @@ en:
           title: Terms and Conditions for API users
           line_1: "You are free to reuse job listing data under the terms of the <a href='https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/' target='_blank' class='govuk-link'>Open Government Licence</a> for public sector information with the following exception:"
           list: you may not charge a school any fee or commission for contacting, interviewing or hiring a respondent to your advertisement or listing if it is based on Teaching Vacancies data that you have reused.
-  beta_banner:
-    line_1: This free service lists jobs in select areas. %{link} and will cover all of England in February.
-    link: It is rolling out in phases

--- a/spec/features/job_seekers_can_view_vacancies_spec.rb
+++ b/spec/features/job_seekers_can_view_vacancies_spec.rb
@@ -8,11 +8,6 @@ RSpec.feature 'Viewing vacancies' do
     verify_vacancy_list_page_details(VacancyPresenter.new(vacancy))
   end
 
-  scenario 'View a banner with information about the service' do
-    visit jobs_path
-    expect(page).to have_css('.flash.notice')
-  end
-
   scenario 'There are enough vacancies to invoke pagination', elasticsearch: true do
     job_count = Vacancy.default_per_page + 1 # must be larger than the default page limit
     create_list(:vacancy, job_count)

--- a/spec/features/support_links_spec.rb
+++ b/spec/features/support_links_spec.rb
@@ -32,17 +32,4 @@ RSpec.feature 'A visitor to the website can access the support links' do
     expect(page).to have_content('Please read these Terms of Use (“General Terms”) carefully before using ' \
                                  'this Teaching Vacancies website (the “Service”).')
   end
-
-  context 'the roll out blog link' do
-    scenario 'on the service homepage' do
-      visit root_path
-      expect(page).to have_selector "a[href='#{roll_out_blog_url}']", text: I18n.t('beta_banner.link')
-    end
-
-    scenario 'on the hiring staff sign in page' do
-      visit new_identifications_path
-      expect(page).to have_selector "a[href='#{roll_out_blog_url}']",
-                                    text: 'Invitations are being sent out gradually by region.'
-    end
-  end
 end


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/15IlB8FP

## Changes in this PR:
- remove the school roll out banner completely

## Screenshots of UI changes:

### Before
![screenshot 2019-02-14 at 12 00 02](https://user-images.githubusercontent.com/912473/52785827-e2142a00-3050-11e9-89d6-97d97854dff3.png)

### After
![screenshot 2019-02-14 at 11 59 43](https://user-images.githubusercontent.com/912473/52785835-e9d3ce80-3050-11e9-9619-cb91ece3c372.png)
