### PR TITLE
Fixes the published vacancy Google Sheet auditor

### DIFF
--- a/app/jobs/audit_published_vacancy_job.rb
+++ b/app/jobs/audit_published_vacancy_job.rb
@@ -1,4 +1,6 @@
 class AuditPublishedVacancyJob < ApplicationJob
+  queue_as :audit_published_vacancy
+
   def perform(vacancy_id)
     vacancy = Vacancy.find(vacancy_id)
     row = VacancyPresenter.new(vacancy).to_row

--- a/app/models/audit_data.rb
+++ b/app/models/audit_data.rb
@@ -11,6 +11,6 @@ class AuditData < ApplicationRecord
   ]
 
   def to_row
-    data.values.unshift(created_at.to_s)
+    data.values.unshift(Time.zone.now.to_s)
   end
 end

--- a/app/presenters/vacancy_presenter.rb
+++ b/app/presenters/vacancy_presenter.rb
@@ -128,7 +128,7 @@ class VacancyPresenter < BasePresenter
     {
       id: id,
       slug: slug,
-      created_at: created_at,
+      created_at: created_at.to_s,
       status: status,
       publish_on: publish_on,
       expires_on: expires_on,

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -4,6 +4,7 @@
   - [ google_indexing, 2]
   - [ import_school_data, 1 ]
   - [ update_vacancy_spreadsheet, 1 ]
+  - [ audit_published_vacancy, 1 ]
   - [ audit_sign_in_event, 1 ]
   - [ audit_express_interest_event, 1 ]
   - [ audit_search_event, 1 ]
@@ -11,6 +12,8 @@
   - [ audit_toc_acceptance_event, 1 ]
   - [ audit_spreadsheet, 1 ]
 update_vacancy_spreadsheet:
+  :concurrency: 1
+audit_published_vacancy:
   :concurrency: 1
 audit_sign_in_event:
   :concurrency: 1

--- a/spec/jobs/audit_published_vacancy_job_spec.rb
+++ b/spec/jobs/audit_published_vacancy_job_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe AuditPublishedVacancyJob, type: :job do
   end
 
   it 'is in the default queue' do
-    expect(job.queue_name).to eq('default')
+    expect(job.queue_name).to eq('audit_published_vacancy')
   end
 
   it 'creates an audit record' do

--- a/spec/lib/add_audit_data_spec.rb
+++ b/spec/lib/add_audit_data_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe AddAuditData do
     end
 
     it 'adds all the data to the spreadsheet' do
-      data = (existing_data + new_data).map { |d| d.data.values.unshift(d.created_at.to_s) }
+      data = (existing_data + new_data).map { |d| d.data.values.unshift(Time.zone.now.to_s) }
       expect(worksheet).to receive(:append_rows).with(data)
       subject.run!
     end

--- a/spec/models/audit_data_spec.rb
+++ b/spec/models/audit_data_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe AuditData, type: :model do
     let(:row) { audit_data.to_row }
 
     it 'returns a row' do
-      expect(row).to eq([audit_data.created_at.to_s, 'data'])
+      expect(row).to eq([Time.zone.now.to_s, 'data'])
     end
   end
 end


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/BedHMPme/730-data-on-published-jobs-should-be-downloadable-rather-than-sent-to-a-google-sheet

## Changes in this PR:

- We don't have a `default` queue so these jobs are never getting picked up by Sidekiq. By following convention for the rest of the project we give this job its own queue.
- First column in spreadsheet should be current time job ran at. We were getting duplicate audit records when setting it to be the record's `created_at`
- Convert `created_at` from audit record to string when saving to JSON. This allows the date to be formatted correctly when it is saved in Google Sheets
