### PR TITLE
[725–2] Cache public job listing content

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -2,5 +2,7 @@ class StatsController < ApplicationController
   def index
     @audit_summary = PublicActivity::Activity.order(:key)
                                              .group(:key).count
+
+    expires_in 60.minutes, public: true
   end
 end

--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -19,12 +19,16 @@ class VacanciesController < ApplicationController
     audit_search_event(records, @filters) if @filters.any?
 
     @vacancies = VacanciesPresenter.new(records, searched: @filters.any?)
+
+    expires_in 5.minutes, public: true
   end
 
   def show
     vacancy = Vacancy.listed.friendly.find(id)
     return redirect_to(job_path(vacancy), status: :moved_permanently) if old_vacancy_path?(vacancy)
     @vacancy = VacancyPresenter.new(vacancy)
+
+    expires_in 5.minutes, public: true
   end
 
   def params

--- a/spec/requests/caching_spec.rb
+++ b/spec/requests/caching_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe 'Caching', type: :request do
+  describe 'vacancies#index' do
+    it 'sets the cache-control to 5 minutes' do
+      get root_path
+      expect(response.headers['cache-control']).to eq('max-age=300, public')
+    end
+  end
+
+  describe 'vacancies#show' do
+    it 'sets the cache-control to 5 minutes' do
+      vacancy = create(:vacancy)
+
+      get jobs_path(vacancy.id)
+
+      expect(response.headers['cache-control']).to eq('max-age=300, public')
+    end
+  end
+end

--- a/spec/requests/caching_spec.rb
+++ b/spec/requests/caching_spec.rb
@@ -17,4 +17,12 @@ RSpec.describe 'Caching', type: :request do
       expect(response.headers['cache-control']).to eq('max-age=300, public')
     end
   end
+
+  describe 'stats#index' do
+    it 'sets the cache-control to 60 minutes' do
+      get stats_path
+
+      expect(response.headers['cache-control']).to eq('max-age=3600, public')
+    end
+  end
 end

--- a/terraform/modules/cloudfront/cloudfront.tf
+++ b/terraform/modules/cloudfront/cloudfront.tf
@@ -122,6 +122,28 @@ resource "aws_cloudfront_distribution" "default" {
     viewer_protocol_policy = "redirect-to-https"
   }
 
+  cache_behavior {
+    allowed_methods  = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "${var.project_name}-${var.environment}-default-origin"
+
+    path_pattern = "/*"
+
+    forwarded_values = {
+      query_string = true
+      headers      = ["Host", "Origin", "Authorization"]
+
+      cookies {
+        forward = "all"
+      }
+    }
+
+    # The absense of `ttl` configuration here means caching is deferred to the origin
+    # https://angristan.xyz/terraform-enable-origin-cache-headers-aws-cloudfront/
+    
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
   price_class = "PriceClass_100"
 
   restrictions {

--- a/terraform/modules/cloudfront/cloudfront.tf
+++ b/terraform/modules/cloudfront/cloudfront.tf
@@ -54,7 +54,7 @@ resource "aws_cloudfront_distribution" "default" {
     viewer_protocol_policy = "redirect-to-https"
   }
 
-  cache_behavior {
+  ordered_cache_behavior {
     allowed_methods  = ["GET", "HEAD"]
     cached_methods   = ["GET", "HEAD"]
     target_origin_id = "${var.project_name}-${var.environment}-offline"
@@ -76,7 +76,7 @@ resource "aws_cloudfront_distribution" "default" {
     viewer_protocol_policy = "redirect-to-https"
   }
 
-  cache_behavior {
+  ordered_cache_behavior {
     allowed_methods  = ["GET", "HEAD"]
     cached_methods   = ["GET", "HEAD"]
     target_origin_id = "${var.project_name}-${var.environment}-default-origin"
@@ -99,7 +99,7 @@ resource "aws_cloudfront_distribution" "default" {
     viewer_protocol_policy = "redirect-to-https"
   }
 
-  cache_behavior {
+  ordered_cache_behavior {
     allowed_methods  = ["GET", "HEAD"]
     cached_methods   = ["GET", "HEAD"]
     target_origin_id = "${var.project_name}-${var.environment}-default-origin"
@@ -122,7 +122,7 @@ resource "aws_cloudfront_distribution" "default" {
     viewer_protocol_policy = "redirect-to-https"
   }
 
-  cache_behavior {
+  ordered_cache_behavior {
     allowed_methods  = ["GET", "HEAD"]
     cached_methods   = ["GET", "HEAD"]
     target_origin_id = "${var.project_name}-${var.environment}-default-origin"


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/ecGy8swS

## Changes in this PR:
* use cache-control headers to instruct users' browsers to use their local cache before hitting our server a second time for 5 minutes
* added a new cache_behaviour rather than using default, since we only want it for `GET` and `HEAD` requests
* fix deprecation warning on cache behaviours, as we are working on adding a new one in this work
* any unique search query should be cached independently eg. `keyword=foo` and `keyword=bar` should be cached independently
* cache the stats page to an hour as it's being used frequently by our dashboards and they don't need to be that live

### Before
Multiple requests to the following endpoints render:
```
curl -X HEAD -I https://user:XXX@tvs.edge.dxw.net
curl -X HEAD -I https://user:XXX@tvs.edge.dxw.net/jobs 
curl -X HEAD -I https://user:XXX@tvs.edge.dxw.net/jobs?utf8=%E2%9C%93&location=&radius=20&keyword=&minimum_salary=&maximum_salary=&working_pattern=&phase=&sort_column=&sort_order=&commit=Search
=> 
cache-control: max-age=0, private, must-revalidate
x-cache: Miss from cloudfront
```

### After

On the second request to the same endpoints the response should change:
```
curl -X HEAD -I https://user:XXX@tvs.edge.dxw.net
curl -X HEAD -I https://user:XXX@tvs.edge.dxw.net/jobs 
curl -X HEAD -I https://user:XXX@tvs.edge.dxw.net/jobs?utf8=%E2%9C%93&location=&radius=20&keyword=&minimum_salary=&maximum_salary=&working_pattern=&phase=&sort_column=&sort_order=&commit=Search
=> 
cache-control: max-age=300, public
age: 84
x-cache: Hit from cloudfront
```

## Next steps:

- [x] Terraform deployment required?
