### PR TITLE
[722] Import vacancies from the production API to other environments

### DIFF
--- a/app/controllers/api/vacancies_controller.rb
+++ b/app/controllers/api/vacancies_controller.rb
@@ -9,6 +9,7 @@ class Api::VacanciesController < Api::ApplicationController
                      .published
                      .page(page_number)
                      .per(MAX_API_RESULTS_PER_PAGE)
+                     .order(publish_on: :desc)
     @vacancies = VacanciesPresenter.new(records, searched: false)
 
     respond_to do |format|

--- a/app/jobs/save_job_posting_to_vacancy_job.rb
+++ b/app/jobs/save_job_posting_to_vacancy_job.rb
@@ -7,8 +7,10 @@ class SaveJobPostingToVacancyJob < ApplicationJob
     job_posting = JobPosting.new(data)
     vacancy = job_posting.to_vacancy
 
-    return if vacancy.save
-
-    Rails.logger.warn("Failed to save vacancy from JobPosting: #{vacancy.errors.messages.inspect}")
+    if vacancy.save
+      Rails.logger.info("Saved vacancy from JobPosting. Vacancy ID: #{vacancy.id}")
+    else
+      Rails.logger.warn("Failed to save vacancy from JobPosting: #{vacancy.errors.messages.inspect}")
+    end
   end
 end

--- a/app/jobs/save_job_posting_to_vacancy_job.rb
+++ b/app/jobs/save_job_posting_to_vacancy_job.rb
@@ -1,0 +1,5 @@
+class SaveJobPostingToVacancyJob < ApplicationJob
+  queue_as :seed_vacancies_from_api
+
+  def perform(vacancy); end
+end

--- a/app/jobs/save_job_posting_to_vacancy_job.rb
+++ b/app/jobs/save_job_posting_to_vacancy_job.rb
@@ -1,5 +1,14 @@
+require 'job_posting'
+
 class SaveJobPostingToVacancyJob < ApplicationJob
   queue_as :seed_vacancies_from_api
 
-  def perform(vacancy); end
+  def perform(data)
+    job_posting = JobPosting.new(data)
+    vacancy = job_posting.to_vacancy
+
+    return if vacancy.save
+
+    Rails.logger.warn("Failed to save vacancy from JobPosting: #{vacancy.errors.messages.inspect}")
+  end
 end

--- a/config/initializers/feature_flags.rb
+++ b/config/initializers/feature_flags.rb
@@ -1,5 +1,7 @@
 require 'feature_flag'
 
 FEATURE_EMAIL_ALERTS = ENV['FEATURE_EMAIL_ALERTS']
+FEATURE_IMPORT_VACANCIES = ENV['FEATURE_IMPORT_VACANCIES']
 
 EmailAlertsFeature = FeatureFlag.new('email_alerts')
+ImportVacanciesFeature = FeatureFlag.new('import_vacancies')

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -12,6 +12,7 @@
   - [ audit_search_event, 1 ]
   - [ audit_feedback, 1 ]
   - [ audit_spreadsheet, 1 ]
+  - [ seed_vacancies_from_api, 1 ]
 update_vacancy_spreadsheet:
   :concurrency: 1
 audit_published_vacancy:
@@ -24,7 +25,7 @@ audit_feedback:
   :concurrency: 1
 audit_spreadsheet:
   :concurrency: 1
-audit_toc_acceptance_event:
-  :concurrency: 1
 mailers:
+  :concurrency: 2
+seed_vacancies_from_api:
   :concurrency: 2

--- a/lib/job_posting.rb
+++ b/lib/job_posting.rb
@@ -1,0 +1,50 @@
+class JobPosting
+  def initialize(schema)
+    @schema = schema
+  end
+
+  def to_vacancy
+    Vacancy.new(map_schema_to_vacancy_fields)
+  end
+
+  private
+
+  def map_schema_to_vacancy_fields
+    {
+      job_title: @schema['title'],
+      job_description: @schema['description'],
+      benefits: @schema['jobBenefits'],
+      education: @schema['educationRequirements'],
+      qualifications: @schema['qualifications'],
+      experience: @schema['experienceRequirements'],
+      working_pattern: @schema['employmentType'].downcase.to_sym,
+      status: :published,
+      weekly_hours: @schema['workHours'],
+      application_link: @schema['url'],
+      contact_email: 'recruitment@school.invalid',
+      minimum_salary: @schema.dig('baseSalary', 'value', 'value') || @schema.dig('baseSalary', 'value', 'minValue'),
+      maximum_salary: @schema.dig('baseSalary', 'value', 'maxValue'),
+      publish_on: publish_on_or_today,
+      expires_on: expires_on_or_future,
+      school: school_by_urn_or_random
+    }
+  end
+
+  def school_by_urn_or_random
+    School.find_by(urn: @schema['hiringOrganization']['identifier']) || random_school
+  end
+
+  def random_school
+    School.offset(rand(School.count)).first
+  end
+
+  def publish_on_or_today
+    publish_on = Time.zone.parse(@schema['datePosted'])
+    publish_on.past? ? Time.zone.now : publish_on
+  end
+
+  def expires_on_or_future
+    expires_on = Time.zone.parse(@schema['validThrough'])
+    expires_on.future? ? expires_on : 4.months.from_now
+  end
+end

