### PR TITLE
Add Bullet gem to test suite

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,6 +75,7 @@ group :development do
 end
 
 group :development, :test do
+  gem 'bullet'
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
   gem 'elasticsearch-extensions'
   gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,9 @@ GEM
     breasal (0.0.1)
     browser (2.5.3)
     builder (3.2.3)
+    bullet (5.9.0)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     byebug (10.0.2)
     capybara (3.12.0)
       addressable
@@ -454,6 +457,7 @@ GEM
     uglifier (4.1.20)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.4.1)
+    uniform_notifier (1.12.1)
     validate_email (0.1.6)
       activemodel (>= 3.0)
       mail (>= 2.2.5)
@@ -488,6 +492,7 @@ DEPENDENCIES
   addressable
   breasal (~> 0.0.1)
   browser
+  bullet
   byebug
   capybara (~> 3.12)
   coffee-rails

--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -15,7 +15,7 @@ class VacanciesController < ApplicationController
   def index
     @filters = VacancyFilters.new(search_params)
     @sort = VacancySort.new.update(column: sort_column, order: sort_order)
-    records = Vacancy.public_search(filters: @filters, sort: @sort).page(page_number).records
+    records = Vacancy.public_search(filters: @filters, sort: @sort).page(page_number).records(includes: [:school])
     audit_search_event(records, @filters) if @filters.any?
 
     @vacancies = VacanciesPresenter.new(records, searched: @filters.any?)


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/NoBFfbxV/753-add-bullet-gem-to-test-suite-and-ci-to-catch-future-n1-queries-incident-action

## Changes in this PR:

* adds Bullet gem to run alongside our test suite to catch any n+1 queries that could potentially slow the application down 
* fixes an n+1 query that was picked up by Bullet on the vacancies page