### PR TITLE
Remove reference to rollout on signin page

### DIFF
--- a/app/views/hiring_staff/identifications/new.html.haml
+++ b/app/views/hiring_staff/identifications/new.html.haml
@@ -8,5 +8,6 @@
 
     = simple_form_for :identifications, url: identifications_path, :defaults => { :input_html => { :class => "text" } }, method: :post do |f|
       .govuk-form-group
-        %p= t('sign_in.guidance', link: link_to('Invitations are being sent out gradually by region.', roll_out_blog_url, target: :_blank, class: 'govuk-link')).html_safe
+        %p= t('sign_in.intro')
+        %p= t('sign_in.guidance', email: mail_to('teaching.vacancies@education.gov.uk', nil, class: 'govuk-link')).html_safe
         = f.submit t('sign_in.link'), class: 'govuk-button'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,7 +25,8 @@ en:
   sign_in:
     title: 'Sign in to Teaching Vacancies'
     link: 'Sign in'
-    guidance: 'Once you have received an email invitation from Teaching Vacancies you can sign in to this service. %{link}'
+    intro: You must have an account to sign into this service.
+    guidance: 'You can get one if you work at a publicly funded school or trust providing primary or secondary education in England and have been authorised by your headteacher or CEO. Just ask them to send your full name and email address to %{email}. Or email us your details directly, copying in your headteacher or CEO.'
     organisation:
       title: 'Select your organisation'
       legend: 'You are associated with more than one organisation, please select the one you wish to sign-in with.'


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/UhfXlJRr/742-edit-content-on-hiring-staff-sign-in-page

## Changes in this PR:

Changes to text to remove reference to the rollout on the sign-in page

## Screenshots of UI changes:

### Before

![image](https://user-images.githubusercontent.com/109774/54669285-e668b280-4ae8-11e9-8943-7bf132809650.png)

### After

![image](https://user-images.githubusercontent.com/109774/54669307-f41e3800-4ae8-11e9-83b1-e0847bdb2bf6.png)