--- a/lib/tasks/seed_vacancies_from_api.rake
+++ b/lib/tasks/seed_vacancies_from_api.rake
@@ -1,9 +1,11 @@
+require 'teaching_vacancies_api'
+
 namespace :data do
   desc 'Seed from the Teaching Vacancies API'
   namespace :seed_from_api do
     task vacancies: :environment do
       Rails.logger.debug("Seeding vacancies from Teaching Vacancies API in #{Rails.env}")
-      job_postings = TeachingVacancies::API.new.jobs(limit: 10)
+      job_postings = TeachingVacancies::API.new.jobs(limit: 50)
       job_postings.each do |job_posting|
         SaveJobPostingToVacancyJob.perform_later(job_posting)
       end

--- a/lib/tasks/seed_vacancies_from_api.rake
+++ b/lib/tasks/seed_vacancies_from_api.rake
@@ -11,6 +11,8 @@ namespace :data do
       job_postings.each do |job_posting|
         SaveJobPostingToVacancyJob.perform_later(job_posting)
       end
+    rescue HTTParty::ResponseError => e
+      Rails.logger.warn("Teaching Vacancies API response error: #{e.message}")
     end
   end
 end

--- a/lib/tasks/seed_vacancies_from_api.rake
+++ b/lib/tasks/seed_vacancies_from_api.rake
@@ -5,6 +5,7 @@ namespace :data do
   namespace :seed_from_api do
     task vacancies: :environment do
       next if Rails.env.production?
+      next unless ImportVacanciesFeature.enabled?
 
       Rails.logger.debug("Seeding vacancies from Teaching Vacancies API in #{Rails.env}")
       job_postings = TeachingVacancies::API.new.jobs(limit: 50)

--- a/lib/tasks/seed_vacancies_from_api.rake
+++ b/lib/tasks/seed_vacancies_from_api.rake
@@ -4,6 +4,8 @@ namespace :data do
   desc 'Seed from the Teaching Vacancies API'
   namespace :seed_from_api do
     task vacancies: :environment do
+      next if Rails.env.production?
+
       Rails.logger.debug("Seeding vacancies from Teaching Vacancies API in #{Rails.env}")
       job_postings = TeachingVacancies::API.new.jobs(limit: 50)
       job_postings.each do |job_posting|

--- a/lib/tasks/seed_vacancies_from_api.rake
+++ b/lib/tasks/seed_vacancies_from_api.rake
@@ -6,6 +6,7 @@ namespace :data do
     task vacancies: :environment do
       next if Rails.env.production?
       next unless ImportVacanciesFeature.enabled?
+      next unless database_name_in_whitelist?
 
       Rails.logger.debug("Seeding vacancies from Teaching Vacancies API in #{Rails.env}")
       job_postings = TeachingVacancies::API.new.jobs(limit: 50)
@@ -16,4 +17,10 @@ namespace :data do
       Rails.logger.warn("Teaching Vacancies API response error: #{e.message}")
     end
   end
+end
+
+DB_ALLOWING_IMPORT_VACANCIES = %w[tvs_development tvs2_staging tvs2_edge tvs2_testing].freeze
+
+def database_name_in_whitelist?
+  DB_ALLOWING_IMPORT_VACANCIES.include?(Vacancy.connection.current_database)
 end

--- a/lib/tasks/seed_vacancies_from_api.rake
+++ b/lib/tasks/seed_vacancies_from_api.rake
@@ -1,0 +1,12 @@
+namespace :data do
+  desc 'Seed from the Teaching Vacancies API'
+  namespace :seed_from_api do
+    task vacancies: :environment do
+      Rails.logger.debug("Seeding vacancies from Teaching Vacancies API in #{Rails.env}")
+      job_postings = TeachingVacancies::API.new.jobs(limit: 10)
+      job_postings.each do |job_posting|
+        SaveJobPostingToVacancyJob.perform_later(job_posting)
+      end
+    end
+  end
+end

