### PR TITLE
(chore) Temporarily turn off audit search data Google Sheet job

### DIFF
--- a/app/jobs/audit_search_event_job.rb
+++ b/app/jobs/audit_search_event_job.rb
@@ -3,6 +3,7 @@ class AuditSearchEventJob < SpreadsheetWriterJob
   queue_as :audit_search_event
 
   def perform(data)
+    return if WORKSHEET_POSITION.present? # Temporarily turn off this auditing until we decide what to do with it
     return unless AUDIT_SPREADSHEET_ID
 
     write_row(data, WORKSHEET_POSITION)

--- a/spec/jobs/audit_search_event_job_spec.rb
+++ b/spec/jobs/audit_search_event_job_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe AuditSearchEventJob, type: :job do
   end
 
   it 'writes to the spreadsheet' do
+    pending 'Temporarily turn off this auditing until we decide what to do with it'
     stub_const('AUDIT_SPREADSHEET_ID', 'abc1-def2')
     spreadsheet = double(:mock)
     expect(Spreadsheet::Writer).to receive(:new)


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/OOdZ8z3b/796-temporarily-turn-off-audit-search-data-until-we-decide-what-to-do-with-it

## Changes in this PR:

It's the last remaining Google Sheet job that uses index instead of GID. We should decide what to do with it then take our time to refactor out using the index in Google Sheets.

For now its having unintended consequences overwriting whichever sheet is in position 3 and the worksheet's positions seem to randomly change so we decided to turn it off for now.

