### PR TITLE
Subscription emails are deleted after their last use

### DIFF
--- a/app/jobs/send_daily_alert_email_job.rb
+++ b/app/jobs/send_daily_alert_email_job.rb
@@ -2,7 +2,8 @@ class SendDailyAlertEmailJob < ApplicationJob
   queue_as :daily_alert_email
 
   def perform
-    Subscription.ongoing.each do |s|
+    Subscription.all.each do |s|
+      s.delete && next if s.expired?
       next if s.alert_run_today?
 
       vacancies = vacancies_for_subscription(s)

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -68,4 +68,8 @@ class Subscription < ApplicationRecord
   def create_alert_run
     alert_runs.find_or_create_by(run_on: Time.zone.today)
   end
+
+  def expired?
+    expires_on < Time.zone.today
+  end
 end

--- a/spec/jobs/send_daily_alert_email_job_spec.rb
+++ b/spec/jobs/send_daily_alert_email_job_spec.rb
@@ -14,29 +14,23 @@ RSpec.describe SendDailyAlertEmailJob, type: :job do
     expect { job }.to change(ActiveJob::Base.queue_adapter.enqueued_jobs, :size).by(1)
   end
 
-  context 'when a subscription is ongoing' do
+  context 'with vacancies' do
     before do
-      allow(Subscription).to receive(:ongoing) { [subscription] }
+      allow_any_instance_of(described_class).to receive(:vacancies_for_subscription) { vacancies }
     end
 
-    context 'with vacancies' do
-      before do
-        allow_any_instance_of(described_class).to receive(:vacancies_for_subscription) { vacancies }
-      end
+    it 'sends an email' do
+      expect(AlertMailer).to receive(:daily_alert).with(subscription.id, vacancies.pluck(:id)) { mail }
+      expect(mail).to receive(:deliver_later) { ActionMailer::DeliveryJob.new }
+      perform_enqueued_jobs { job }
+    end
 
-      it 'sends an email' do
-        expect(AlertMailer).to receive(:daily_alert).with(subscription.id, vacancies.pluck(:id)) { mail }
-        expect(mail).to receive(:deliver_later) { ActionMailer::DeliveryJob.new }
+    context 'when a run exists' do
+      let!(:run) { subscription.alert_runs.create(run_on: Time.zone.today) }
+
+      it 'does not send another email' do
+        expect(AlertMailer).to_not receive(:daily_alert)
         perform_enqueued_jobs { job }
-      end
-
-      context 'when a run exists' do
-        let!(:run) { subscription.alert_runs.create(run_on: Time.zone.today) }
-
-        it 'does not send another email' do
-          expect(AlertMailer).to_not receive(:daily_alert)
-          perform_enqueued_jobs { job }
-        end
       end
     end
 
@@ -57,17 +51,6 @@ RSpec.describe SendDailyAlertEmailJob, type: :job do
     end
   end
 
-  context 'when a subscription is not ongoing' do
-    before do
-      allow(Subscription).to receive(:ongoing) { [] }
-    end
-
-    it 'does not send an email' do
-      expect(AlertMailer).to_not receive(:daily_alert)
-      perform_enqueued_jobs { job }
-    end
-  end
-
   describe '#vacancies_for_subscription' do
     let(:job) { described_class.new }
 
@@ -78,6 +61,24 @@ RSpec.describe SendDailyAlertEmailJob, type: :job do
       expect(relation).to receive(:limit).with(500)
 
       job.vacancies_for_subscription(subscription)
+    end
+  end
+
+  context 'when a subscription is expired' do
+    let!(:subscription) { create(:daily_subscription, expires_on: Time.zone.today - 1.day) }
+
+    it 'deletes the subscription' do
+      expect { perform_enqueued_jobs { job } }.to change { Subscription.all.count }.by(-1)
+    end
+  end
+
+  context 'when a subscription is not expired' do
+    let!(:subscription) do
+      create(:daily_subscription, expires_on: Time.zone.today + 5.days, search_criteria: {}.to_json)
+    end
+
+    it 'does not delete the subscription' do
+      expect { perform_enqueued_jobs { job } }.to change { Subscription.all.count }.by(0)
     end
   end
 end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -204,4 +204,18 @@ RSpec.describe Subscription, type: :model do
       end
     end
   end
+
+  describe 'expired?' do
+    context 'when the expires_on date is in the future' do
+      let(:subscription) { build_stubbed(:daily_subscription, expires_on: Time.zone.today + 1.month) }
+
+      it { expect(subscription.expired?).to eq(false) }
+    end
+
+    context 'when the expires_on date is in the past' do
+      let(:subscription) { create(:daily_subscription, expires_on: Time.zone.today - 1.day) }
+
+      it { expect(subscription.expired?).to eq(true) }
+    end
+  end
 end


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/oL7yOC4I/728-431-email-alerts-subscription-emails-are-deleted-after-their-last-use

## Changes in this PR:

This PR uses the `SendDailyAlertEmailJob` job to run through all the subscriptions, and delete any that are expired before sending an alert. 

We may want to, in future, send a reminder email to users with subscriptions that are due to expire and allow them to continue to recieve emails after the initial three month period has expired, but this can come later.