### PR TITLE
(731) Allow feedback user to be nil

### DIFF
--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -9,7 +9,7 @@ class Feedback < ApplicationRecord
   def to_row
     [
       Time.zone.now.to_s,
-      user.oid,
+      user&.oid,
       vacancy.id,
       vacancy.school.urn,
       rating,

--- a/spec/factories/feedbacks.rb
+++ b/spec/factories/feedbacks.rb
@@ -4,5 +4,10 @@ FactoryBot.define do
     comment { 'Some feedback text' }
     vacancy
     user
+
+    trait :old_with_no_user do
+      to_create { |instance| instance.save(validate: false) }
+      user { nil }
+    end
   end
 end

--- a/spec/lib/add_feedback_to_spreadsheet_spec.rb
+++ b/spec/lib/add_feedback_to_spreadsheet_spec.rb
@@ -11,4 +11,9 @@ RSpec.describe AddFeedbackToSpreadsheet do
   subject { described_class.new }
 
   it_behaves_like 'ExportToSpreadsheet'
+
+  context 'with no user attached to the feedback' do
+    let!(:new_data) { create_list(:feedback, 3, :old_with_no_user) }
+    it_behaves_like 'ExportToSpreadsheet'
+  end
 end


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/MtL5EUEU/731-feedback-from-hiring-staff-should-be-downloadable-rather-than-sent-to-a-google-sheet

## Changes in this PR:

We only introduced the feedback->user relationship recently and if we want to backfill older feedback items on to Google Sheets we need to allow for `user` to be nil.
