### PR TITLE
[764] Fix vacancy publish_on validation

### DIFF
--- a/app/controllers/hiring_staff/vacancies/copy_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/copy_controller.rb
@@ -11,7 +11,8 @@ class HiringStaff::Vacancies::CopyController < HiringStaff::Vacancies::Applicati
     @copy_form = CopyVacancyForm.new(vacancy: old_vacancy)
 
     proposed_vacancy = @copy_form.apply_changes!(copy_form_params)
-    if proposed_vacancy.valid?
+
+    if proposed_vacancy.valid? && @copy_form.valid?
       new_vacancy = CopyVacancy.new(proposed_vacancy: proposed_vacancy).call
       Auditor::Audit.new(new_vacancy, 'vacancy.copy', current_session_id).log
       redirect_to review_path(new_vacancy)

--- a/app/form_models/application_details_form.rb
+++ b/app/form_models/application_details_form.rb
@@ -1,7 +1,7 @@
 class ApplicationDetailsForm < VacancyForm
   delegate :expires_on_dd, :expires_on_mm, :expires_on_yyyy,
            :publish_on_dd, :publish_on_mm, :publish_on_yyyy,
-           :published?, :status, to: :vacancy
+           :published?, :status, :publish_on_changed?, to: :vacancy
 
   include VacancyApplicationDetailValidations
 

--- a/app/form_models/copy_vacancy_form.rb
+++ b/app/form_models/copy_vacancy_form.rb
@@ -18,6 +18,8 @@ class CopyVacancyForm < VacancyForm
   def initialize(vacancy:)
     self.vacancy = vacancy
     self.job_title = vacancy.job_title
+
+    self.publish_on = nil if vacancy.publish_on.past?
     reset_date_fields if vacancy.expires_on.past?
   end
 

--- a/app/form_models/copy_vacancy_form.rb
+++ b/app/form_models/copy_vacancy_form.rb
@@ -7,6 +7,14 @@ class CopyVacancyForm < VacancyForm
            :publish_on_dd, :publish_on_mm, :publish_on_yyyy,
            :errors, to: :vacancy
 
+  validate :publish_on_must_not_be_in_the_past
+
+  def publish_on_must_not_be_in_the_past
+    return unless publish_on.past?
+
+    errors.add(:publish_on, I18n.t('activerecord.errors.models.vacancy.attributes.publish_on.before_today'))
+  end
+
   def initialize(vacancy:)
     self.vacancy = vacancy
     self.job_title = vacancy.job_title

--- a/app/models/concerns/vacancy_application_detail_validations.rb
+++ b/app/models/concerns/vacancy_application_detail_validations.rb
@@ -8,11 +8,11 @@ module VacancyApplicationDetailValidations
     validates :application_link, url: true, if: proc { |v| v.application_link.present? }
 
     validates :publish_on, presence: true, if: proc { |v| !v.published? }
-    validate :validity_of_publish_on, :validity_of_expires_on
+    validate :publish_on_must_not_be_in_the_past, :validity_of_expires_on
     validates_with DateFormatValidator, fields: %i[publish_on expires_on]
   end
 
-  def validity_of_publish_on
+  def publish_on_must_not_be_in_the_past
     errors.add(:publish_on, publish_on_before_today_error) if publish_on_in_past? && publish_on_changed?
   end
 

--- a/app/models/concerns/vacancy_application_detail_validations.rb
+++ b/app/models/concerns/vacancy_application_detail_validations.rb
@@ -13,7 +13,7 @@ module VacancyApplicationDetailValidations
   end
 
   def validity_of_publish_on
-    errors.add(:publish_on, publish_on_before_today_error) if publish_on_in_past?
+    errors.add(:publish_on, publish_on_before_today_error) if publish_on_in_past? && publish_on_changed?
   end
 
   def validity_of_expires_on

--- a/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
@@ -513,18 +513,6 @@ RSpec.feature 'Creating a vacancy' do
         expect(page).to have_content("Date posted #{format_date(vacancy.publish_on)}")
       end
 
-      scenario 'can not be published at a date in the past' do
-        vacancy = create(:vacancy, :draft, school_id: school.id)
-        vacancy.assign_attributes(publish_on: Time.zone.yesterday)
-        vacancy.save(validate: false)
-
-        visit school_job_review_path(vacancy.id)
-        click_on 'Confirm and submit job'
-
-        expect(page).to have_content(I18n.t('errors.jobs.unable_to_publish'))
-        expect(page).to have_content(I18n.t('activerecord.errors.models.vacancy.attributes.publish_on.before_today'))
-      end
-
       scenario 'displays the expiration date on the confirmation page' do
         vacancy = create(:vacancy, :draft, school_id: school.id)
         visit school_job_review_path(vacancy.id)

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -121,7 +121,7 @@ module VacancyHelpers
   end
 
   def skip_vacancy_publish_on_validation
-    allow_any_instance_of(Vacancy).to receive(:validity_of_publish_on).and_return(true)
+    allow_any_instance_of(Vacancy).to receive(:publish_on_must_not_be_in_the_past).and_return(true)
   end
 
   def vacancy_json_ld(vacancy)


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/W4yWwhbW/764-fix-vacancy-validation

## Changes in this PR:

### The problem:

Any published vacancy can't be modified internally (eg. by a worker). The validation for checking `publish_on` date isn't in the past always fails.

### The solution:

We only check if `publish_on` isn't in the past if the value has changed, this allows us to save vacancies internally. We use ActiveModel's dirty methods for checking if the value has changed.

The presents a problem on the copy a vacancy page where the user could leave the `publish_on` date in the past, therefore passing validation. To fix this we added another check for the `publish_on` date in the `CopyVacancyForm` and reset the `publish_on` date if it has past to help the user not run in to the error.
