### PR TITLE
[765] One off script to backfill vacancy data to google sheets

### DIFF
--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -6,4 +6,20 @@ namespace :data do
       UpdateSchoolsDataFromSourceJob.perform_later
     end
   end
+
+  desc 'Backfill AuditData for past vacancy.publish events'
+  namespace :backfill do
+    namespace :audit_data do
+      task vacancy_publishing: :environment do
+        PublicActivity::Activity.where(key: 'vacancy.publish').map do |audit|
+          vacancy = Vacancy.find(audit.trackable_id)
+
+          if AuditData.where("data->>'id' = ?", vacancy.id).count.zero?
+            row = VacancyPresenter.new(vacancy).to_row
+            AuditData.create(category: :vacancies, data: row)
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/lib/tasks/backfill_audit_data_for_published_jobs.rb
+++ b/spec/lib/tasks/backfill_audit_data_for_published_jobs.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+RSpec.describe 'rake data:backfill:audit_data:vacancy_publishing', type: :task do
+  before do
+    Timecop.freeze(Time.zone.local(2010))
+  end
+
+  after do
+    Timecop.return
+  end
+
+  it 'adds a new AuditData record for every vacancy.publish PublicActivity' do
+    school = create(:school)
+    vacancy = create(:vacancy, :published, school: school, flexible_working: false)
+    PublicActivity::Activity.create(key: 'vacancy.publish', trackable: vacancy)
+
+    task.execute
+
+    expect(AuditData.count).to eq(1)
+
+    last_audit = AuditData.last
+    expect(last_audit.category).to eql('vacancies')
+    expect(last_audit.data).to eql(
+      'created_at' => vacancy.created_at.to_s,
+      'ends_on' => vacancy.ends_on,
+      'expires_on' => vacancy.expires_on.strftime('%F'),
+      'flexible_working' => 'No',
+      'id' => vacancy.id,
+      'publish_on' => vacancy.publish_on.strftime('%F'),
+      'school_county' => school.county,
+      'school_urn' => school.urn,
+      'slug' => vacancy.slug,
+      'starts_on' => vacancy.starts_on,
+      'status' => vacancy.status,
+      'weekly_hours' => vacancy.weekly_hours
+    )
+  end
+
+  context 'when the task is called again' do
+    it 'does not add duplicate AuditData records' do
+      vacancy = create(:vacancy, :published)
+      PublicActivity::Activity.create(key: 'vacancy.publish', trackable: vacancy)
+
+      task.execute
+      expect(AuditData.count).to eq(1)
+      previous_audit_data_id = AuditData.last.id
+
+      task.execute
+      expect(AuditData.count).to eq(1)
+      latest_audit_data_id = AuditData.last.id
+      expect(latest_audit_data_id).to eql(previous_audit_data_id)
+    end
+  end
+
+  context 'when the once published vacancy is now in a trashed state' do
+    it 'adds the listing with the trashed status' do
+      vacancy = create(:vacancy, :trashed)
+      PublicActivity::Activity.create(key: 'vacancy.publish', trackable: vacancy)
+
+      task.execute
+
+      expect(AuditData.last.data).to include('status' => vacancy.status)
+    end
+  end
+end

--- a/terraform.tf
+++ b/terraform.tf
@@ -88,6 +88,8 @@ module "ecs" {
 
   reindex_vacancies_task_command = "${var.reindex_vacancies_task_command}"
 
+  backfill_audit_data_for_vacancy_publish_events = "${var.backfill_audit_data_for_vacancy_publish_events}"
+
   performance_platform_submit_task_command     = "${var.performance_platform_submit_task_command}"
   performance_platform_submit_task_schedule    = "${var.performance_platform_submit_task_schedule}"
   performance_platform_submit_all_task_command = "${var.performance_platform_submit_all_task_command}"

--- a/terraform/modules/ecs/ecs.tf
+++ b/terraform/modules/ecs/ecs.tf
@@ -272,6 +272,32 @@ data "template_file" "reindex_vacancies_container_definition" {
   }
 }
 