--- a/lib/teaching_vacancies_api.rb
+++ b/lib/teaching_vacancies_api.rb
@@ -6,6 +6,8 @@ module TeachingVacancies
       response = HTTParty.get(api_url('jobs.json'))
       json = JSON.parse(response.body)
       json['data'].take(limit)
+    rescue HTTParty::ResponseError => e
+      Rails.logger.warn("Teaching Vacancies API response error: #{e.message}")
     end
 
     private

--- a/lib/teaching_vacancies_api.rb
+++ b/lib/teaching_vacancies_api.rb
@@ -6,8 +6,6 @@ module TeachingVacancies
       response = HTTParty.get(api_url('jobs.json'))
       json = JSON.parse(response.body)
       json['data'].take(limit)
-    rescue HTTParty::ResponseError => e
-      Rails.logger.warn("Teaching Vacancies API response error: #{e.message}")
     end
 
     private

--- a/lib/teaching_vacancies_api.rb
+++ b/lib/teaching_vacancies_api.rb
@@ -1,0 +1,17 @@
+module TeachingVacancies
+  class API
+    BASE_URL = 'https://teaching-vacancies.service.gov.uk/api/v1/'.freeze
+
+    def jobs(limit: 10)
+      response = HTTParty.get(api_url('jobs.json'))
+      json = JSON.parse(response.body)
+      json['data'].take(limit)
+    end
+
+    private
+
+    def api_url(endpoint)
+      BASE_URL + endpoint
+    end
+  end
+end

--- a/spec/jobs/save_job_posting_to_vacancy_job_spec.rb
+++ b/spec/jobs/save_job_posting_to_vacancy_job_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe SaveJobPostingToVacancyJob, type: :job do
 
   context 'when the vacancy fails to save' do
     let(:vacancy) { double(:vacancy, errors: double(messages: ['Education can’t be blank'])) }
+
     it 'logs the errors' do
       allow(vacancy).to receive(:save) { false }
       expect(Rails.logger).to receive(:warn)

--- a/spec/jobs/save_job_posting_to_vacancy_job_spec.rb
+++ b/spec/jobs/save_job_posting_to_vacancy_job_spec.rb
@@ -4,13 +4,15 @@ RSpec.describe SaveJobPostingToVacancyJob, type: :job do
   include ActiveJob::TestHelper
 
   let(:job_posting) { instance_double('JobPosting') }
-  let(:vacancy) { double(:vacancy) }
+  let(:vacancy) { double(:vacancy, id: 'some-uuid-1234') }
   let(:data) { { '@context' => 'http://schema.org', '@type' => 'JobPosting', 'title' => 'Science Teacher' } }
+  let(:logger_double) { double(:logger).as_null_object }
   subject(:job) { described_class.perform_later(data) }
 
   before do
     allow(JobPosting).to receive(:new).with(data).and_return(job_posting)
     allow(job_posting).to receive(:to_vacancy).and_return(vacancy)
+    allow(Rails).to receive(:logger).and_return(logger_double)
   end
 
   it 'queues the job' do
@@ -27,12 +29,20 @@ RSpec.describe SaveJobPostingToVacancyJob, type: :job do
     perform_enqueued_jobs { job }
   end
 
+  it 'logs the ID of the vacancy it created' do
+    allow(vacancy).to receive(:save) { true }
+    expect(logger_double).to receive(:info)
+      .with("Saved vacancy from JobPosting. Vacancy ID: #{vacancy.id}")
+
+    perform_enqueued_jobs { job }
+  end
+
   context 'when the vacancy fails to save' do
     let(:vacancy) { double(:vacancy, errors: double(messages: ['Education can’t be blank'])) }
 
     it 'logs the errors' do
       allow(vacancy).to receive(:save) { false }
-      expect(Rails.logger).to receive(:warn)
+      expect(logger_double).to receive(:warn)
         .with('Failed to save vacancy from JobPosting: ["Education can’t be blank"]')
 
       perform_enqueued_jobs { job }

