### PR TITLE
(chore) Allow Postgres to auto update patch versions without conflicting with use of Terraform

### DIFF
--- a/terraform/modules/rds/rds.tf
+++ b/terraform/modules/rds/rds.tf
@@ -17,6 +17,7 @@ resource "aws_db_instance" "default" {
   backup_retention_period   = 14
   maintenance_window        = "Sun:00:00-Sun:03:00"
   multi_az                  = "${terraform.workspace == "production" ? "true" : "false"}"
+  auto_minor_version_upgrade = true
 
   tags {
     Name        = "${var.project_name}-${var.environment}"

--- a/variables.tf
+++ b/variables.tf
@@ -215,7 +215,7 @@ variable "rds_engine_version" {
 
   default = {
     mysql    = "5.6.22"
-    postgres = "9.6.6"
+    postgres = "9.6"
   }
 }
 


### PR DESCRIPTION
* This has already been applied to all environments, seemingly automatically by AWS and without this change our Terraform deployments will fail as we try to instruct it to go backwards.

![screenshot 2019-02-21 at 10 51 56](https://user-images.githubusercontent.com/912473/53163782-c536a400-35c6-11e9-91a9-7bf366c7bab0.png)

* We can omit the patch version and set `9.6` to avoid this problem happening in future