### PR TITLE
Content update on zero jobs results page

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -61,9 +61,9 @@ en:
     job_count_plural: '%{count} jobs match your search.'
     no_jobs:
       - 'Expanding your search may give more results.'
-      - 'There may be few jobs if this isn’t a busy period in the teacher recruitment cycle. Also, as this new service rolls out to more areas of England, the number of jobs will grow.'
+      - 'There may be few jobs if this isn’t a busy period in the teacher recruitment cycle.'
     none_listed:
-      - 'This may be because this isn’t a busy period in the teacher recruitment cycle. Also, as this new service is rolled out to more areas of England, the number of jobs will grow. Check back regularly for new listings.'
+      - 'This may be because this isn’t a busy period in the teacher recruitment cycle.'
       - 'Schools have listed %{count} jobs but they have since expired.'
     job_title: 'Job title'
     benefits: 'Employee benefits'


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/Clf0fPyq/754-content-update-on-zero-jobs-results-page

## Changes in this PR:

* Removes reference to the rollout when no jobs are found, as the rollout is now nationwide

## Screenshots of UI changes:

### Before

![image](https://user-images.githubusercontent.com/109774/53410235-1c6bb880-39bb-11e9-9926-2cac441bb672.png)

### After

![image](https://user-images.githubusercontent.com/109774/53410253-2a213e00-39bb-11e9-8ed3-11dc97f3cf1d.png)