--- a/spec/jobs/save_job_posting_to_vacancy_job_spec.rb
+++ b/spec/jobs/save_job_posting_to_vacancy_job_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe SaveJobPostingToVacancyJob, type: :job do
+  include ActiveJob::TestHelper
+
+  let(:job_posting) { instance_double('JobPosting') }
+  let(:vacancy) { double(:vacancy) }
+  let(:data) { { '@context' => 'http://schema.org', '@type' => 'JobPosting', 'title' => 'Science Teacher' } }
+  subject(:job) { described_class.perform_later(data) }
+
+  before do
+    allow(JobPosting).to receive(:new).with(data).and_return(job_posting)
+    allow(job_posting).to receive(:to_vacancy).and_return(vacancy)
+  end
+
+  it 'queues the job' do
+    expect { job }.to change(ActiveJob::Base.queue_adapter.enqueued_jobs, :size).by(1)
+  end
+
+  it 'is in the seed vacancies from api queue' do
+    expect(job.queue_name).to eq('seed_vacancies_from_api')
+  end
+
+  it 'executes perform' do
+    expect(vacancy).to receive(:save) { true }
+
+    perform_enqueued_jobs { job }
+  end
+
+  context 'when the vacancy fails to save' do
+    let(:vacancy) { double(:vacancy, errors: double(messages: ['Education can’t be blank'])) }
+    it 'logs the errors' do
+      allow(vacancy).to receive(:save) { false }
+      expect(Rails.logger).to receive(:warn)
+        .with('Failed to save vacancy from JobPosting: ["Education can’t be blank"]')
+
+      perform_enqueued_jobs { job }
+    end
+  end
+end

--- a/spec/lib/job_posting_spec.rb
+++ b/spec/lib/job_posting_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+require 'job_posting'
+
+RSpec.describe JobPosting do
+  let(:data) do
+    {
+      '@type' => 'JobPosting',
+      'title' => 'Teacher of English',
+      'jobBenefits' => '<p>This is an exceptional opportunity to make a difference within a positive environment.</p>',
+      'datePosted' => date_posted,
+      'description' => '<p>We are seeking an inspirational, dynamic and industrious Teacher of English</p>',
+      'educationRequirements' => '<p>Relevant degree</p>',
+      'qualifications' => '<p>Qualified Teacher Status</p>',
+      'experienceRequirements' => '<p>Excellent classroom practitioner</p>',
+      'employmentType' => 'FULL_TIME',
+      'industry' => 'Education',
+      'url' => 'https://teaching-vacancies.service.gov.uk/jobs/teacher-of-english-gosforth-academy',
+      'baseSalary' => {
+        '@type' => 'MonetaryAmount',
+        'currency' => 'GBP',
+        'value' => {
+          '@type' => 'QuantitativeValue',
+          'minValue' => '22917',
+          'maxValue' => '38633',
+          'unitText' => 'YEAR'
+        }
+      },
+      'hiringOrganization' => {
+        '@type' => 'School',
+        'name' => 'Gosforth Academy',
+        'identifier' => '136352'
+      },
+      'validThrough' => valid_through,
+      'workHours' => '37.5'
+    }
+  end
+  let(:school_by_urn) { build(:school, urn: '136352') }
+  let(:job_posting) { JobPosting.new(data) }
+  let(:date_posted) { Time.zone.now.iso8601 }
+  let(:valid_through) { 1.week.from_now.iso8601 }
+
+  describe '#to_vacancy' do
+    before { allow(School).to receive(:find_by).with(urn: '136352').and_return(school_by_urn) }
+    subject(:to_vacancy) { job_posting.to_vacancy }
+
+    it { is_expected.to be_a(Vacancy) }
+    it { is_expected.to be_valid }
+
+    context 'when the school urn is not found' do
+      let(:school_by_urn) { nil }
+      let(:random_school) { build(:school) }
+
+      it 'assigns a random school' do
+        allow(School).to receive(:offset).and_return(double(first: random_school))
+        vacancy = to_vacancy
+        expect(vacancy.school).to eql(random_school)
+      end
+    end
+
+    context 'when the publish date is in the past' do
+      let(:date_posted) { 1.day.ago.iso8601 }
+
+      it 'sets the publish_on field to today' do
+        vacancy = to_vacancy
+        expect(vacancy.publish_on).to eql(Time.zone.today)
+      end
+    end
+
+    context 'when the expiry date is in the past' do
+      let(:valid_through) { 1.week.ago.iso8601 }
+
+      it 'sets the expires_on field to a date in the future' do
+        vacancy = to_vacancy
+        expect(vacancy.expires_on).to eql(4.months.from_now.to_date)
+      end
+    end
+  end
+end

