### PR TITLE
[725] POST, DELETE requests continue to work with 403 errors from Clo…

### DIFF
--- a/terraform/modules/cloudfront/cloudfront.tf
+++ b/terraform/modules/cloudfront/cloudfront.tf
@@ -40,16 +40,25 @@ resource "aws_cloudfront_distribution" "default" {
 
     forwarded_values {
       query_string = true
-      headers      = ["*"]
+      headers      = [
+        "Host",
+        "Authorization",
+        "Origin",
+        "Referer",
+        "Accept",
+        "Accept-Charset",
+        "Accept-DateTime",
+        "Accept-Encoding",
+        "Accept-Language"
+      ]
 
       cookies {
         forward = "all"
       }
     }
 
-    min_ttl     = 0
-    default_ttl = 5
-    max_ttl     = 86400
+    # The absense of `ttl` configuration here means caching is deferred to the origin
+    # https://angristan.xyz/terraform-enable-origin-cache-headers-aws-cloudfront/
 
     viewer_protocol_policy = "redirect-to-https"
   }
@@ -118,28 +127,6 @@ resource "aws_cloudfront_distribution" "default" {
     min_ttl     = 900
     default_ttl = 3600
     max_ttl     = 86400
-
-    viewer_protocol_policy = "redirect-to-https"
-  }
-
-  ordered_cache_behavior {
-    allowed_methods  = ["GET", "HEAD"]
-    cached_methods   = ["GET", "HEAD"]
-    target_origin_id = "${var.project_name}-${var.environment}-default-origin"
-
-    path_pattern = "/*"
-
-    forwarded_values = {
-      query_string = true
-      headers      = ["Host", "Origin", "Authorization"]
-
-      cookies {
-        forward = "all"
-      }
-    }
-
-    # The absense of `ttl` configuration here means caching is deferred to the origin
-    # https://angristan.xyz/terraform-enable-origin-cache-headers-aws-cloudfront/
 
     viewer_protocol_policy = "redirect-to-https"
   }


### PR DESCRIPTION
…udfront

## Trello card URL:
https://trello.com/c/ecGy8swS

## Changes in this PR:

* Before this change trying to sign in or create a job listing were met with an unsettled cloud front error:
```
The request could not be satisfied.
This distribution is not configured to allow the HTTP request method that was used for this request. The distribution supports only cachable requests.
Generated by cloudfront (CloudFront)
Request ID: ZrAJUCiNfTwNUV0iFM398CaryU2CnS-ZP7NIZG5wV9dvAxNvuIoTjw==
```
* Default cache behaviour now respects cache-control headers instead of a different cache_behaviour block in Terraform. The hope was that request methods that did not match eg. POST would fall down the order to the default cache behaviour - apparently not!
* To make this change CloudFront does not allow all headers to be send, so we have to add ‘all’ the headers it used to allow as a white list for this change to work.
* There is a limit on how many headers that we can forward through Cloudfront when declaring it manually (this feels wrong) but these were the ones I chose to drop since they appear specific to Cloudfront and are unlikely to affect the app:
```
        "CloudFront-Forwarded-Proto",
        "CloudFront-Is-Desktop-Viewer",
        "CloudFront-Is-Mobile-Viewer",
        "CloudFront-Is-SmartTV-Viewer",
        "CloudFront-Is-Tablet-Viewer",
        "CloudFront-Viewer-Country",
```

## Screenshots of UI changes:

### Before
![screenshot 2019-02-21 at 18 02 45](https://user-images.githubusercontent.com/912473/53191120-e917db00-3602-11e9-8d5c-fa094f4cd766.png)

## Next steps:

- [x] Terraform deployment required?
