### PR TITLE
Address performance warnings

### DIFF
--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -17,8 +17,12 @@ class VacanciesController < ApplicationController
   def index
     @filters = VacancyFilters.new(search_params)
     @sort = VacancySort.new.update(column: sort_column, order: sort_order)
-    records = Vacancy.public_search(filters: @filters, sort: @sort).page(page_number).records(includes: [:school])
-    audit_search_event(records, @filters) if @filters.any?
+
+    records = if @filters.any?
+                Vacancy.public_search(filters: @filters, sort: @sort).page(page_number).records(includes: [:school])
+              else
+                Vacancy.live.order(@sort.column => @sort.order).includes(:school).page(page_number)
+              end
 
     @vacancies = VacanciesPresenter.new(records, searched: @filters.any?)
 

--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -26,6 +26,8 @@ class VacanciesController < ApplicationController
 
     @vacancies = VacanciesPresenter.new(records, searched: @filters.any?)
 
+    audit_search_event if @filters.any?
+
     expires_in 5.minutes, public: true
   end
 
@@ -55,10 +57,10 @@ class VacanciesController < ApplicationController
     request.path != job_path(vacancy) && !request.format.json?
   end
 
-  def audit_search_event(records, filters)
+  def audit_search_event
     AuditSearchEventJob.perform_later([Time.zone.now.iso8601.to_s,
-                                       records.total_count,
-                                       *filters.to_hash.values])
+                                       @vacancies.total_count,
+                                       *@filters.to_hash.values])
   end
 
   def id

--- a/app/presenters/vacancies_presenter.rb
+++ b/app/presenters/vacancies_presenter.rb
@@ -21,6 +21,10 @@ class VacanciesPresenter < BasePresenter
     decorated_collection.each(&block)
   end
 
+  def any?
+    decorated_collection.count.nonzero?
+  end
+
   def total_count_message
     if total_count == 1
       return I18n.t('jobs.job_count_without_search', count: total_count) unless @searched

--- a/app/presenters/vacancies_presenter.rb
+++ b/app/presenters/vacancies_presenter.rb
@@ -70,16 +70,16 @@ class VacanciesPresenter < BasePresenter
 
   private
 
+  def total_count
+    @total_count ||= model.total_count
+  end
+
   def json_api_params
     {
       format: :json,
       api_version: 1,
       protocol: 'https'
     }
-  end
-
-  def total_count
-    model.total_count
   end
 
   # rubocop:disable Metrics/AbcSize

--- a/app/services/vacancies_finder.rb
+++ b/app/services/vacancies_finder.rb
@@ -1,0 +1,42 @@
+class VacanciesFinder
+  attr_reader :vacancies
+
+  def initialize(filters, sort, page_number)
+    @filters = filters
+    @sort = sort
+    @page_number = page_number
+    @vacancies = VacanciesPresenter.new(records, searched: search_filters_given?)
+    audit_search_event if search_filters_given?
+  end
+
+  private
+
+  attr_reader :filters, :sort, :page_number
+
+  def search_filters_given?
+    @search_filters_given ||= filters.any?
+  end
+
+  def records
+    search_filters_given? ? search_results : all_vacancies
+  end
+
+  def search_results
+    Vacancy.public_search(filters: filters, sort: sort)
+           .page(page_number)
+           .records(includes: [:school])
+  end
+
+  def all_vacancies
+    Vacancy.live
+           .order(sort.column => sort.order)
+           .includes(:school)
+           .page(page_number)
+  end
+
+  def audit_search_event
+    AuditSearchEventJob.perform_later([Time.zone.now.iso8601.to_s,
+                                       vacancies.total_count,
+                                       *filters.to_hash.values])
+  end
+end

--- a/db/migrate/20190319151242_add_missing_indexes.rb
+++ b/db/migrate/20190319151242_add_missing_indexes.rb
@@ -1,0 +1,8 @@
+class AddMissingIndexes < ActiveRecord::Migration[5.2]
+  def change
+    add_index :schools, :detailed_school_type_id
+    add_index :vacancies, :first_supporting_subject_id
+    add_index :vacancies, :max_pay_scale_id
+    add_index :vacancies, :second_supporting_subject_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_18_181006) do
+ActiveRecord::Schema.define(version: 2019_03_19_151242) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -128,6 +128,7 @@ ActiveRecord::Schema.define(version: 2019_03_18_181006) do
     t.text "easting"
     t.text "northing"
     t.point "geolocation"