--- a/spec/lib/tasks/seed_vacancies_from_api_rake_spec.rb
+++ b/spec/lib/tasks/seed_vacancies_from_api_rake_spec.rb
@@ -10,6 +10,17 @@ RSpec.describe 'rake data:seed_from_api:vacancies', type: :task do
       expect(SaveJobPostingToVacancyJob).to receive(:perform_later).with(vacancy)
     end
 
-    task.invoke
+    task.execute
+  end
+
+  context 'when in production' do
+    before { allow(Rails.env).to receive(:production?).and_return(true) }
+
+    it 'returns early and doesn’t call the API at all' do
+      expect(TeachingVacancies::API).not_to receive(:new)
+      expect(SaveJobPostingToVacancyJob).not_to receive(:perform_later)
+
+      task.execute
+    end
   end
 end

--- a/spec/lib/tasks/seed_vacancies_from_api_rake_spec.rb
+++ b/spec/lib/tasks/seed_vacancies_from_api_rake_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+require 'teaching_vacancies_api'
+
+RSpec.describe 'rake data:seed_from_api:vacancies', type: :task do
+  it 'queues jobs to add vacancies from the Teaching Vacancies API' do
+    vacancies = [double]
+    allow(TeachingVacancies::API).to receive(:new).and_return(double(jobs: vacancies))
+
+    vacancies.each do |vacancy|
+      expect(SaveJobPostingToVacancyJob).to receive(:perform_later).with(vacancy)
+    end
+
+    task.invoke
+  end
+end

--- a/spec/lib/tasks/seed_vacancies_from_api_rake_spec.rb
+++ b/spec/lib/tasks/seed_vacancies_from_api_rake_spec.rb
@@ -4,9 +4,11 @@ require 'teaching_vacancies_api'
 RSpec.describe 'rake data:seed_from_api:vacancies', type: :task do
   let(:teaching_vacancies_api) { instance_double(TeachingVacancies::API) }
   let(:feature_enabled?) { true }
+  let(:current_database) { 'tvs_development' }
   before do
     allow(TeachingVacancies::API).to receive(:new).and_return(teaching_vacancies_api)
     allow(ImportVacanciesFeature).to receive(:enabled?).and_return(feature_enabled?)
+    allow(Vacancy.connection).to receive(:current_database).and_return(current_database)
   end
 
   it 'queues jobs to add vacancies from the Teaching Vacancies API' do
@@ -33,6 +35,17 @@ RSpec.describe 'rake data:seed_from_api:vacancies', type: :task do
 
   context 'when the import vacancies feature is NOT enabled' do
     let(:feature_enabled?) { false }
+
+    it 'returns early and doesn’t call the API at all' do
+      expect(teaching_vacancies_api).not_to receive(:jobs)
+      expect(SaveJobPostingToVacancyJob).not_to receive(:perform_later)
+
+      task.execute
+    end
+  end
+
+  context 'when the database name is NOT in the whitelist' do
+    let(:current_database) { 'tvs2_production' }
 
     it 'returns early and doesn’t call the API at all' do
       expect(teaching_vacancies_api).not_to receive(:jobs)

--- a/spec/lib/teaching_vacancies_api_spec.rb
+++ b/spec/lib/teaching_vacancies_api_spec.rb
@@ -26,5 +26,16 @@ RSpec.describe TeachingVacancies::API do
         expect(teaching_vacancies_api.jobs(limit: 1)).to eql([job_postings.first])
       end
     end
+
+    context 'when there is a response error' do
+      before do
+        allow(HTTParty).to receive(:get).with(endpoint).and_raise(HTTParty::ResponseError, 'foo')
+      end
+
+      it 'logs the error' do
+        expect(Rails.logger).to receive(:warn).with('Teaching Vacancies API response error: foo')
+        teaching_vacancies_api.jobs
+      end
+    end
   end
 end

--- a/spec/lib/teaching_vacancies_api_spec.rb
+++ b/spec/lib/teaching_vacancies_api_spec.rb
@@ -26,16 +26,5 @@ RSpec.describe TeachingVacancies::API do
         expect(teaching_vacancies_api.jobs(limit: 1)).to eql([job_postings.first])
       end
     end
-
-    context 'when there is a response error' do
-      before do
-        allow(HTTParty).to receive(:get).with(endpoint).and_raise(HTTParty::ResponseError, 'foo')
-      end
-
-      it 'logs the error' do
-        expect(Rails.logger).to receive(:warn).with('Teaching Vacancies API response error: foo')
-        teaching_vacancies_api.jobs
-      end
-    end
   end
 end

