### PR TITLE
Update fake course method from deprecation warning

### DIFF
--- a/spec/factories/subjects.rb
+++ b/spec/factories/subjects.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :subject do
-    name { Faker::Educator.course }
+    name { Faker::Educator.course_name }
     initialize_with { Subject.find_or_create_by(name: name) }
   end
 end


### PR DESCRIPTION
```
NOTE: Faker::Educator.course is deprecated; use course_name instead. It will be removed on or after 2018-10-01.
```
