### PR TITLE
(fix) guard the backfilling of audit data against vacancies that no l…

### DIFF
--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -12,7 +12,11 @@ namespace :data do
     namespace :audit_data do
       task vacancy_publishing: :environment do
         PublicActivity::Activity.where(key: 'vacancy.publish').map do |audit|
-          vacancy = Vacancy.find(audit.trackable_id)
+          begin
+            vacancy = Vacancy.find(audit.trackable_id)
+          rescue ActiveRecord::RecordNotFound
+            next
+          end
 
           if AuditData.where("data->>'id' = ?", vacancy.id).count.zero?
             row = VacancyPresenter.new(vacancy).to_row

--- a/spec/lib/tasks/backfill_audit_data_for_published_jobs.rb
+++ b/spec/lib/tasks/backfill_audit_data_for_published_jobs.rb
@@ -61,4 +61,16 @@ RSpec.describe 'rake data:backfill:audit_data:vacancy_publishing', type: :task d
       expect(AuditData.last.data).to include('status' => vacancy.status)
     end
   end
+
+  context 'when the vacancy cannot be found' do
+    it 'does not error or create an AuditData' do
+      vacancy = create(:vacancy, :published)
+      PublicActivity::Activity.create(key: 'vacancy.publish', trackable: vacancy)
+      vacancy.destroy # We aren't show why, but this has happened in production
+
+      expect { task.execute }.not_to raise_error
+
+      expect(AuditData.count).to eq(0)
+    end
+  end
 end


### PR DESCRIPTION
…onger exist

## Trello card URL:
https://trello.com/c/e82Vre89

## Changes in this PR:
* We aren’t sure why this would have happened as vacancies can only be soft deleted in the front end, and although we saw this on staging we assumed it was because of manually poking around.

### Before
```
Mar 14 15:30:43 Production ecs-tvs2_production_web_backfill_audit_data_for_vacancy_publish_events_task-1-tvs2productionwebbackfillauditdataforvacancypublishevents-e88cd2c3ecf1a493ce01: rake aborted!
Mar 14 15:30:43 Production ecs-tvs2_production_web_backfill_audit_data_for_vacancy_publish_events_task-1-tvs2productionwebbackfillauditdataforvacancypublishevents-e88cd2c3ecf1a493ce01: ActiveRecord::RecordNotFound: Couldn't find Vacancy with 'id'=3d10d399-44a6-44c2-8745-c267d1b8ee8c
Mar 14 15:30:43 Production ecs-tvs2_production_web_backfill_audit_data_for_vacancy_publish_events_task-1-tvs2productionwebbackfillauditdataforvacancypublishevents-e88cd2c3ecf1a493ce01: /usr/local/bundle/gems/activerecord-5.2.2.1/lib/active_record/core.rb:177:in `find'
Mar 14 15:30:43 Production ecs-tvs2_production_web_backfill_audit_data_for_vacancy_publish_events_task-1-tvs2productionwebbackfillauditdataforvacancypublishevents-e88cd2c3ecf1a493ce01: /srv/dfe-tvs/lib/tasks/data.rake:15:in `block (5 levels) in <top (required)>'
Mar 14 15:30:43 Production ecs-tvs2_production_web_backfill_audit_data_for_vacancy_publish_events_task-1-tvs2productionwebbackfillauditdataforvacancypublishevents-e88cd2c3ecf1a493ce01: /usr/local/bundle/gems/activerecord-5.2.2.1/lib/active_record/relation/delegation.rb:71:in `each'
Mar 14 15:30:43 Production ecs-tvs2_production_web_backfill_audit_data_for_vacancy_publish_events_task-1-tvs2productionwebbackfillauditdataforvacancypublishevents-e88cd2c3ecf1a493ce01: /usr/local/bundle/gems/activerecord-5.2.2.1/lib/active_record/relation/delegation.rb:71:in `each'
Mar 14 15:30:43 Production ecs-tvs2_production_web_backfill_audit_data_for_vacancy_publish_events_task-1-tvs2productionwebbackfillauditdataforvacancypublishevents-e88cd2c3ecf1a493ce01: /srv/dfe-tvs/lib/tasks/data.rake:14:in `map'
Mar 14 15:30:43 Production ecs-tvs2_production_web_backfill_audit_data_for_vacancy_publish_events_task-1-tvs2productionwebbackfillauditdataforvacancypublishevents-e88cd2c3ecf1a493ce01: /srv/dfe-tvs/lib/tasks/data.rake:14:in `block (4 levels) in <top (required)>'
Mar 14 15:30:43 Production ecs-tvs2_production_web_backfill_audit_data_for_vacancy_publish_events_task-1-tvs2productionwebbackfillauditdataforvacancypublishevents-e88cd2c3ecf1a493ce01: Tasks: TOP => data:backfill:audit_data:vacancy_publishing
```