+    t.index ["detailed_school_type_id"], name: "index_schools_on_detailed_school_type_id"
     t.index ["region_id"], name: "index_schools_on_region_id"
     t.index ["school_type_id"], name: "index_schools_on_school_type_id"
     t.index ["urn"], name: "index_schools_on_urn", unique: true
@@ -209,9 +210,12 @@ ActiveRecord::Schema.define(version: 2019_03_18_181006) do
     t.uuid "first_supporting_subject_id"
     t.uuid "second_supporting_subject_id"
     t.index ["expires_on"], name: "index_vacancies_on_expires_on"
+    t.index ["first_supporting_subject_id"], name: "index_vacancies_on_first_supporting_subject_id"
     t.index ["leadership_id"], name: "index_vacancies_on_leadership_id"
+    t.index ["max_pay_scale_id"], name: "index_vacancies_on_max_pay_scale_id"
     t.index ["min_pay_scale_id"], name: "index_vacancies_on_min_pay_scale_id"
     t.index ["school_id"], name: "index_vacancies_on_school_id"
+    t.index ["second_supporting_subject_id"], name: "index_vacancies_on_second_supporting_subject_id"
     t.index ["subject_id"], name: "index_vacancies_on_subject_id"
   end
 

--- a/spec/controllers/vacancies_controller_spec.rb
+++ b/spec/controllers/vacancies_controller_spec.rb
@@ -61,47 +61,6 @@ RSpec.describe VacanciesController, type: :controller do
           subject
         end
       end
-
-      context 'when parameters are given' do
-        let(:params) { { keyword: 'English' } }
-        it 'calls ElasticSearch' do
-          expect(Vacancy).to receive(:__elasticsearch__).and_call_original
-
-          subject
-        end
-
-        it 'invokes pagination correctly to ensure sort order persists' do
-          create(:vacancy)
-
-          # This assertion ensures the ordering of search and pagination stays correct
-          # in future as the gem allows you to call `page` on 2 similar objects.
-          #
-          # Correct:
-          # - Vacancy.search.page.records
-          # - Vacancy.search.page => Elasticsearch::Model::Response::Records
-          # Incorrect:
-          # - Vacancy.search.records.page
-          # - Vacancy.search.records => Elasticsearch::Model::Response::Response
-
-          elasticsearch_response = instance_double(Elasticsearch::Model::Response::Response)
-          records = instance_double(Elasticsearch::Model::Response::Records)
-          expect(Vacancy).to receive(:public_search).ordered.and_return(elasticsearch_response)
-          expect(elasticsearch_response).to receive(:page).ordered.and_return(elasticsearch_response)
-          expect(elasticsearch_response).to receive(:records).ordered.and_return(records)
-          expect(records).to receive(:total_count) { 0 }
-          expect(records).to receive(:map)
-
-          subject
-        end
-      end
-
-      context 'when no parameters are given' do
-        let(:params) { {} }
-        it 'does not call ElasticSearch' do
-          expect(Vacancy).to_not receive(:__elasticsearch__)
-          subject
-        end
-      end
     end
 
     context 'feature flagging' do

--- a/spec/controllers/vacancies_controller_spec.rb
+++ b/spec/controllers/vacancies_controller_spec.rb
@@ -9,71 +9,99 @@ RSpec.describe VacanciesController, type: :controller do
   end
 
   describe '#index' do
+    let(:subject) { get :index, params: params }
     context 'when parameters include syntax' do
-      it 'passes only safe values to VacancyFilters' do
-        received_values = {
-          keyword: "<body onload=alert('test1')>Text</body>",
-          location: "<img src='http://url.to.file.which/not.exist' onerror=alert(document.cookie);>",
-          minimum_salary: '<xml>Foo</xml',
-          maximum_salary: '<style>Foo</style>',
-          phase: '<iframe>Foo</iframe>',
-          working_pattern: '<script>Foo</script>',
-        }
+      context 'search params' do
+        let(:params) do
+          {
+            keyword: "<body onload=alert('test1')>Text</body>",
+            location: "<img src='http://url.to.file.which/not.exist' onerror=alert(document.cookie);>",
+            minimum_salary: '<xml>Foo</xml',
+            maximum_salary: '<style>Foo</style>',
+            phase: '<iframe>Foo</iframe>',
+            working_pattern: '<script>Foo</script>',
+          }
+        end
 
