### PR TITLE
Redirect auth/failure to DSI login

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,7 @@ Rails.application.routes.draw do
            path: '/dfe/sessions',
            controller: 'hiring_staff/sign_in/dfe/sessions'
   get '/auth/dfe/callback', to: 'hiring_staff/sign_in/dfe/sessions#create'
+  get '/auth/failure', to: 'hiring_staff/sign_in/dfe/sessions#new'
 
   resource :terms_and_conditions, only: %i[show update], controller: 'hiring_staff/terms_and_conditions'
 


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/ikmTQ91m/769-fix-404-error-as-dsi-is-sometimes-redirecting-to-auth-failure-when-credentials-are-invalid

## Changes in this PR:

When users use the back button after logging in, DfE signin redirects the user to /auth/failure on our app, which returns a 404. This redirects that path to the `HiringStaff::IdentificationsController#create` action, which then in turn prompts the user to log in again.