### PR TITLE
[729] Only update vacancies that have page view increments

### DIFF
--- a/app/services/vacancy_page_view.rb
+++ b/app/services/vacancy_page_view.rb
@@ -8,6 +8,8 @@ class VacancyPageView
   end
 
   def persist!
+    return if @vacancy.page_view_counter.to_i.zero?
+
     @vacancy.total_pageviews = @vacancy.total_pageviews.to_i + @vacancy.page_view_counter.to_i
     @vacancy.total_pageviews_updated_at = Time.zone.now
     reset_counter if @vacancy.save

--- a/spec/services/vacancy_page_view_spec.rb
+++ b/spec/services/vacancy_page_view_spec.rb
@@ -65,5 +65,15 @@ RSpec.describe VacancyPageView do
         expect(page_view_counter).not_to have_received(:reset)
       end
     end
+
+    context 'when the page counter is 0' do
+      let(:page_view_counter) { spy(to_i: 0) }
+
+      it 'does not save the vacancy' do
+        vacancy_page_view.persist!
+
+        expect(vacancy).not_to have_received(:save)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/ZfIhptK0

## Changes in this PR:
* running this on Staging resulted in a single Vacancy update for every active listing which can be in the thousands, we need to optimise this to save on unnecessary resource use and logging storage
* avoid additional callbacks to elastic search to reindex for all records
## Screenshots of UI changes:

### Before
![screenshot 2019-03-08 at 09 43 30](https://user-images.githubusercontent.com/912473/54020842-acadb880-4186-11e9-8689-5b8154753c5b.png)

