### PR TITLE
Feature/761 updating job seeker email content

### DIFF
--- a/app/mailers/alert_mailer.rb
+++ b/app/mailers/alert_mailer.rb
@@ -1,9 +1,10 @@
 class AlertMailer < ApplicationMailer
   self.delivery_job = DailyAlertMailerJob
+  add_template_helper(DateHelper)
 
   def daily_alert(subscription_id, vacancy_ids)
     subscription = Subscription.find(subscription_id)
-    vacancies = Vacancy.where(id: vacancy_ids).order(:created_at)
+    vacancies = Vacancy.where(id: vacancy_ids).order(:expires_on)
 
     @email = subscription.email
     @subscription_reference = subscription.reference

--- a/app/views/alert_mailer/daily_alert.text.haml
+++ b/app/views/alert_mailer/daily_alert.text.haml
@@ -1,15 +1,20 @@
 \# #{t('app.title')}
-\# #{t('alerts.email.daily.summary', count: @vacancies.count)}
+\## #{t('alerts.email.daily.summary', count: @vacancies.count)}
 \
 \---
 \
 - @vacancies.each do |vacancy|
   = notify_link(vacancy.share_url(source: 'subscription', medium: 'email', campaign: 'daily_alert'), vacancy.job_title).html_safe
-  = vacancy.school_name
+  = vacancy.location
+  \
   = "Salary: #{vacancy.salary_range}"
+  = "Working pattern: #{vacancy.working_pattern}"
+  = "Closing date: #{format_date(vacancy.expires_on)}" 
+  \
   \---
+  \
 \
-Visit #{notify_link('https://teaching-vacancies.service.gov.uk', t('app.title'))}
+Visit #{notify_link('https://teaching-vacancies.service.gov.uk', t('app.title'))} - the free service for schools in England to list teaching roles and for jobseekers to find them.
 
 \---
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -268,7 +268,7 @@ en:
       resubscribe_link_text: resubscribe here
     back_to_search_results: 'Return to your search results'
     email:
-      unsubscribe_text_html: "Don't want to recieve these email alerts? %{link}"
+      unsubscribe_text_html: "Don't want to receive these email alerts? %{link}"
       unsubscribe_link_text: Unsubscribe here
       confirmation:
         subheading: 'You have subscribed to email notifications for jobs that match the following search criteria:'

--- a/lib/tasks/send_sample_alert.rake
+++ b/lib/tasks/send_sample_alert.rake
@@ -2,6 +2,6 @@ namespace :daily_emails do
   task :send_sample, [:email] => :environment do |_t, args|
     subscription = Subscription.find_or_create_by(email: args[:email], frequency: :daily)
     vacancies = Vacancy.all.count.zero? ? FactoryBot.create_list(:vacancy, 5) : Vacancy.all.sample(5)
-    AlertMailer.daily_alert(subscription.id, vacancies.pluck(:id)).deliver_later
+    AlertMailer.daily_alert(subscription.id, vacancies.pluck(:id)).deliver_now!
   end
 end

