### PR TITLE
Feature/714 privacy policy update

### DIFF
--- a/app/views/pages/privacy-policy.html.haml
+++ b/app/views/pages/privacy-policy.html.haml
@@ -54,7 +54,7 @@
 
     %h2.govuk-heading-m=t('static_pages.privacy_policy.withdrawal_of_consent.title')
     %p=t('static_pages.privacy_policy.withdrawal_of_consent.line_1', mailto: mail_to(t('help.email'), t('help.email'), class: 'govuk-link')).html_safe
-    %p=t('static_pages.privacy_policy.withdrawal_of_consent.line_2')
+    %p=t('static_pages.privacy_policy.withdrawal_of_consent.line_2', ico_url: link_to(t('static_pages.privacy_policy.withdrawal_of_consent.ico'), 'https://ico.org.uk/concerns/', target: '_blank', class: 'govuk-link')).html_safe
 
     %h2.govuk-heading-m=t('static_pages.privacy_policy.last_updated.title')
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -385,26 +385,30 @@ en:
       title: 'Privacy Notice: Teaching Vacancies'
       who_we_are:
         title: Who we are
-        about: This work is being carried out by Department for Education (DfE) Digital, which is a part of DfE. DfE engages the private company dxw to help improve and provide the service. For the purpose of data protection legislation, the DfE is the data controller for the personal data processed as part of Teaching Vacancies. Teaching Vacancies is a free and optional service for schools to advertise teaching roles.
+        about: This work is being carried out by Department for Education (DfE) Digital, which is a part of DfE. DfE engages the private company dxw to help improve and provide the service. For the purpose of data protection legislation, the DfE is the data controller for the personal data processed as part of Teaching Vacancies. Teaching Vacancies is a free and optional service for schools to list teaching roles.
       when_we_collect:
         title: When we collect personal information
         about: 'We receive your personal data when you submit it:'
         list:
-          - when contacting us for support using the service or any other matters
+          - when contacting us for support using the service, to leave feedback or for any other matters
           - as a headteacher or other authorised person at a school when selecting which hiring staff can create Teaching Vacancies accounts
           - as hiring staff in order to create a Teaching Vacancies account
           - as a contact person for a job that has been listed on Teaching Vacancies
+          - as a jobseeker signing up to emailed job alerts
       what_we_collect:
         title: What personal information we will collect
         about: 'We will collect:'
         list:
           - your name, email and (if applicable) your phone number when you contact us
+          - your email address when you sign up for a job alert
+          - your email address if you include it with feedback to us on the service or agree to be contacted for user research purposes
           - email addresses that are shared with us by schools for the purposes of creating a Teaching Vacancies account and posting jobs
           - personal information such as the name and email of a contact person at your school, if you choose to share this in a job listing you post to Teaching Vacancies
       how_we_use:
         title: How we will use your information
         text:
           - If you contact us, DfE and (where applicable) dxw will use your name and contact information for the purpose of responding to you and providing support. We will not share this information with any other parties.
+          - If you sign up for a job alert your email address will be used exclusively for the purpose of sending you an email when a job meeting your chosen search criteria is published to the service.
           - To list jobs on the service, hiring staff at schools need a Teaching Vacancies account, which requires them to supply their name and email address. Names and email addresses shared with us for this purpose are not shared by us with other parties.
           - Information published in job listings may be used by third party job listing sites that use our job listing data via an application programming interface (API), as described in our Terms and Conditions. We are not responsible for how a third party handles any personal information you choose to include in a job listing.
       why_its_lawful:
@@ -413,12 +417,12 @@ en:
       who_we_make_available_to:
         title: Who we will make your personal data available to
         line_1: We sometimes need to make personal data available to other organisations. These might include contracted partners (who we have employed to process your personal data on our behalf) and/or other organisations (with whom we need to share your personal data for specific purposes).
-        line_2: Where we need to share your personal data with others, we ensure that this data sharing complies with data protection legislation. We share specific types of personal data with dxw, who have been contracted by DfE to manage the delivery of the digital service. If you represent a school and are publishing a job listing through Teaching Vacancies we share your email with #{link_to('Microsoft','https://privacy.microsoft.com/en-us/privacystatement', class: 'govuk-link')} solely for the purpose of enabling sign-in to the publishing environment.
+        line_2: Where we need to share your personal data with others, we ensure that this data sharing complies with data protection legislation. We share specific types of personal data with dxw, who have been contracted by DfE to manage the delivery of the digital service.
         line_3: 'The firm dxw uses your data:'
         list:
           - for user research that informs development of the service, where you have shared your name, email address and/or phone number for this purpose
           - 'for security purposes: dxw collects part of the IP addresses of people visiting the Teaching Vacancies website (for example, if we were receiving continuous direct denial of service attacks from an IP address range then we could block it)'
