### PR TITLE
[725] Caching and autoscaling to better support higher load

### DIFF
--- a/terraform/modules/cloudfront/cloudfront.tf
+++ b/terraform/modules/cloudfront/cloudfront.tf
@@ -122,6 +122,29 @@ resource "aws_cloudfront_distribution" "default" {
     viewer_protocol_policy = "redirect-to-https"
   }
 
+  cache_behavior {
+    allowed_methods  = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "${var.project_name}-${var.environment}-default-origin"
+
+    path_pattern = "/"
+
+    forwarded_values = {
+      query_string = false
+      headers      = ["Host", "Authorization"]
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl     = 300 # 5 minutes
+    default_ttl = 900 # 15 minutes
+    max_ttl     = 3600 # 60 minutes
+
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
   price_class = "PriceClass_100"
 
   restrictions {

--- a/terraform/modules/cloudfront/cloudfront.tf
+++ b/terraform/modules/cloudfront/cloudfront.tf
@@ -108,7 +108,7 @@ resource "aws_cloudfront_distribution" "default" {
 
     forwarded_values = {
       query_string = true
-      headers      = ["Host"]
+      headers      = ["Host", "Authorization"]
 
       cookies {
         forward = "none"

--- a/terraform/modules/cloudfront/cloudfront.tf
+++ b/terraform/modules/cloudfront/cloudfront.tf
@@ -145,6 +145,29 @@ resource "aws_cloudfront_distribution" "default" {
     viewer_protocol_policy = "redirect-to-https"
   }
 
+  cache_behavior {
+    allowed_methods  = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "${var.project_name}-${var.environment}-default-origin"
+
+    path_pattern = "/jobs"
+
+    forwarded_values = {
+      query_string = true
+      headers      = ["Host", "Authorization"]
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl     = 60 # 1 minute
+    default_ttl = 60 # 1 minute
+    max_ttl     = 300 # 5 minutes
+
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
   price_class = "PriceClass_100"
 
   restrictions {

--- a/terraform/modules/ecs/ecs.tf
+++ b/terraform/modules/ecs/ecs.tf
@@ -47,6 +47,7 @@ resource "aws_ecs_service" "web" {
   desired_count   = "${var.ecs_service_web_task_count}"
 
   deployment_minimum_healthy_percent = 50
+  deployment_maximum_percent = 100
   health_check_grace_period_seconds  = 30
 
   load_balancer {
@@ -70,9 +71,7 @@ resource "aws_ecs_service" "logspout" {
 
   deployment_minimum_healthy_percent = 50
 
-  placement_constraints {
-    type = "distinctInstance"
-  }
+  scheduling_strategy = "DAEMON"
 
   lifecycle {
     ignore_changes = ["desired_count"]

--- a/variables.tf
+++ b/variables.tf
@@ -215,7 +215,7 @@ variable "rds_engine_version" {
 
   default = {
     mysql    = "5.6.22"
-    postgres = "9.6.6"
+    postgres = "9.6.11"
   }
 }
 


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/ecGy8swS

## Changes in this PR:

Before this change a conceivable amount of concurrent requests to the home page starts to take 5-8 seconds, with searches and API requests introducing 503 responses. This has has become an issue as we have many more job listings on the service, a fair bit more traffic (with much more expected soon) arriving compared to 6 months ago and not having enough caching in place.

The investigation on a recent incident with one of our API endpoints has highlighted this situation which has led us here to review the general services ability to handle load.

On Edge (which has parity with Production) I have tested the request times and AWS resources being used in the following scenarios:

1. normal usage ✅
2. sudden load increase ✅
3. persistent load increase ✅
4. persistent load increase during a deployment ✅

My strategy is to _generously_ scale up the web services quickly and scale back down slowly. I understand that to start with we might be spinning up more instances and containers than we need if the thresholds are slightly out but I believe it's better to have more than we need and tweak it down later than to have not enough, which is the current problem.

* requests to the root path are cached by 15 minutes
* requests to the `/jobs` path including searches and sorting are cached by `60` seconds
* increase the number of web containers and ec2 instances autoscaling can utilise, and lower the thresholds to make them more responsive (lots more info on the commits themselves)
* deployments only use 100% of the desired count, ensuring if the desired count changes to 20/20 then it will not use more than 20 containers for the deployment, which is the maximum 6 medium instances can support, ensuring deployments can succeed.
* set logspout to daemon as it wasn’t always going onto autoscaled instances, sitting at 2/6 which won’t give us logs.

## Next steps:

- [x] Terraform deployment required?
