### PR TITLE
(fix) Add missing input variable for ECS terraform module

### DIFF
--- a/terraform/modules/ecs/input.tf
+++ b/terraform/modules/ecs/input.tf
@@ -60,6 +60,7 @@ variable "google_drive_json_key" {
 variable "audit_spreadsheet_id" {}
 variable "audit_vacancies_worksheet_gid" {}
 variable "audit_feedback_worksheet_gid" {}
+variable "audit_express_interest_worksheet_gid" {}
 
 variable "domain" {}
 variable "google_geocoding_api_key" {}


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/KHw00TmT/732-expressing-interest-by-job-seekers-should-be-downloadable-rather-than-sent-to-a-google-sheet

## Changes in this PR:

- Add missing input variable for ECS terraform module

## Next steps:

- [x] Terraform deployment required?

