### PR TITLE
Fix autogenerated subscriptions

### DIFF
--- a/lib/tasks/send_sample_alert.rake
+++ b/lib/tasks/send_sample_alert.rake
@@ -1,6 +1,9 @@
 namespace :daily_emails do
   task :send_sample, [:email] => :environment do |_t, args|
     subscription = Subscription.find_or_create_by(email: args[:email], frequency: :daily)
+    subscription.expires_on = 3.months.from_now if subscription.expires_on.nil?
+    subscription.search_criteria = { keyword: 'English' }.to_json if subscription.search_criteria.blank?
+    subscription.save
     vacancies = Vacancy.all.count.zero? ? FactoryBot.create_list(:vacancy, 5) : Vacancy.all.sample(5)
     AlertMailer.daily_alert(subscription.id, vacancies.pluck(:id)).deliver_now!
   end


### PR DESCRIPTION
If we use this rake task, we need to make sure subscriptions have `expires_on` dates and `search_criteria`, otherwise things don’t work as expected