+/* backfill_audit_data_for_vacancy_publish_events_container_definition task definition*/
+data "template_file" "backfill_audit_data_for_vacancy_publish_events_container_definition" {
+  template = "${file(var.ecs_service_rake_container_definition_file_path)}"
+
+  vars {
+    image                    = "${aws_ecr_repository.default.repository_url}"
+    secret_key_base          = "${var.secret_key_base}"
+    project_name             = "${var.project_name}"
+    task_name                = "${var.ecs_service_web_task_name}_backfill_audit_data_for_vacancy_publish_events"
+    environment              = "${var.environment}"
+    rails_env                = "${var.rails_env}"
+    redis_cache_url          = "${var.redis_cache_url}"
+    redis_queue_url          = "${var.redis_queue_url}"
+    region                   = "${var.region}"
+    log_group                = "${var.aws_cloudwatch_log_group_name}"
+    database_user            = "${var.rds_username}"
+    database_password        = "${var.rds_password}"
+    database_url             = "${var.rds_address}"
+    elastic_search_url       = "${var.es_address}"
+    aws_elasticsearch_region = "${var.aws_elasticsearch_region}"
+    aws_elasticsearch_key    = "${var.aws_elasticsearch_key}"
+    aws_elasticsearch_secret = "${var.aws_elasticsearch_secret}"
+    entrypoint               = "${jsonencode(var.backfill_audit_data_for_vacancy_publish_events)}"
+  }
+}
+
 /* performance_platform_submit task definition*/
 data "template_file" "performance_platform_submit_container_definition" {
   template = "${file(var.performance_platform_rake_container_definition_file_path)}"
@@ -515,6 +541,17 @@ ECS ONE-OFF TASKS
 resource "aws_ecs_task_definition" "reindex_vacancies_task" {
   family                   = "${var.ecs_service_web_task_name}_reindex_vacancies_task"
   container_definitions    = "${data.template_file.reindex_vacancies_container_definition.rendered}"
+  requires_compatibilities = ["EC2"]
+  network_mode             = "bridge"
+  cpu                      = "256"
+  memory                   = "512"
+  execution_role_arn       = "${aws_iam_role.ecs_execution_role.arn}"
+  task_role_arn            = "${aws_iam_role.ecs_execution_role.arn}"
+}
+
+resource "aws_ecs_task_definition" "backfill_audit_data_for_vacancy_publish_events_task" {
+  family                   = "${var.ecs_service_web_task_name}_backfill_audit_data_for_vacancy_publish_events_task"
+  container_definitions    = "${data.template_file.backfill_audit_data_for_vacancy_publish_events_container_definition.rendered}"
   requires_compatibilities = ["EC2"]
   network_mode             = "bridge"
   cpu                      = "256"

--- a/terraform/modules/ecs/input.tf
+++ b/terraform/modules/ecs/input.tf
@@ -98,6 +98,10 @@ variable "reindex_vacancies_task_command" {
   type = "list"
 }
 
+variable "backfill_audit_data_for_vacancy_publish_events" {
+  type = "list"
+}
+
 variable "performance_platform_submit_task_command" {
   type = "list"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -189,6 +189,11 @@ variable "reindex_vacancies_task_command" {
   default     = ["rake", "verbose", "elasticsearch:vacancies:index"]
 }
 
+variable "backfill_audit_data_for_vacancy_publish_events" {
+  description = "The Entrypoint for the data:backfill:audit_data:vacancy_publishing task"
+  default     = ["rake", "verbose", "data:backfill:audit_data:vacancy_publishing"]
+}
+
 variable "performance_platform_submit_task_command" {
   description = "The Entrypoint for the performance_platform_submit task"
   default     = ["rake", "verbose", "performance_platform:submit"]


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/kkqTzeMb supporting recent changes https://trello.com/c/BedHMPme 

## Changes in this PR:
* Plan is to remove this after its use, however it doesn't matter if it needs to be run multiple times as it's idempotent
* We have to do `.strftime(‘%F’)` as at some point when this data is written into Postgres to_json is called. We can’t call that here for comparison as Ruby’s output is an escaped string: `"\"2010-01-21\""`
* task.invoke only works once per spec file, task.execute works multiple times: https://www.eliotsykes.com/test-rails-rake-tasks-with-rspec

## Screenshots of UI changes:

![Screenshot 2019-03-13 at 17 37 53](https://user-images.githubusercontent.com/912473/54301517-06631800-45b7-11e9-8735-1f4980baf4db.png)

## Next steps:

- [x] Terraform deployment required?
