### PR TITLE
Remove `rails_max_threads` variable from Terraform after bad rebase

### DIFF
--- a/terraform/modules/ecs/ecs.tf
+++ b/terraform/modules/ecs/ecs.tf
@@ -180,7 +180,6 @@ data "template_file" "import_schools_container_definition" {
     task_name                = "${var.ecs_service_web_task_name}_import_schools"
     environment              = "${var.environment}"
     rails_env                = "${var.rails_env}"
-    rails_max_threads        = "${var.rails_max_threads}"
     redis_url                = "${var.redis_url}"
     redis_cache_url          = "${var.redis_cache_url}"
     redis_queue_url          = "${var.redis_queue_url}"


### PR DESCRIPTION
## Changes in this PR:
 * This managed to get through in a bad rebase, which then was missed at code review. Whilst this code is likely to coming in soon, it is not worth blocking the deployment pipeline for. https://github.com/dxw/teacher-vacancy-service/pull/773
