### PR TITLE
(fix) Remove reference to recently removed REDIS_URL

### DIFF
--- a/terraform/modules/ecs/ecs.tf
+++ b/terraform/modules/ecs/ecs.tf
@@ -205,7 +205,6 @@ data "template_file" "update_spreadsheets_container_definition" {
     task_name                = "${var.ecs_service_web_task_name}_update_spreadsheets"
     environment              = "${var.environment}"
     rails_env                = "${var.rails_env}"
-    redis_url                = "${var.redis_url}"
     redis_cache_url          = "${var.redis_cache_url}"
     redis_queue_url          = "${var.redis_queue_url}"
     region                   = "${var.region}"


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/Z6Pe6Igm

## Changes in this PR:
Remove reference to recently removed REDIS_URL that was added.

- [x] Terraform deployment required?