--- a/spec/mailers/alert_mailer_spec.rb
+++ b/spec/mailers/alert_mailer_spec.rb
@@ -1,7 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe AlertMailer, type: :mailer do
-  let(:body_lines) { mail.body.raw_source.lines }
+  include DateHelper
+  let(:body) { mail.body.raw_source }
   let(:subscription) do
     create(:daily_subscription, email: 'an@email.com',
                                 reference: 'a-reference',
@@ -29,14 +30,16 @@ RSpec.describe AlertMailer, type: :mailer do
         expect(mail.subject).to eq(I18n.t('alerts.email.daily.subject.one'))
         expect(mail.to).to eq([subscription.email])
 
-        expect(body_lines[0]).to match(/# #{I18n.t('app.title')}/)
-        expect(body_lines[1]).to match(/# #{I18n.t('alerts.email.daily.summary.one')}/)
-        expect(body_lines[3]).to match(/---/)
-        expect(body_lines[5]).to eql(
-          "[#{vacancy_presenter.job_title}](#{vacancy_presenter.share_url(campaign_params)})\r\n"
-        )
-        expect(body_lines[6]).to match(/#{vacancy_presenter.school_name}/)
-        expect(body_lines[7]).to match(/Salary: #{vacancy_presenter.salary_range}/)
+        expect(body).to match(/# #{I18n.t('app.title')}/)
+        expect(body).to match(/# #{I18n.t('alerts.email.daily.summary.one')}/)
+        expect(body).to match(/---/)
+        expect(body).to match(/#{Regexp.escape(vacancy_presenter.share_url(campaign_params))}/)
+        expect(body).to match(/#{vacancy_presenter.location}/)
+        expect(body).to match(/Salary: #{vacancy_presenter.salary_range}/)
+
+        expect(body).to match(/#{vacancy_presenter.working_pattern}/)
+
+        expect(body).to match(/#{format_date(vacancy_presenter.expires_on)}/)
       end
     end
 
@@ -49,19 +52,19 @@ RSpec.describe AlertMailer, type: :mailer do
         expect(mail.subject).to eq(I18n.t('alerts.email.daily.subject.other', count: vacancies.count))
         expect(mail.to).to eq([subscription.email])
 
-        expect(body_lines[5]).to match(/\[#{first_vacancy_presenter.job_title}\]/)
-        expect(body_lines[5]).to eql(
-          "[#{first_vacancy_presenter.job_title}](#{first_vacancy_presenter.share_url(campaign_params)})\r\n"
-        )
-        expect(body_lines[6]).to match(/#{first_vacancy_presenter.school_name}/)
-        expect(body_lines[7]).to match(/Salary: #{first_vacancy_presenter.salary_range}/)
+        expect(body).to match(/\[#{first_vacancy_presenter.job_title}\]/)
+        expect(body).to match(/#{Regexp.escape(first_vacancy_presenter.share_url(campaign_params))}/)
+        expect(body).to match(/#{first_vacancy_presenter.location}/)
+        expect(body).to match(/Salary: #{first_vacancy_presenter.salary_range}/)
+        expect(body).to match(/#{first_vacancy_presenter.working_pattern}/)
+        expect(body).to match(/#{format_date(first_vacancy_presenter.expires_on)}/)
 
-        expect(body_lines[9]).to match(/\[#{second_vacancy_presenter.job_title}\]/)
-        expect(body_lines[9]).to eql(
-          "[#{second_vacancy_presenter.job_title}](#{second_vacancy_presenter.share_url(campaign_params)})\r\n"
-        )
-        expect(body_lines[10]).to match(/#{second_vacancy_presenter.school_name}/)
-        expect(body_lines[11]).to match(/Salary: #{second_vacancy_presenter.salary_range}/)
+        expect(body).to match(/\[#{second_vacancy_presenter.job_title}\]/)
+        expect(body).to match(/#{Regexp.escape(second_vacancy_presenter.share_url(campaign_params))}/)
+        expect(body).to match(/#{second_vacancy_presenter.location}/)
+        expect(body).to match(/Salary: #{second_vacancy_presenter.salary_range}/)
+        expect(body).to match(/#{second_vacancy_presenter.working_pattern}/)
+        expect(body).to match(/#{format_date(second_vacancy_presenter.expires_on)}/)
       end
     end
   end


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/XyhPB5zA/761-update-email-alert-content-to-include-more-information-jobseekers-need

## Changes in this PR:
- Short address, working pattern and closing date added to the email
- Extra content added to the bottom area
- Vacancies sorted by closing date
- General styling of the page
- Spec updated

## Screenshots of UI changes:

### Before
![job-seeker-alert-screengrab-before-v01](https://user-images.githubusercontent.com/6421298/54429492-9a98c080-4718-11e9-9cb6-bd1fe879c71e.png)


### After
![job-seeker-alert-screengrab-after-v03](https://user-images.githubusercontent.com/6421298/54429500-9ec4de00-4718-11e9-92e4-883496eb7206.png)
