### PR TITLE
(fix) add validations to vacancy form model

### DIFF
--- a/app/form_models/copy_vacancy_form.rb
+++ b/app/form_models/copy_vacancy_form.rb
@@ -7,10 +7,11 @@ class CopyVacancyForm < VacancyForm
            :publish_on_dd, :publish_on_mm, :publish_on_yyyy,
            :errors, to: :vacancy
 
+  validates_presence_of :publish_on
   validate :publish_on_must_not_be_in_the_past
 
   def publish_on_must_not_be_in_the_past
-    return unless publish_on.past?
+    return unless publish_on.present? && publish_on.past?
 
     errors.add(:publish_on, I18n.t('activerecord.errors.models.vacancy.attributes.publish_on.before_today'))
   end

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -48,12 +48,12 @@ module VacancyHelpers
     fill_in 'copy_vacancy_form[ends_on_dd]', with: vacancy.ends_on.day
     fill_in 'copy_vacancy_form[ends_on_mm]', with: vacancy.ends_on.strftime('%m')
     fill_in 'copy_vacancy_form[ends_on_yyyy]', with: vacancy.ends_on.year
-    fill_in 'copy_vacancy_form[expires_on_dd]', with: vacancy.expires_on.day
-    fill_in 'copy_vacancy_form[expires_on_mm]', with: vacancy.expires_on.strftime('%m')
-    fill_in 'copy_vacancy_form[expires_on_yyyy]', with: vacancy.expires_on.year
-    fill_in 'copy_vacancy_form[publish_on_dd]', with: vacancy.publish_on.day
-    fill_in 'copy_vacancy_form[publish_on_mm]', with: vacancy.publish_on.strftime('%m')
-    fill_in 'copy_vacancy_form[publish_on_yyyy]', with: vacancy.publish_on.year
+    fill_in 'copy_vacancy_form[expires_on_dd]', with: vacancy.expires_on&.day
+    fill_in 'copy_vacancy_form[expires_on_mm]', with: vacancy.expires_on&.strftime('%m')
+    fill_in 'copy_vacancy_form[expires_on_yyyy]', with: vacancy.expires_on&.year
+    fill_in 'copy_vacancy_form[publish_on_dd]', with: vacancy.publish_on&.day
+    fill_in 'copy_vacancy_form[publish_on_mm]', with: vacancy.publish_on&.strftime('%m')
+    fill_in 'copy_vacancy_form[publish_on_yyyy]', with: vacancy.publish_on&.year
   end
 
   def verify_all_vacancy_details(vacancy)


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/gbTNiXRm/789-bug-when-a-hiring-staff-copied-a-job

## Changes in this PR:

This adds a validation to make sure that `publish_on` is present when submitting a job copy. It's required anyway, but the form model validations get run before the model validations themselves, and the `publish_on_must_not_be_in_the_past` method assumes that `publish_on` is always present. 

I initially added some other validations to the form model, but then realised they weren't necessary as they were covered by the Vacancy model, but I think the tests are useful to have around anyway.