### PR TITLE
(fix) Audit worksheet GIDs are now interpolated strings

### DIFF
--- a/terraform/container-definitions/web_container_definition.json
+++ b/terraform/container-definitions/web_container_definition.json
@@ -131,14 +131,6 @@
         "value": "${audit_spreadsheet_id}"
       },
       {
-        "name": "AUDIT_VACANCIES_WORKSHEET_GID",
-        "value": "${audit_vacancies_worksheet_gid}"
-      },
-      {
-        "name": "AUDIT_FEEDBACK_WORKSHEET_GID",
-        "value": "${audit_feedback_worksheet_gid}"
-      },
-      {
         "name": "DOMAIN",
         "value": "${domain}"
       },

--- a/terraform/container-definitions/web_container_definition.json
+++ b/terraform/container-definitions/web_container_definition.json
@@ -132,11 +132,11 @@
       },
       {
         "name": "AUDIT_VACANCIES_WORKSHEET_GID",
-        "value": "audit_vacancies_worksheet_gid"
+        "value": "${audit_vacancies_worksheet_gid}"
       },
       {
         "name": "AUDIT_FEEDBACK_WORKSHEET_GID",
-        "value": "audit_feedback_worksheet_gid"
+        "value": "${audit_feedback_worksheet_gid}"
       },
       {
         "name": "DOMAIN",

--- a/terraform/container-definitions/worker_container_definition.json
+++ b/terraform/container-definitions/worker_container_definition.json
@@ -98,7 +98,7 @@
       },
       {
         "name": "AUDIT_FEEDBACK_WORKSHEET_GID",
-        "value": "audit_feedback_worksheet_gid"
+        "value": "${audit_feedback_worksheet_gid}"
       },
       {
         "name": "GOOGLE_DRIVE_JSON_KEY",


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/MtL5EUEU/731-feedback-from-hiring-staff-should-be-downloadable-rather-than-sent-to-a-google-sheet

## Changes in this PR:

I noticed during the most recent `terraform plan` on staging that these values weren't getting passed in to the container definitions. This commit should fix that by making the strings interpolated so they are resolved when the container definition is generated.
