### PR TITLE
Error messages from job alert creations should disappear if browser back used

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -10,12 +10,11 @@ class SubscriptionsController < ApplicationController
   end
 
   def create
-    flash.clear
     subscription = Subscription.new(daily_subscription_params)
     @subscription = SubscriptionPresenter.new(subscription)
 
     if SubscriptionFinder.new(daily_subscription_params).exists?
-      flash[:error] = I18n.t('errors.subscriptions.already_exists')
+      flash.now[:error] = I18n.t('errors.subscriptions.already_exists')
     elsif subscription.save
       Auditor::Audit.new(subscription, 'subscription.daily_alert.create', nil).log
       SubscriptionMailer.confirmation(subscription.id).deliver_later


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/F3G2fZFY/747-error-messages-from-job-alert-creations-should-disappear-if-browser-back-used

## Changes in this PR:

* Changes setting the flash message from `flash[:error]` to `flash.now[:error]`, which means the flash message is not persisted
* Removes the call to `flash.clear` when creating a subscription, as this is no longer needed