--- a/spec/lib/teaching_vacancies_api_spec.rb
+++ b/spec/lib/teaching_vacancies_api_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+require 'teaching_vacancies_api'
+
+RSpec.describe TeachingVacancies::API do
+  describe '#vacancies' do
+    let(:teaching_vacancies_api) { TeachingVacancies::API.new }
+    let(:endpoint) { 'https://teaching-vacancies.service.gov.uk/api/v1/jobs.json' }
+    let(:job_postings) do
+      [
+        { '@context' => 'http://schema.org', '@type' => 'JobPosting', 'title' => 'Teacher of Maths' },
+        { '@context' => 'http://schema.org', '@type' => 'JobPosting', 'title' => 'Second in Science' }
+      ]
+    end
+    let(:api_response) { double(body: "{\"data\": #{job_postings.to_json}}") }
+
+    before do
+      allow(HTTParty).to receive(:get).with(endpoint).and_return(api_response)
+    end
+
+    it 'returns the job postings from the API' do
+      expect(teaching_vacancies_api.jobs).to eql(job_postings)
+    end
+
+    context 'when a limit is given' do
+      it 'limits the amount of job postings returned' do
+        expect(teaching_vacancies_api.jobs(limit: 1)).to eql([job_postings.first])
+      end
+    end
+  end
+end

--- a/terraform.tf
+++ b/terraform.tf
@@ -92,6 +92,7 @@ module "ecs" {
   reindex_vacancies_task_command = "${var.reindex_vacancies_task_command}"
 
   backfill_audit_data_for_vacancy_publish_events = "${var.backfill_audit_data_for_vacancy_publish_events}"
+  seed_vacancies_from_api = "${var.seed_vacancies_from_api}"
 
   performance_platform_submit_task_command     = "${var.performance_platform_submit_task_command}"
   performance_platform_submit_task_schedule    = "${var.performance_platform_submit_task_schedule}"

--- a/terraform.tf
+++ b/terraform.tf
@@ -150,6 +150,7 @@ module "ecs" {
   notify_subscription_confirmation_template = "${var.notify_subscription_confirmation_template}"
   notify_subscription_daily_template = "${var.notify_subscription_daily_template}"
   feature_email_alerts                      = "${var.feature_email_alerts}"
+  feature_import_vacancies                  = "${var.feature_import_vacancies}"
 }
 
 module "logs" {

--- a/terraform/container-definitions/rake_container_definition.json
+++ b/terraform/container-definitions/rake_container_definition.json
@@ -64,6 +64,10 @@
       {
         "name": "ROLLBAR_ACCESS_TOKEN",
         "value": "${rollbar_access_token}"
+      },
+      {
+        "name": "FEATURE_IMPORT_VACANCIES",
+        "value": "${feature_import_vacancies}"
       }
     ]
   }

--- a/terraform/modules/ecs/ecs.tf
+++ b/terraform/modules/ecs/ecs.tf
@@ -197,6 +197,7 @@ data "template_file" "send_job_alerts_daily_email_container_definition" {
     aws_elasticsearch_key    = "${var.aws_elasticsearch_key}"
     aws_elasticsearch_secret = "${var.aws_elasticsearch_secret}"
     rollbar_access_token     = "${var.rollbar_access_token}"
+    feature_import_vacancies = "${var.feature_import_vacancies}"
     entrypoint               = "${jsonencode(var.send_job_alerts_daily_email_command)}"
   }
 }
@@ -224,6 +225,7 @@ data "template_file" "import_schools_container_definition" {
     aws_elasticsearch_key    = "${var.aws_elasticsearch_key}"
     aws_elasticsearch_secret = "${var.aws_elasticsearch_secret}"
     rollbar_access_token     = "${var.rollbar_access_token}"
+    feature_import_vacancies = "${var.feature_import_vacancies}"
     entrypoint               = "${jsonencode(var.import_schools_task_command)}"
   }
 }
@@ -251,6 +253,7 @@ data "template_file" "update_spreadsheets_container_definition" {
     aws_elasticsearch_key    = "${var.aws_elasticsearch_key}"
     aws_elasticsearch_secret = "${var.aws_elasticsearch_secret}"
     rollbar_access_token     = "${var.rollbar_access_token}"
+    feature_import_vacancies = "${var.feature_import_vacancies}"
     entrypoint               = "${jsonencode(var.update_spreadsheets_task_command)}"
   }
 }
