### PR TITLE
[757] Don’t build dev and test gems into staging envs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,10 +45,10 @@ RUN gem install bundler
 # bundle ruby gems based on the current environment, default to production
 RUN echo $RAILS_ENV
 RUN \
-  if [ "$RAILS_ENV" = "production" ]; then \
-    bundle install --without development test --retry 10; \
-  else \
+  if [ "$RAILS_ENV" = "development" ] || [ "$RAILS_ENV" = "test" ]; then \
     bundle install --retry 10; \
+  else \
+    bundle install --without development test --retry 10; \
   fi
 
 COPY . $INSTALL_PATH


### PR DESCRIPTION
## Trello card URL:
In the investigation of https://trello.com/c/yeyEZCG7

## Changes in this PR:
* This increases parity with production which was discovered during an investigation into high web container memory usage. I noticed spring was running all over Edge with 4 servers and 8 clients, all using 4% of the disk. The way the Dockerfile works is that if it has a RAILS_ENV of edge, it bundles all the groups. This includes Spring, which is then loaded when bin/rails is called by `rails s` which is needed in development and test only. Switch the logic to whitelist the 2 known occasions when we DO want all the gems, this makes the code less fragile to new environments being created

## Before
Edge
<img width="1311" alt="screenshot 2019-02-28 at 11 46 38" src="https://user-images.githubusercontent.com/912473/53584015-9d24e300-3b7a-11e9-834b-814f75f8af9e.png">
