### PR TITLE
Fixes for the deployment of job seeker alerts

### DIFF
--- a/spec/features/job_seekers_can_subscribe_to_a_job_alert_spec.rb
+++ b/spec/features/job_seekers_can_subscribe_to_a_job_alert_spec.rb
@@ -162,8 +162,9 @@ RSpec.feature 'A job seeker can subscribe to a job alert' do
       expect(page).to have_content('3 jobs match your search')
 
       activities = PublicActivity::Activity.all
-      expect(activities[0].key).to eq('subscription.daily_alert.new')
-      expect(activities[1].key).to eq('subscription.daily_alert.create')
+      keys = activities.pluck(:key)
+      expect(keys).to include('subscription.daily_alert.new')
+      expect(keys).to include('subscription.daily_alert.create')
     end
   end
 end

--- a/terraform/modules/ecs/ecs.tf
+++ b/terraform/modules/ecs/ecs.tf
@@ -196,6 +196,7 @@ data "template_file" "send_job_alerts_daily_email_container_definition" {
     aws_elasticsearch_region = "${var.aws_elasticsearch_region}"
     aws_elasticsearch_key    = "${var.aws_elasticsearch_key}"
     aws_elasticsearch_secret = "${var.aws_elasticsearch_secret}"
+    rollbar_access_token     = "${var.rollbar_access_token}"
     entrypoint               = "${jsonencode(var.send_job_alerts_daily_email_command)}"
   }
 }


### PR DESCRIPTION
## Changes in this PR:
- add rollbar token to the new container definition file to enable TF deploy
- attempt to fix fragile test for the audits when setting up a job seeker alert

## Next steps:

- [x] Terraform deployment required?