-          - 'to enable users to use the service and receive updates: dxw collects the emails of those publishing job listings on Teaching Vacancies'
+          - 'to enable users to use the service and receive updates: dxw collects the emails of those publishing job listings on Teaching Vacancies and those signing up to job alerts'
       how_long:
         title: How long we will keep your personal data
         text:
@@ -431,7 +435,7 @@ en:
         list:
           - to ask us for access to information about you that we hold
           - to have your personal data rectified, if it is inaccurate or incomplete
-          - to ask us to delete your personal data where there is no compelling reason for its continued processing
+          - to ask us to delete your personal data unless there is a legal reason to continue to store and process it
           - to restrict our processing of your personal data (i.e. permitting its storage but no further processing)
           - to object to direct marketing (including profiling) and processing for the purposes of scientific/historical research and statistics
           - not to be subject to decisions based purely on automated processing where it produces a legal or similarly significant effect on you
@@ -442,10 +446,11 @@ en:
       withdrawal_of_consent:
         title: Withdrawal of consent and the right to lodge a complaint
         line_1: Where we are processing your personal data with your consent, you have the right to withdraw that consent. If you change your mind, or you are unhappy with our use of your personal data, please let us know by emailing %{mailto}.
-        line_2: You also have the right to raise any concerns with the Information Commissioner’s Office (ICO).
+        line_2: You also have the right to raise any concerns with the %{ico_url}.
+        ico: Information Commissioner’s Office (ICO)
       last_updated:
         title: Last updated
-        line_1: We may need to update this privacy notice periodically so we recommend that you revisit this information from time to time. This version was last updated on 20 September 2018.
+        line_1: We may need to update this privacy notice periodically so we recommend that you revisit this information from time to time. This version was last updated on 25 February 2019.
     terms_and_conditions:
       title: Terms and Conditions
       all_users:

--- a/spec/features/support_links_spec.rb
+++ b/spec/features/support_links_spec.rb
@@ -15,12 +15,7 @@ RSpec.feature 'A visitor to the website can access the support links' do
     click_on 'Privacy policy'
 
     expect(page).to have_content('Privacy Notice: Teaching Vacancies')
-    expect(page).to have_content('This work is being carried out by Department for Education (DfE) Digital, ' \
-                                 'which is a part of DfE. DfE engages the private company dxw to help improve ' \
-                                 'and provide the service. For the purpose of data protection legislation, ' \
-                                 'the DfE is the data controller for the personal data processed as part of ' \
-                                 'Teaching Vacancies. Teaching Vacancies is a free and optional service for schools ' \
-                                 'to list teaching roles.')
+    expect(page).to have_content(I18n.t('static_pages.privacy_policy.who_we_are.about'))
   end
 
   scenario 'the terms and conditions' do

--- a/spec/features/support_links_spec.rb
+++ b/spec/features/support_links_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature 'A visitor to the website can access the support links' do
                                  'and provide the service. For the purpose of data protection legislation, ' \
                                  'the DfE is the data controller for the personal data processed as part of ' \
                                  'Teaching Vacancies. Teaching Vacancies is a free and optional service for schools ' \
-                                 'to advertise teaching roles.')
+                                 'to list teaching roles.')
   end
 
   scenario 'the terms and conditions' do


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/j7CDQ812/714-privacy-policy-update-text-of-when-we-collect-your-data-to-cover-jobseekers-who-sign-up-for-alerts

## Changes in this PR:
- Content changes based on Michael's document: https://docs.google.com/document/d/1urpSULzlc-WL6YUcJlL_UT91Qg5tCa0ERFNZJU78tU4/edit?ts=5c73b3d5#
- Hard-coded checking of privacy notice content removed from the fragile test

## Screenshots of UI changes:

### Before (first fold only)
![screenshot 2019-02-25 at 13 36 16](https://user-images.githubusercontent.com/6421298/53407888-212d6e00-39b5-11e9-852a-0940a00ccddc.png)


### After (first fold only)
![screenshot 2019-02-25 at 13 35 37](https://user-images.githubusercontent.com/6421298/53407892-24285e80-39b5-11e9-92ed-3f5fb412b48a.png)

