### PR TITLE
[806] Anonymise email addresses used for job alerts in the logs

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,4 +1,4 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password]
+Rails.application.config.filter_parameters += %i[password email]


### PR DESCRIPTION

## Trello card URL:

## Changes in this PR:
* stop them going to Papertrail or any future logging service as we have no need for this information and it makes it impractical to clear up when we no longer need to for sending alerts.
* arguably we should use a more specific parameter key here to avoid any unexpected filtering for other controllers in the future that may have `email: true` for example. The current `email` field is baked into the form via the `Subscription` model rather than an intermediary form object so this can't be changed super quickly. I've decided to kick this can down the road, there's a low likelihood we add a new parameter like this and a low impact if we didn't have this information in our logs - we might be hindered in debugging for a time

## Screenshots of UI changes:

### Before
![Screenshot 2019-03-21 at 16 02 16](https://user-images.githubusercontent.com/912473/54766422-261bc100-4bf3-11e9-96bd-5f663ae214ac.png)

### After
![Screenshot 2019-03-21 at 16 02 48](https://user-images.githubusercontent.com/912473/54766428-2916b180-4bf3-11e9-8e1e-e5fc4289eb3b.png)