@@ -278,6 +281,7 @@ data "template_file" "sessions_trim_container_definition" {
     aws_elasticsearch_key    = "${var.aws_elasticsearch_key}"
     aws_elasticsearch_secret = "${var.aws_elasticsearch_secret}"
     rollbar_access_token     = "${var.rollbar_access_token}"
+    feature_import_vacancies = "${var.feature_import_vacancies}"
     entrypoint               = "${jsonencode(var.sessions_trim_task_command)}"
   }
 }
@@ -305,6 +309,7 @@ data "template_file" "reindex_vacancies_container_definition" {
     aws_elasticsearch_key    = "${var.aws_elasticsearch_key}"
     aws_elasticsearch_secret = "${var.aws_elasticsearch_secret}"
     rollbar_access_token     = "${var.rollbar_access_token}"
+    feature_import_vacancies = "${var.feature_import_vacancies}"
     entrypoint               = "${jsonencode(var.reindex_vacancies_task_command)}"
   }
 }
@@ -332,6 +337,7 @@ data "template_file" "backfill_audit_data_for_vacancy_publish_events_container_d
     aws_elasticsearch_key    = "${var.aws_elasticsearch_key}"
     aws_elasticsearch_secret = "${var.aws_elasticsearch_secret}"
     rollbar_access_token     = "${var.rollbar_access_token}"
+    feature_import_vacancies = "${var.feature_import_vacancies}"
     entrypoint               = "${jsonencode(var.backfill_audit_data_for_vacancy_publish_events)}"
   }
 }
@@ -359,6 +365,7 @@ data "template_file" "seed_vacancies_from_api_container_definition" {
     aws_elasticsearch_key    = "${var.aws_elasticsearch_key}"
     aws_elasticsearch_secret = "${var.aws_elasticsearch_secret}"
     rollbar_access_token     = "${var.rollbar_access_token}"
+    feature_import_vacancies = "${var.feature_import_vacancies}"
     entrypoint               = "${jsonencode(var.seed_vacancies_from_api)}"
   }
 }
@@ -387,6 +394,7 @@ data "template_file" "performance_platform_submit_container_definition" {
     aws_elasticsearch_secret         = "${var.aws_elasticsearch_secret}"
     pp_transactions_by_channel_token = "${var.pp_transactions_by_channel_token}"
     pp_user_satisfaction_token       = "${var.pp_user_satisfaction_token}"
+    feature_import_vacancies         = "${var.feature_import_vacancies}"
     entrypoint                       = "${jsonencode(var.performance_platform_submit_task_command)}"
   }
 }
@@ -415,6 +423,7 @@ data "template_file" "performance_platform_submit_all_container_definition" {
     aws_elasticsearch_secret         = "${var.aws_elasticsearch_secret}"
     pp_transactions_by_channel_token = "${var.pp_transactions_by_channel_token}"
     pp_user_satisfaction_token       = "${var.pp_user_satisfaction_token}"
+    feature_import_vacancies         = "${var.feature_import_vacancies}"
     entrypoint                       = "${jsonencode(var.performance_platform_submit_all_task_command)}"
   }
 }
@@ -441,6 +450,7 @@ data "template_file" "vacancies_pageviews_refresh_cache_container_definition" {
     aws_elasticsearch_secret    = "${var.aws_elasticsearch_secret}"
     google_api_json_key         = "${replace(jsonencode(var.google_api_json_key), "/([\"\\\\])/", "\\$1")}"
     google_analytics_profile_id = "${var.google_analytics_profile_id}"
+    feature_import_vacancies    = "${var.feature_import_vacancies}"
     entrypoint                  = "${jsonencode(var.vacancies_pageviews_refresh_cache_task_command)}"
     redis_cache_url             = "${var.redis_cache_url}"
     redis_queue_url             = "${var.redis_queue_url}"

--- a/terraform/modules/ecs/ecs.tf
+++ b/terraform/modules/ecs/ecs.tf
@@ -336,6 +336,33 @@ data "template_file" "backfill_audit_data_for_vacancy_publish_events_container_d
   }
 }
 