-        expected_safe_values = {
-          'keyword' => 'Text',
-          'location' => '',
-          'minimum_salary' => 'Foo',
-          'maximum_salary' => '',
-          'phase' => '',
-          'working_pattern' => '',
-        }
+        it 'passes only safe values to VacancyFilters' do
+          expected_safe_values = {
+            'keyword' => 'Text',
+            'location' => '',
+            'minimum_salary' => 'Foo',
+            'maximum_salary' => '',
+            'phase' => '',
+            'working_pattern' => '',
+          }
 
-        expect(VacancyFilters).to receive(:new)
-          .with(expected_safe_values)
-          .and_call_original
+          expect(VacancyFilters).to receive(:new)
+            .with(expected_safe_values)
+            .and_call_original
 
-        get :index, params: received_values
+          subject
+        end
       end
 
-      it 'passes sanitised params to VacancySort' do
-        received_values = {
-          sort_column: "<body onload=alert('test1')>Text</script>",
-          sort_order: '<xml>Foo</xml',
-        }
+      context 'sort params' do
+        let(:params) do
+          {
+            sort_column: "<body onload=alert('test1')>Text</script>",
+            sort_order: '<xml>Foo</xml',
+          }
+        end
+        it 'passes sanitised params to VacancySort' do
+          expected_safe_values = {
+            column: 'Text',
+            order: 'Foo',
+          }
 
-        expected_safe_values = {
-          column: 'Text',
-          order: 'Foo',
-        }
+          expect_any_instance_of(VacancySort).to receive(:update)
+            .with(expected_safe_values)
+            .and_call_original
 
-        expect_any_instance_of(VacancySort).to receive(:update)
-          .with(expected_safe_values)
-          .and_call_original
-
-        get :index, params: received_values
+          subject
+        end
       end
-    end
 
-    it 'invokes pagination correctly to ensure sort order persists' do
-      create(:vacancy)
+      context 'when parameters are given' do
+        let(:params) { { keyword: 'English' } }
+        it 'calls ElasticSearch' do
+          expect(Vacancy).to receive(:__elasticsearch__).and_call_original
 
-      # This assertion ensures the ordering of search and pagination stays correct
-      # in future as the gem allows you to call `page` on 2 similar objects.
-      #
-      # Correct:
-      # - Vacancy.search.page.records
-      # - Vacancy.search.page => Elasticsearch::Model::Response::Records
-      # Incorrect:
-      # - Vacancy.search.records.page
-      # - Vacancy.search.records => Elasticsearch::Model::Response::Response
+          subject
+        end
 
-      elasticsearch_response = instance_double(Elasticsearch::Model::Response::Response)
-      allow(Vacancy).to receive(:public_search).and_return(elasticsearch_response)
-      expect(elasticsearch_response).to receive(:page).and_return(elasticsearch_response)
-      expect(elasticsearch_response).to receive(:records).and_return([])
+        it 'invokes pagination correctly to ensure sort order persists' do
+          create(:vacancy)
 
-      get :index
+          # This assertion ensures the ordering of search and pagination stays correct
+          # in future as the gem allows you to call `page` on 2 similar objects.
+          #
+          # Correct:
+          # - Vacancy.search.page.records
+          # - Vacancy.search.page => Elasticsearch::Model::Response::Records
+          # Incorrect:
+          # - Vacancy.search.records.page
+          # - Vacancy.search.records => Elasticsearch::Model::Response::Response
+
+          elasticsearch_response = instance_double(Elasticsearch::Model::Response::Response)
+          records = instance_double(Elasticsearch::Model::Response::Records)
+          expect(Vacancy).to receive(:public_search).ordered.and_return(elasticsearch_response)
+          expect(elasticsearch_response).to receive(:page).ordered.and_return(elasticsearch_response)
+          expect(elasticsearch_response).to receive(:records).ordered.and_return(records)
+          expect(records).to receive(:total_count) { 0 }
+          expect(records).to receive(:map)
+
+          subject
+        end
+      end
+
+      context 'when no parameters are given' do
+        let(:params) { {} }
+        it 'does not call ElasticSearch' do
+          expect(Vacancy).to_not receive(:__elasticsearch__)
+          subject
+        end
+      end
     end
 
     context 'feature flagging' do

--- a/spec/features/job_seekers_can_view_vacancies_spec.rb
+++ b/spec/features/job_seekers_can_view_vacancies_spec.rb
@@ -32,7 +32,6 @@ RSpec.feature 'Viewing vacancies' do
     already_published.send :set_slug
     already_published.save(validate: false)
 
