### PR TITLE
[757] ElasticSearch performance increase when only returning the first 10 results

### DIFF
--- a/app/services/elastic_search_finder.rb
+++ b/app/services/elastic_search_finder.rb
@@ -2,6 +2,10 @@ require 'elasticsearch'
 
 class ElasticSearchFinder
   def call(query, sort)
-    Vacancy.__elasticsearch__.search(size: 1000, query: query, sort: sort)
+    Vacancy.__elasticsearch__.search(size: size, query: query, sort: sort)
+  end
+
+  def size
+    Vacancy.default_per_page
   end
 end

--- a/spec/services/elastic_search_finder_spec.rb
+++ b/spec/services/elastic_search_finder_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+RSpec.describe ElasticSearchFinder do
+  describe '#call' do
+    it 'searches elasticsearch and asks for the default pagination amount' do
+      expect(Vacancy).to receive_message_chain(:__elasticsearch__, :search)
+        .with(a_hash_including(size: Vacancy.default_per_page))
+      described_class.new.call({}, {})
+    end
+
+    it 'searches elasticsearch with the provided query and sort params' do
+      expect(Vacancy).to receive_message_chain(:__elasticsearch__, :search)
+        .with(a_hash_including(query: {}, sort: {}))
+      described_class.new.call({}, {})
+    end
+  end
+end


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/yeyEZCG7

## Changes in this PR:
* The size parameter allows you to configure the maximum amount of hits to be returned: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-from-size.html
* This significantly improves response times as less is going over the wire and I presume ES is allowed to be more efficient
* No specific reason as to why this was first set to 1000 so I don’t believe I’m going to fall into an old trap

## Screenshots of UI changes:

### Before
with 800 jobs
before 899ms

### After
with 800 jobs
after 429ms
