### PR TITLE
[801] Email subject clarity for job alerts

### DIFF
--- a/app/mailers/alert_mailer.rb
+++ b/app/mailers/alert_mailer.rb
@@ -12,7 +12,11 @@ class AlertMailer < ApplicationMailer
     @unsubscribe_token = subscription.token
     @vacancies = VacanciesPresenter.new(vacancies, searched: false)
 
-    subject_key = @vacancies.many? ? 'alerts.email.daily.subject.many' : 'alerts.email.daily.subject.one'
+    subject_key = if @vacancies.many?
+                    'job_alerts.alert.email.daily.subject.many'
+                  else
+                    'job_alerts.alert.email.daily.subject.one'
+                  end
 
     view_mail(
       NOTIFY_SUBSCRIPTION_DAILY_TEMPLATE,

--- a/app/mailers/alert_mailer.rb
+++ b/app/mailers/alert_mailer.rb
@@ -12,10 +12,12 @@ class AlertMailer < ApplicationMailer
     @unsubscribe_token = subscription.token
     @vacancies = VacanciesPresenter.new(vacancies, searched: false)
 
+    subject_key = @vacancies.many? ? 'alerts.email.daily.subject.many' : 'alerts.email.daily.subject.one'
+
     view_mail(
       NOTIFY_SUBSCRIPTION_DAILY_TEMPLATE,
       to: subscription.email,
-      subject: I18n.t('alerts.email.daily.subject', count: vacancies.count),
+      subject: I18n.t(subject_key, reference: subscription.reference),
     )
   end
 end

--- a/app/mailers/subscription_mailer.rb
+++ b/app/mailers/subscription_mailer.rb
@@ -10,7 +10,7 @@ class SubscriptionMailer < ApplicationMailer
     view_mail(
       NOTIFY_SUBSCRIPTION_CONFIRMATION_TEMPLATE,
       to: subscription.email,
-      subject: "Teaching Vacancies subscription confirmation: #{subscription.reference}",
+      subject: I18n.t('job_alerts.confirmation.email.subject', reference: subscription.reference),
     )
   end
 end

--- a/app/views/alert_mailer/daily_alert.text.haml
+++ b/app/views/alert_mailer/daily_alert.text.haml
@@ -1,5 +1,5 @@
 \# #{t('app.title')}
-\## #{t('alerts.email.daily.summary', count: @vacancies.count)}
+\## #{t('job_alerts.alert.email.daily.summary', count: @vacancies.count)}
 \
 \---
 \
@@ -9,7 +9,7 @@
   \
   = "Salary: #{vacancy.salary_range}"
   = "Working pattern: #{vacancy.working_pattern}"
-  = "Closing date: #{format_date(vacancy.expires_on)}" 
+  = "Closing date: #{format_date(vacancy.expires_on)}"
   \
   \---
   \

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -278,7 +278,7 @@ en:
   job_alerts:
     confirmation:
       email:
-        subject: ""
+        subject: "Teaching Vacancies job alert confirmation for '%{reference}'"
     alert:
       email:
         daily:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -279,8 +279,8 @@ en:
     email:
       daily:
         subject:
-          one: "We've found a new job for you"
-          other: "We've found %{count} new jobs for you"
+          one: "Teaching Vacancies job alert for '%{reference}'"
+          many: "Teaching Vacancies job alerts for '%{reference}'"
         summary:
           one: "A new job matching your search criteria was posted yesterday."
           other: "%{count} new jobs matching your search criteria were posted yesterday."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -275,16 +275,20 @@ en:
         expiry_text_html: Your subscription will expire in %{distance}, on the %{date}.
     manage: Manage your subscription
     unsubscribe: Unsubscribe
-  alerts:
-    email:
-      daily:
-        subject:
-          one: "Teaching Vacancies job alert for '%{reference}'"
-          many: "Teaching Vacancies job alerts for '%{reference}'"
-        summary:
-          one: "A new job matching your search criteria was posted yesterday."
-          other: "%{count} new jobs matching your search criteria were posted yesterday."
-        unsubscribe: Follow this link to unsubscribe.
+  job_alerts:
+    confirmation:
+      email:
+        subject: ""
+    alert:
+      email:
+        daily:
+          subject:
+            one: "Teaching Vacancies job alert for '%{reference}'"
+            many: "Teaching Vacancies job alerts for '%{reference}'"
+          summary:
+            one: "A new job matching your search criteria was posted yesterday."
+            other: "%{count} new jobs matching your search criteria were posted yesterday."
+          unsubscribe: Follow this link to unsubscribe.
   terms_and_conditions:
     page_title: 'Terms and Conditions'
     intro: 'Before listing any role at your school on Teaching Vacancies you must first read our Terms and Conditions and agree to abide by them.'

--- a/spec/mailers/alert_mailer_spec.rb
+++ b/spec/mailers/alert_mailer_spec.rb
@@ -27,7 +27,12 @@ RSpec.describe AlertMailer, type: :mailer do
       let(:vacancy_presenter) { VacancyPresenter.new(vacancies.first) }
 
       it 'shows a vacancy' do
-        expect(mail.subject).to eq(I18n.t('alerts.email.daily.subject.one', reference: subscription.reference))
+        expect(mail.subject).to eq(
+          I18n.t(
+            'job_alerts.alert.email.daily.subject.one',
+            reference: subscription.reference
+          )
+        )
         expect(mail.to).to eq([subscription.email])
 
         expect(body).to match(/# #{I18n.t('app.title')}/)
@@ -49,7 +54,12 @@ RSpec.describe AlertMailer, type: :mailer do
       let(:second_vacancy_presenter) { VacancyPresenter.new(vacancies.last) }
 
       it 'shows vacancies' do
-        expect(mail.subject).to eq(I18n.t('alerts.email.daily.subject.many', reference: subscription.reference))
+        expect(mail.subject).to eq(
+          I18n.t(
+            'job_alerts.alert.email.daily.subject.many',
+            reference: subscription.reference
+          )
+        )
         expect(mail.to).to eq([subscription.email])
 
         expect(body).to match(/\[#{first_vacancy_presenter.job_title}\]/)

--- a/spec/mailers/alert_mailer_spec.rb
+++ b/spec/mailers/alert_mailer_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe AlertMailer, type: :mailer do
         expect(mail.to).to eq([subscription.email])
 
         expect(body).to match(/# #{I18n.t('app.title')}/)
-        expect(body).to match(/# #{I18n.t('alerts.email.daily.summary.one')}/)
+        expect(body).to match(/# #{I18n.t('job_alerts.alert.email.daily.summary.one')}/)
         expect(body).to match(/---/)
         expect(body).to match(/#{Regexp.escape(vacancy_presenter.share_url(campaign_params))}/)
         expect(body).to match(/#{vacancy_presenter.location}/)

--- a/spec/mailers/alert_mailer_spec.rb
+++ b/spec/mailers/alert_mailer_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe AlertMailer, type: :mailer do
       let(:vacancy_presenter) { VacancyPresenter.new(vacancies.first) }
 
       it 'shows a vacancy' do
-        expect(mail.subject).to eq(I18n.t('alerts.email.daily.subject.one'))
+        expect(mail.subject).to eq(I18n.t('alerts.email.daily.subject.one', reference: subscription.reference))
         expect(mail.to).to eq([subscription.email])
 
         expect(body).to match(/# #{I18n.t('app.title')}/)
@@ -49,7 +49,7 @@ RSpec.describe AlertMailer, type: :mailer do
       let(:second_vacancy_presenter) { VacancyPresenter.new(vacancies.last) }
 
       it 'shows vacancies' do
-        expect(mail.subject).to eq(I18n.t('alerts.email.daily.subject.other', count: vacancies.count))
+        expect(mail.subject).to eq(I18n.t('alerts.email.daily.subject.many', reference: subscription.reference))
         expect(mail.to).to eq([subscription.email])
 
         expect(body).to match(/\[#{first_vacancy_presenter.job_title}\]/)

--- a/spec/mailers/subscription_spec.rb
+++ b/spec/mailers/subscription_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe SubscriptionMailer, type: :mailer do
   let(:body_lines) { mail.body.raw_source.lines }
 
   it 'sends a confirmation email' do
-    expect(mail.subject).to eq("Teaching Vacancies subscription confirmation: #{subscription.reference}")
+    expect(mail.subject).to eq(I18n.t('job_alerts.confirmation.email.subject', reference: subscription.reference))
     expect(mail.to).to eq([subscription.email])
     expect(body_lines[0]).to match(/# #{I18n.t('app.title')}/)
     expect(body_lines[1]).to match(/# #{subscription.reference}/)


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/DQjIIKLC

## Changes in this PR:
- job alert emails are grouped by their subscription in inboxes, rather than a single group of all job alerts
- alert and confirmation emails for job alerts are consistent

## Screenshots of UI changes:

### Before
![Screenshot 2019-03-20 at 14 21 12](https://user-images.githubusercontent.com/912473/54691594-6e67b000-4b1b-11e9-9f75-e5b29384cd0a.png)

### After
![Screenshot 2019-03-20 at 14 15 31](https://user-images.githubusercontent.com/912473/54691523-47a97980-4b1b-11e9-99ff-baf9198c4567.png)
