### PR TITLE
Increase build speed with bigger Code Build instance

### DIFF
--- a/terraform/modules/pipeline/pipeline.tf
+++ b/terraform/modules/pipeline/pipeline.tf
@@ -67,8 +67,8 @@ resource "aws_codebuild_project" "tvs_build" {
   }
 
   environment {
-    compute_type    = "BUILD_GENERAL1_SMALL"
-    image           = "aws/codebuild/docker:17.09.0"
+    compute_type    = "BUILD_GENERAL1_MEDIUM"
+    image           = "aws/codebuild/docker:18.09.0"
     type            = "LINUX_CONTAINER"
     privileged_mode = true
   }


### PR DESCRIPTION
* Use same major Docker version as used on environments, this has now auto updated to 18.x which we noticed during yesterdays deployment. The exact minor version isn't available on codebuild at the moment https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-available.html - it is better to have the major the same I think for parity however we should keep this in mind if unusual things happen
* Increase from a small to a medium
* Previous build timings are averaging about 7 minutes 37 seconds - this
takes a lot of our time when there’s lots of rebasing to do. After this
change they go down to 6 minutes 11 seconds.

## Next steps:

- [x] Terraform deployment required?

- [ ] New development configuration to be shared?