+/* seed_vacancies_from_api_container_definition task definition*/
+data "template_file" "seed_vacancies_from_api_container_definition" {
+  template = "${file(var.ecs_service_rake_container_definition_file_path)}"
+
+  vars {
+    image                    = "${aws_ecr_repository.default.repository_url}"
+    secret_key_base          = "${var.secret_key_base}"
+    project_name             = "${var.project_name}"
+    task_name                = "${var.ecs_service_web_task_name}_seed_vacancies_from_api"
+    environment              = "${var.environment}"
+    rails_env                = "${var.rails_env}"
+    redis_cache_url          = "${var.redis_cache_url}"
+    redis_queue_url          = "${var.redis_queue_url}"
+    region                   = "${var.region}"
+    log_group                = "${var.aws_cloudwatch_log_group_name}"
+    database_user            = "${var.rds_username}"
+    database_password        = "${var.rds_password}"
+    database_url             = "${var.rds_address}"
+    elastic_search_url       = "${var.es_address}"
+    aws_elasticsearch_region = "${var.aws_elasticsearch_region}"
+    aws_elasticsearch_key    = "${var.aws_elasticsearch_key}"
+    aws_elasticsearch_secret = "${var.aws_elasticsearch_secret}"
+    rollbar_access_token     = "${var.rollbar_access_token}"
+    entrypoint               = "${jsonencode(var.seed_vacancies_from_api)}"
+  }
+}
+
 /* performance_platform_submit task definition*/
 data "template_file" "performance_platform_submit_container_definition" {
   template = "${file(var.performance_platform_rake_container_definition_file_path)}"
@@ -597,6 +624,17 @@ resource "aws_ecs_task_definition" "reindex_vacancies_task" {
 resource "aws_ecs_task_definition" "backfill_audit_data_for_vacancy_publish_events_task" {
   family                   = "${var.ecs_service_web_task_name}_backfill_audit_data_for_vacancy_publish_events_task"
   container_definitions    = "${data.template_file.backfill_audit_data_for_vacancy_publish_events_container_definition.rendered}"
+  requires_compatibilities = ["EC2"]
+  network_mode             = "bridge"
+  cpu                      = "256"
+  memory                   = "512"
+  execution_role_arn       = "${aws_iam_role.ecs_execution_role.arn}"
+  task_role_arn            = "${aws_iam_role.ecs_execution_role.arn}"
+}
+
+resource "aws_ecs_task_definition" "seed_vacancies_from_api_task" {
+  family                   = "${var.ecs_service_web_task_name}_seed_vacancies_from_api_task"
+  container_definitions    = "${data.template_file.seed_vacancies_from_api_container_definition.rendered}"
   requires_compatibilities = ["EC2"]
   network_mode             = "bridge"
   cpu                      = "256"

--- a/terraform/modules/ecs/input.tf
+++ b/terraform/modules/ecs/input.tf
@@ -76,6 +76,7 @@ variable "skylight_enabled" {}
 variable "skylight_ignored_endpoints" {}
 variable "notify_key" {}
 variable "feature_email_alerts" {}
+variable "feature_import_vacancies" {}
 variable "notify_subscription_confirmation_template" {}
 variable "notify_subscription_daily_template" {}
 

--- a/terraform/modules/ecs/input.tf
+++ b/terraform/modules/ecs/input.tf
@@ -113,6 +113,10 @@ variable "backfill_audit_data_for_vacancy_publish_events" {
   type = "list"
 }
 
+variable "seed_vacancies_from_api" {
+  type = "list"
+}
+
 variable "performance_platform_submit_task_command" {
   type = "list"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -203,6 +203,11 @@ variable "backfill_audit_data_for_vacancy_publish_events" {
   default     = ["rake", "verbose", "data:backfill:audit_data:vacancy_publishing"]
 }
 
+variable "seed_vacancies_from_api" {
+  description = "The Entrypoint for the data:seed_from_api:vacancies task"
+  default     = ["rake", "verbose", "data:seed_from_api:vacancies"]
+}
+
 variable "performance_platform_submit_task_command" {
   description = "The Entrypoint for the performance_platform_submit task"
   default     = ["rake", "verbose", "performance_platform:submit"]

--- a/variables.tf
+++ b/variables.tf
@@ -373,6 +373,9 @@ variable "skylight_ignored_endpoints" {
 }
 variable "notify_key" {}
 variable "feature_email_alerts" {}
+variable "feature_import_vacancies" {
+  default = "false"
+}
 variable "notify_subscription_confirmation_template" {}
 variable "notify_subscription_daily_template" {}
 variable "subscription_key_generator_secret" {}


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/hjkz9DrM/722-ensure-environment-data-parity-between-production-and-staging-testing

## Changes in this PR:

The aim of this PR is to import vacancies from production to other environments so that we have meaningful data.

- Rake task to fetch the latest 50 vacancies from the production API and queue a job up for each
- The job then maps the `JobPosting` values to a `Vacancy` and attempts to make it valid before saving

## Questions
- Do we want to make this task run on a schedule?

## Next steps:

- [x] Terraform deployment required?

- [ ] New development configuration to be shared?
