### PR TITLE
(fix) SpreadsheetWriter#last_row now calls correct way of returning row

### DIFF
--- a/lib/spreadsheet_writer.rb
+++ b/lib/spreadsheet_writer.rb
@@ -26,7 +26,7 @@ module Spreadsheet
     def last_row
       return nil if worksheet.num_rows <= 1
 
-      worksheet[worksheet.num_rows - 1]
+      worksheet.rows[worksheet.num_rows - 1]
     end
 
     private

--- a/spec/lib/spreadsheet_writer_spec.rb
+++ b/spec/lib/spreadsheet_writer_spec.rb
@@ -123,14 +123,14 @@ RSpec.describe 'Spreadsheet::Writer' do
 
   describe '#last_row' do
     let(:data) { [['foo', 'bar'], ['fizz', 'buzz']] }
-    let(:worksheet) { double(num_rows: 2, save: nil) }
+    let(:worksheet) { double(num_rows: 2, save: nil, rows: double) }
     let(:spreadsheet) { double(worksheets: [worksheet]) }
     let(:row) { Spreadsheet::Writer.new(:spreadsheet_id).last_row }
 
     before do
       allow(GoogleDrive::Session).to receive(:from_service_account_key).and_return(session)
       allow(session).to receive(:spreadsheet_by_key).and_return(spreadsheet)
-      allow(worksheet).to receive(:[]) { |arg| data[arg] }
+      allow(worksheet.rows).to receive(:[]) { |arg| data[arg] }
     end
 
     it 'gets the last row' do


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/BedHMPme/730-data-on-published-jobs-should-be-downloadable-rather-than-sent-to-a-google-sheet

## Changes in this PR:

Previously we were calling the `[]` method on the worksheet which returns a specific cell, therefore requires a row and a column (either two integers or string eg. 'A2')

We need to call the worksheet's `rows` method in order to return an array of rows. Then our `#last_row` method will work as expected.