### PR TITLE
[725] Increase auto scaling

### DIFF
--- a/terraform/modules/cloudfront/cloudfront.tf
+++ b/terraform/modules/cloudfront/cloudfront.tf
@@ -108,7 +108,7 @@ resource "aws_cloudfront_distribution" "default" {
 
     forwarded_values = {
       query_string = true
-      headers      = ["Host"]
+      headers      = ["Host", "Authorization"]
 
       cookies {
         forward = "none"

--- a/terraform/modules/core/core.tf
+++ b/terraform/modules/core/core.tf
@@ -466,8 +466,8 @@ resource "aws_appautoscaling_target" "target" {
   resource_id        = "service/${var.ecs_cluster_name}/${var.ecs_service_web_name}"
   scalable_dimension = "ecs:service:DesiredCount"
   role_arn           = "${aws_iam_role.ecs_autoscale_role.arn}"
-  min_capacity       = 3
-  max_capacity       = 10
+  min_capacity       = 6
+  max_capacity       = 20
 }
 
 resource "aws_appautoscaling_policy" "up" {
@@ -478,12 +478,12 @@ resource "aws_appautoscaling_policy" "up" {
 
   step_scaling_policy_configuration {
     adjustment_type         = "ChangeInCapacity"
-    cooldown                = 60
+    cooldown                = 30
     metric_aggregation_type = "Maximum"
 
     step_adjustment {
       metric_interval_lower_bound = 0
-      scaling_adjustment          = 2
+      scaling_adjustment          = 4
     }
   }
 
@@ -503,7 +503,7 @@ resource "aws_appautoscaling_policy" "down" {
 
     step_adjustment {
       metric_interval_upper_bound = 0
-      scaling_adjustment          = -1
+      scaling_adjustment          = -2
     }
   }
 

--- a/terraform/modules/core/core.tf
+++ b/terraform/modules/core/core.tf
@@ -453,6 +453,12 @@ resource "aws_autoscaling_group" "ecs-autoscaling-group" {
   ]
 
   depends_on = ["aws_vpc.vpc", "aws_launch_configuration.ecs-launch-configuration", "aws_security_group.default", "aws_security_group.ecs"]
+
+  # Requires commenting out if the `asg_desired_size` variable in .tfvars is changed
+  # in either direction.
+  lifecycle {
+    ignore_changes = ["desired_capacity"]
+  }
 }
 
 resource "aws_appautoscaling_target" "target" {

--- a/terraform/modules/core/core.tf
+++ b/terraform/modules/core/core.tf
@@ -400,12 +400,12 @@ resource "aws_autoscaling_policy" "ecs-autoscaling-down-policy" {
 resource "aws_cloudwatch_metric_alarm" "cluster-cpu-reservation-high" {
   alarm_name          = "${var.project_name}-${var.environment}-cluster-cpu-reservation-high"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "2"
+  evaluation_periods  = "1"
   metric_name         = "CPUReservation"
   namespace           = "AWS/ECS"
   period              = "60"
   statistic           = "Average"
-  threshold           = "70"
+  threshold           = "40"
 
   dimensions {
     ClusterName = "${var.ecs_cluster_name}"
@@ -418,12 +418,12 @@ resource "aws_cloudwatch_metric_alarm" "cluster-cpu-reservation-high" {
 resource "aws_cloudwatch_metric_alarm" "cluster-cpu-reservation-low" {
   alarm_name          = "${var.project_name}-${var.environment}-cluster-cpu-reservation-low"
   comparison_operator = "LessThanOrEqualToThreshold"
-  evaluation_periods  = "2"
+  evaluation_periods  = "5"
   metric_name         = "CPUReservation"
   namespace           = "AWS/ECS"
   period              = "60"
-  statistic           = "Minimum"
-  threshold           = "45"
+  statistic           = "Average"
+  threshold           = "35"
 
   dimensions {
     ClusterName = "${var.ecs_cluster_name}"

--- a/terraform/modules/core/core.tf
+++ b/terraform/modules/core/core.tf
@@ -514,12 +514,31 @@ resource "aws_appautoscaling_policy" "down" {
 resource "aws_cloudwatch_metric_alarm" "web-cpu-utilisation-high" {
   alarm_name          = "${var.project_name}-${var.environment}-web-cpu-utilisation-high"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "5"
+  evaluation_periods  = "2"
   metric_name         = "CPUUtilization"
   namespace           = "AWS/ECS"
   period              = "60"
   statistic           = "Average"
-  threshold           = "85"
+  threshold           = "30"
+
+  dimensions {
+    ClusterName = "${var.ecs_cluster_name}"
+    ServiceName = "${var.ecs_service_web_name}"
+  }
+
+  alarm_actions = ["${aws_appautoscaling_policy.up.arn}"]
+  ok_actions    = ["${aws_appautoscaling_policy.down.arn}"]
+}
+
+resource "aws_cloudwatch_metric_alarm" "web-memory-utilisation-high" {
+  alarm_name          = "${var.project_name}-${var.environment}-web-memory-utilisation-high"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "MemoryUtilization"
+  namespace           = "AWS/ECS"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = "80"
 
   dimensions {
     ClusterName = "${var.ecs_cluster_name}"

--- a/terraform/modules/core/core.tf
+++ b/terraform/modules/core/core.tf
@@ -397,8 +397,8 @@ resource "aws_autoscaling_policy" "ecs-autoscaling-down-policy" {
   metric_aggregation_type = "Minimum"
 }
 
-resource "aws_cloudwatch_metric_alarm" "average-reserved-cpu-high" {
-  alarm_name          = "${var.project_name}-${var.environment}-average-reserved-cpu-high"
+resource "aws_cloudwatch_metric_alarm" "cluster-cpu-reservation-high" {
+  alarm_name          = "${var.project_name}-${var.environment}-cluster-cpu-reservation-high"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "2"
   metric_name         = "CPUReservation"
@@ -415,8 +415,8 @@ resource "aws_cloudwatch_metric_alarm" "average-reserved-cpu-high" {
   alarm_actions     = ["${aws_autoscaling_policy.ecs-autoscaling-up-policy.arn}"]
 }
 
-resource "aws_cloudwatch_metric_alarm" "average-reserved-cpu-low" {
-  alarm_name          = "${var.project_name}-${var.environment}-minimum-reserved-cpu-low"
+resource "aws_cloudwatch_metric_alarm" "cluster-cpu-reservation-low" {
+  alarm_name          = "${var.project_name}-${var.environment}-cluster-cpu-reservation-low"
   comparison_operator = "LessThanOrEqualToThreshold"
   evaluation_periods  = "2"
   metric_name         = "CPUReservation"
@@ -505,8 +505,8 @@ resource "aws_appautoscaling_policy" "down" {
 }
 
 /* metric used for auto scale */
-resource "aws_cloudwatch_metric_alarm" "service_cpu_high" {
-  alarm_name          = "${var.project_name}-${var.environment}_web_cpu_utilization_high"
+resource "aws_cloudwatch_metric_alarm" "web-cpu-utilisation-high" {
+  alarm_name          = "${var.project_name}-${var.environment}-web-cpu-utilisation-high"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "5"
   metric_name         = "CPUUtilization"

--- a/terraform/modules/ecs/ecs.tf
+++ b/terraform/modules/ecs/ecs.tf
@@ -70,9 +70,7 @@ resource "aws_ecs_service" "logspout" {
 
   deployment_minimum_healthy_percent = 50
 
-  placement_constraints {
-    type = "distinctInstance"
-  }
+  scheduling_strategy = "DAEMON"
 
   lifecycle {
     ignore_changes = ["desired_count"]

--- a/terraform/modules/ecs/ecs.tf
+++ b/terraform/modules/ecs/ecs.tf
@@ -47,6 +47,8 @@ resource "aws_ecs_service" "web" {
   desired_count   = "${var.ecs_service_web_task_count}"
 
   deployment_minimum_healthy_percent = 50
+  deployment_maximum_percent = 100
+
   health_check_grace_period_seconds  = 30
 
   load_balancer {


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/ecGy8swS

## Changes in this PR:

Before this change a conceivable amount of concurrent requests to the home page starts to take 5-8 seconds, with searches and API requests introducing 503 responses. This has has become an issue as we have many more job listings on the service, a fair bit more traffic (with much more expected soon) arriving compared to 6 months ago and not having enough caching in place.

On Edge (which has parity with Production) I have tested the request times and AWS resources being used in the following scenarios:

1. normal usage ✅
2. sudden load increase ✅
3. persistent load increase ✅
4. persistent load increase during a deployment ✅

My strategy is to be more generous in scaling up the web services quickly and scale back down slowly. I understand that to start with we might be spinning up more instances and containers than we need if the thresholds are slightly out but I believe it's better to have more than we need and tweak it down later than to have not enough, which is the current problem.

## Next steps:

- [x] Terraform deployment required?