-    Vacancy.__elasticsearch__.client.indices.flush
     visit jobs_path
 
     expect(page).to have_content(valid_vacancy.job_title)

--- a/spec/presenters/vacancies_presenter_spec.rb
+++ b/spec/presenters/vacancies_presenter_spec.rb
@@ -2,9 +2,11 @@ require 'rails_helper'
 RSpec.describe VacanciesPresenter do
   describe '#each' do
     it 'is delegated to the decorated collection' do
-      vacancies = create_list(:vacancy, 3)
+      create_list(:vacancy, 3)
+      vacancies = Vacancy.all.page(1)
       searched = true
       decorated_vacancies = vacancies.map { |v| VacancyPresenter.new(v) }
+
       vacancies_presenter = VacanciesPresenter.new(vacancies, searched: searched)
       allow(vacancies_presenter).to receive(:decorated_collection).and_return(decorated_vacancies)
 
@@ -92,7 +94,7 @@ RSpec.describe VacanciesPresenter do
 
   describe '#previous_api_url' do
     let(:vacancies_presenter) { VacanciesPresenter.new(vacancies, searched: false) }
-    let(:vacancies) { double(:vacancies, map: [], prev_page: prev_page) }
+    let(:vacancies) { double(:vacancies, map: [], prev_page: prev_page, total_count: 0) }
 
     context 'when there is a previous page' do
       let(:prev_page) { 4 }
@@ -113,7 +115,7 @@ RSpec.describe VacanciesPresenter do
 
   describe '#next_api_url' do
     let(:vacancies_presenter) { VacanciesPresenter.new(vacancies, searched: false) }
-    let(:vacancies) { double(:vacancies, map: [], next_page: next_page) }
+    let(:vacancies) { double(:vacancies, map: [], next_page: next_page, total_count: 0) }
 
     context 'when there is a next page' do
       let(:next_page) { 2 }

--- a/spec/services/vacancies_finder_spec.rb
+++ b/spec/services/vacancies_finder_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe VacanciesFinder do
+  let(:sort) { VacancySort.new({}) }
+  let(:page_number) { 1 }
+  let(:subject) { described_class.new(filters, sort, page_number) }
+
+  context 'when parameters are given' do
+    let(:filters) { VacancyFilters.new(keyword: 'English') }
+
+    it 'calls ElasticSearch' do
+      expect(Vacancy).to receive(:__elasticsearch__).and_call_original
+
+      subject
+    end
+
+    it 'invokes pagination correctly to ensure sort order persists' do
+      create(:vacancy)
+
+      # This assertion ensures the ordering of search and pagination stays correct
+      # in future as the gem allows you to call `page` on 2 similar objects.
+      #
+      # Correct:
+      # - Vacancy.search.page.records
+      # - Vacancy.search.page => Elasticsearch::Model::Response::Records
+      # Incorrect:
+      # - Vacancy.search.records.page
+      # - Vacancy.search.records => Elasticsearch::Model::Response::Response
+
+      elasticsearch_response = instance_double(Elasticsearch::Model::Response::Response)
+      records = instance_double(Elasticsearch::Model::Response::Records)
+      expect(Vacancy).to receive(:public_search).ordered.and_return(elasticsearch_response)
+      expect(elasticsearch_response).to receive(:page).ordered.and_return(elasticsearch_response)
+      expect(elasticsearch_response).to receive(:records).ordered.and_return(records)
+      expect(records).to receive(:total_count) { 0 }
+      expect(records).to receive(:map)
+
+      subject
+    end
+  end
+
+  context 'when no parameters are given' do
+    let(:filters) { VacancyFilters.new({}) }
+
+    it 'does not call ElasticSearch' do
+      expect(Vacancy).to_not receive(:__elasticsearch__)
+      subject
+    end
+  end
+end


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/mYKQZS1v/766-address-performance-warnings-to-ensure-we-can-scale-up-to-more-jobs

## Changes in this PR:

I've had a stab at addressing some of the issues highlighted by Skylight. There's probably more that can be surfaced, but this is a good start I think:

* When we hit the homepage of TV, we're always hitting ElasticSearch, which probably isn't necessary. If there are no queries, then we just default to getting all vacancies from the database (paginated of course)
* When listing vacancies, the `count` query gets hit a number of times. We're now memoizing the `total_count` var in the presenter
* I noticed some DB queries were running a lot slower than expected, so I installed [lol_dba](https://github.com/plentz/lol_dba) locally to see if we had any missing indexes (which we did), so I've added a migration to add some that we were missing.