### PR TITLE
(768) Log the stored state and Accept header when the callback phase starts

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -10,7 +10,8 @@ module OmniAuth
       def callback_phase
         Rollbar.log(:info, 'A sign-in callback was started',
                     stored_state: session['omniauth.state'],
-                    accept_header: request.has_header?('Accept') ? request.get_header('Accept') : request.get_header('HTTP_ACCEPT'))
+                    accept_header: request.has_header?('Accept') ? request.get_header('Accept') : request.get_header('HTTP_ACCEPT'),
+                    time: Time.zone.now.strftime('%Y-%m-%d %H:%M:%S:%L'))
         error = request.params['error_reason'] || request.params['error']
         if error
           raise CallbackError.new(request.params['error'], request.params['error_description'] || request.params['error_reason'], request.params['error_uri'])

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -8,6 +8,9 @@ module OmniAuth
       # rubocop:disable Style/GuardClause
       # Please refer to this commit to read why this has been copied from: https://github.com/m0n9oose/omniauth_openid_connect/blob/master/lib/omniauth/strategies/openid_connect.rb
       def callback_phase
+        Rollbar.log(:info, 'A sign-in callback was started',
+                    stored_state: session['omniauth.state'],
+                    accept_header: request.has_header?('Accept') ? request.get_header('Accept') : request.get_header('HTTP_ACCEPT'))
         error = request.params['error_reason'] || request.params['error']
         if error
           raise CallbackError.new(request.params['error'], request.params['error_description'] || request.params['error_reason'], request.params['error_uri'])


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/stLxQgfi/768-investigate-intermittent-bug-stopping-hiring-staff-sign-in-on-specific-browsers-or-devices

## Changes in this PR:

- We're seeing a few occurrences of sign-in callback errors. To help us diagnose this we need to log the stored state as well as the state that comes back from DSI.
- From looking at the logs we can see multiple requests hitting our callback endpoint at the same time, the subsequent ones seem to have `*/*` as the value of the `Accept` header. This could be caused by erroneous software on the user's computer, it would be nice to see what values it can be when we see failures.
