### PR TITLE
[744] Caching of API requests takes into account query params

### DIFF
--- a/terraform/modules/cloudfront/cloudfront.tf
+++ b/terraform/modules/cloudfront/cloudfront.tf
@@ -107,7 +107,7 @@ resource "aws_cloudfront_distribution" "default" {
     path_pattern = "/api/*"
 
     forwarded_values = {
-      query_string = false
+      query_string = true
       headers      = ["Host"]
 
       cookies {


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/TjcF4e0g

## Changes in this PR:
* These were not being forwarded so we had a problem where requests for `jobs.json?page=1` would be cached and then we'd request `jobs.json?page=1` only to get a cache hit and the results from page 1, rather than page 2.
* We changed the cloudfront setting for this manually on staging, verified it fixed it before applying to production until this change can be made. https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution.html#query_string

## Next steps:

- [x] Terraform deployment required?
