### PR TITLE
Add terraform config to send daily email alerts

### DIFF
--- a/app/mailers/alert_mailer.rb
+++ b/app/mailers/alert_mailer.rb
@@ -3,7 +3,7 @@ class AlertMailer < ApplicationMailer
 
   def daily_alert(subscription_id, vacancy_ids)
     subscription = Subscription.find(subscription_id)
-    vacancies = Vacancy.where(id: vacancy_ids)
+    vacancies = Vacancy.where(id: vacancy_ids).order(:created_at)
 
     @email = subscription.email
     @subscription_reference = subscription.reference

--- a/terraform.tf
+++ b/terraform.tf
@@ -80,6 +80,9 @@ module "ecs" {
   import_schools_task_command  = "${var.import_schools_task_command}"
   import_schools_task_schedule = "${var.import_schools_task_schedule}"
 
+  send_job_alerts_daily_email_command  = "${var.send_job_alerts_daily_email_command}"
+  send_job_alerts_daily_email_schedule  = "${var.send_job_alerts_daily_email_schedule}"
+
   sessions_trim_task_command  = "${var.sessions_trim_task_command}"
   sessions_trim_task_schedule = "${var.sessions_trim_task_schedule}"
 

--- a/terraform/modules/ecs/ecs.tf
+++ b/terraform/modules/ecs/ecs.tf
@@ -170,6 +170,33 @@ data "template_file" "web_container_definition" {
   }
 }
 
+/* send_job_alerts_daily_email task definition*/
+data "template_file" "send_job_alerts_daily_email_container_definition" {
+  template = "${file(var.ecs_service_rake_container_definition_file_path)}"
+
+  vars {
+    image                    = "${aws_ecr_repository.default.repository_url}"
+    secret_key_base          = "${var.secret_key_base}"
+    project_name             = "${var.project_name}"
+    task_name                = "${var.ecs_service_web_task_name}_send_job_alerts_daily_email"
+    environment              = "${var.environment}"
+    rails_env                = "${var.rails_env}"
+    redis_url                = "${var.redis_url}"
+    redis_cache_url          = "${var.redis_cache_url}"
+    redis_queue_url          = "${var.redis_queue_url}"
+    region                   = "${var.region}"
+    log_group                = "${var.aws_cloudwatch_log_group_name}"
+    database_user            = "${var.rds_username}"
+    database_password        = "${var.rds_password}"
+    database_url             = "${var.rds_address}"
+    elastic_search_url       = "${var.es_address}"
+    aws_elasticsearch_region = "${var.aws_elasticsearch_region}"
+    aws_elasticsearch_key    = "${var.aws_elasticsearch_key}"
+    aws_elasticsearch_secret = "${var.aws_elasticsearch_secret}"
+    entrypoint               = "${jsonencode(var.send_job_alerts_daily_email_command)}"
+  }
+}
+
 /* import_schools task definition*/
 data "template_file" "import_schools_container_definition" {
   template = "${file(var.ecs_service_rake_container_definition_file_path)}"
@@ -574,6 +601,35 @@ resource "aws_cloudwatch_event_target" "performance_platform_submit_task_event" 
   ecs_target {
     task_count          = "1"
     task_definition_arn = "${aws_ecs_task_definition.performance_platform_submit_task.arn}"
+  }
+}
+
+resource "aws_ecs_task_definition" "send_job_alerts_daily_email_task" {
+  family                   = "${var.ecs_service_web_task_name}_send_job_alerts_daily_email_task"
+  container_definitions    = "${data.template_file.send_job_alerts_daily_email_container_definition.rendered}"
+  requires_compatibilities = ["EC2"]
+  network_mode             = "bridge"
+  cpu                      = "256"
+  memory                   = "512"
+  execution_role_arn       = "${aws_iam_role.ecs_execution_role.arn}"
+  task_role_arn            = "${aws_iam_role.ecs_execution_role.arn}"
+}
+
+resource "aws_cloudwatch_event_rule" "send_job_alerts_daily_email_task" {
+  name                = "${var.ecs_service_web_task_name}_send_job_alerts_daily_email_task"
+  description         = "Send daily job alerts emails"
+  schedule_expression = "${var.send_job_alerts_daily_email_schedule}"
+}
+
+resource "aws_cloudwatch_event_target" "send_job_alerts_daily_email_task_event" {
+  target_id = "${var.ecs_service_web_task_name}_send_job_alerts_daily_email_task"
+  rule      = "${aws_cloudwatch_event_rule.send_job_alerts_daily_email_task.name}"
+  arn       = "${aws_ecs_cluster.cluster.arn}"
+  role_arn  = "${aws_iam_role.scheduled_task_role.arn}"
+
+  ecs_target {
+    task_count          = "1"
+    task_definition_arn = "${aws_ecs_task_definition.send_job_alerts_daily_email_task.arn}"
   }
 }
 

--- a/terraform/modules/ecs/input.tf
+++ b/terraform/modules/ecs/input.tf
@@ -89,6 +89,10 @@ variable "import_schools_task_command" {
   type = "list"
 }
 
+variable "send_job_alerts_daily_email_command" {
+  type = "list"
+}
+
 variable "sessions_trim_task_command" {
   type = "list"
 }
@@ -108,6 +112,7 @@ variable "performance_platform_submit_all_task_command" {
 variable "sessions_trim_task_schedule" {}
 variable "performance_platform_submit_task_schedule" {}
 variable "import_schools_task_schedule" {}
+variable "send_job_alerts_daily_email_schedule" {}
 
 variable "vacancies_pageviews_refresh_cache_task_command" {
   type = "list"

--- a/variables.tf
+++ b/variables.tf
@@ -153,6 +153,15 @@ variable "ecs_service_worker_container_definition_file_path" {
   description = "Worker container definition"
   default     = "./terraform/container-definitions/worker_container_definition.json"
 }
+variable "send_job_alerts_daily_email_command" {
+  description = "The Entrypoint for the send_job_alerts_daily_email task"
+  default     = ["rake", "verbose", "daily_emails:send"]
+}
+
+variable "send_job_alerts_daily_email_schedule" {
+  description = "send_job_alerts_daily_email schedule expression - https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html"
+  default     = "cron(0 08 * * ? *)"
+}
 
 variable "import_schools_task_command" {
   description = "The Entrypoint for the import_schools task"


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/0izwIImL/759-add-terraform-config-to-send-daily-email-alerts

## Changes in this PR:

This runs the `rake daily_emails:send` command every day at 8am, which in turn queues the `SendDailyAlertEmailJob`, which checks all subscriptions for recent vacancies and queues up emails. The last piece of the puzzle I think!
