### PR TITLE
[663] Email alerts configure campaign URL

### DIFF
--- a/app/presenters/vacancy_presenter.rb
+++ b/app/presenters/vacancy_presenter.rb
@@ -4,8 +4,17 @@ class VacancyPresenter < BasePresenter
 
   delegate :total_pages, to: :model
 
-  def share_url
-    Rails.application.routes.url_helpers.job_url(model, protocol: 'https')
+  def share_url(source: nil, medium: nil, campaign: nil, content: nil)
+    params = { protocol: 'https' }
+    if source.present?
+      params.merge!(
+        utm_source: source,
+        utm_medium: medium,
+        utm_campaign: campaign,
+        utm_content: content,
+      )
+    end
+    Rails.application.routes.url_helpers.job_url(model, params)
   end
 
   def salary_range(del = 'to')

--- a/app/views/alert_mailer/daily_alert.text.haml
+++ b/app/views/alert_mailer/daily_alert.text.haml
@@ -4,7 +4,7 @@
 \---
 \
 - @vacancies.each do |vacancy|
-  = notify_link(vacancy.share_url, vacancy.job_title)
+  = notify_link(vacancy.share_url(source: 'subscription', medium: 'email', campaign: 'daily_alert'), vacancy.job_title).html_safe
   = vacancy.school_name
   = "Salary: #{vacancy.salary_range}"
   \---

--- a/spec/mailers/alert_mailer_spec.rb
+++ b/spec/mailers/alert_mailer_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe AlertMailer, type: :mailer do
 
     let(:mail) { described_class.daily_alert(subscription.id, vacancies.pluck(:id)) }
     let(:vacancies) { create_list(:vacancy, 1, :published) }
+    let(:campaign_params) { { source: 'subscription', medium: 'email', campaign: 'daily_alert' } }
 
     context 'with a single vacancy' do
       let(:vacancy_presenter) { VacancyPresenter.new(vacancies.first) }
@@ -31,7 +32,9 @@ RSpec.describe AlertMailer, type: :mailer do
         expect(body_lines[0]).to match(/# #{I18n.t('app.title')}/)
         expect(body_lines[1]).to match(/# #{I18n.t('alerts.email.daily.summary.one')}/)
         expect(body_lines[3]).to match(/---/)
-        expect(body_lines[5]).to match(/\[#{vacancy_presenter.job_title}\]\(#{vacancy_presenter.share_url}\)/)
+        expect(body_lines[5]).to eql(
+          "[#{vacancy_presenter.job_title}](#{vacancy_presenter.share_url(campaign_params)})\r\n"
+        )
         expect(body_lines[6]).to match(/#{vacancy_presenter.school_name}/)
         expect(body_lines[7]).to match(/Salary: #{vacancy_presenter.salary_range}/)
       end
@@ -47,12 +50,16 @@ RSpec.describe AlertMailer, type: :mailer do
         expect(mail.to).to eq([subscription.email])
 
         expect(body_lines[5]).to match(/\[#{first_vacancy_presenter.job_title}\]/)
-        expect(body_lines[5]).to match(/\(#{first_vacancy_presenter.share_url}\)/)
+        expect(body_lines[5]).to eql(
+          "[#{first_vacancy_presenter.job_title}](#{first_vacancy_presenter.share_url(campaign_params)})\r\n"
+        )
         expect(body_lines[6]).to match(/#{first_vacancy_presenter.school_name}/)
         expect(body_lines[7]).to match(/Salary: #{first_vacancy_presenter.salary_range}/)
 
         expect(body_lines[9]).to match(/\[#{second_vacancy_presenter.job_title}\]/)
-        expect(body_lines[9]).to match(/\(#{second_vacancy_presenter.share_url}\)/)
+        expect(body_lines[9]).to eql(
+          "[#{second_vacancy_presenter.job_title}](#{second_vacancy_presenter.share_url(campaign_params)})\r\n"
+        )
         expect(body_lines[10]).to match(/#{second_vacancy_presenter.school_name}/)
         expect(body_lines[11]).to match(/Salary: #{second_vacancy_presenter.salary_range}/)
       end

--- a/spec/presenters/vacancy_presenter_spec.rb
+++ b/spec/presenters/vacancy_presenter_spec.rb
@@ -122,6 +122,14 @@ RSpec.describe VacancyPresenter do
       expected_url = URI('localhost:3000/jobs/pe-teacher')
       expect(vacancy.share_url).to match(expected_url.to_s)
     end
+
+    context 'when campaign parameters are passed' do
+      it 'builds the campaign URL' do
+        vacancy = VacancyPresenter.new(create(:vacancy, job_title: 'PE Teacher'))
+        expected_campaign_url = URI('https://localhost:3000/jobs/pe-teacher?utm_medium=dance&utm_source=subscription')
+        expect(vacancy.share_url(source: 'subscription', medium: 'dance')).to match(expected_campaign_url.to_s)
+      end
+    end
   end
 
   describe '#to_row' do


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/I9BAMe5k/

## Changes in this PR:

- Allows the `VacancyPresenter#share_url` to build optional Google Analytics campaign parameters
- Only adds the campaign parameters if `source` is set as that's the only required one.


