### PR TITLE
(fix) Add Rollbar access token to rake container definition

### DIFF
--- a/terraform/container-definitions/rake_container_definition.json
+++ b/terraform/container-definitions/rake_container_definition.json
@@ -60,6 +60,10 @@
       {
         "name": "AWS_ELASTICSEARCH_SECRET",
         "value": "${aws_elasticsearch_secret}"
+      },
+      {
+        "name": "ROLLBAR_ACCESS_TOKEN",
+        "value": "${rollbar_access_token}"
       }
     ]
   }

--- a/terraform/modules/ecs/ecs.tf
+++ b/terraform/modules/ecs/ecs.tf
@@ -190,6 +190,7 @@ data "template_file" "import_schools_container_definition" {
     aws_elasticsearch_region = "${var.aws_elasticsearch_region}"
     aws_elasticsearch_key    = "${var.aws_elasticsearch_key}"
     aws_elasticsearch_secret = "${var.aws_elasticsearch_secret}"
+    rollbar_access_token     = "${var.rollbar_access_token}"
     entrypoint               = "${jsonencode(var.import_schools_task_command)}"
   }
 }
@@ -216,6 +217,7 @@ data "template_file" "update_spreadsheets_container_definition" {
     aws_elasticsearch_region = "${var.aws_elasticsearch_region}"
     aws_elasticsearch_key    = "${var.aws_elasticsearch_key}"
     aws_elasticsearch_secret = "${var.aws_elasticsearch_secret}"
+    rollbar_access_token     = "${var.rollbar_access_token}"
     entrypoint               = "${jsonencode(var.update_spreadsheets_task_command)}"
   }
 }
@@ -242,6 +244,7 @@ data "template_file" "sessions_trim_container_definition" {
     aws_elasticsearch_region = "${var.aws_elasticsearch_region}"
     aws_elasticsearch_key    = "${var.aws_elasticsearch_key}"
     aws_elasticsearch_secret = "${var.aws_elasticsearch_secret}"
+    rollbar_access_token     = "${var.rollbar_access_token}"
     entrypoint               = "${jsonencode(var.sessions_trim_task_command)}"
   }
 }
@@ -268,6 +271,7 @@ data "template_file" "reindex_vacancies_container_definition" {
     aws_elasticsearch_region = "${var.aws_elasticsearch_region}"
     aws_elasticsearch_key    = "${var.aws_elasticsearch_key}"
     aws_elasticsearch_secret = "${var.aws_elasticsearch_secret}"
+    rollbar_access_token     = "${var.rollbar_access_token}"
     entrypoint               = "${jsonencode(var.reindex_vacancies_task_command)}"
   }
 }
@@ -294,6 +298,7 @@ data "template_file" "backfill_audit_data_for_vacancy_publish_events_container_d
     aws_elasticsearch_region = "${var.aws_elasticsearch_region}"
     aws_elasticsearch_key    = "${var.aws_elasticsearch_key}"
     aws_elasticsearch_secret = "${var.aws_elasticsearch_secret}"
+    rollbar_access_token     = "${var.rollbar_access_token}"
     entrypoint               = "${jsonencode(var.backfill_audit_data_for_vacancy_publish_events)}"
   }
 }


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/BoB5c43I/797-add-rollbar-access-token-to-rake-container-definition

## Changes in this PR:

- Add Rollbar access token to rake container definition

## Next steps:

- [x] Terraform deployment required?
