### PR TITLE
[809] Track job alert emails sent by the service

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -3,6 +3,8 @@ class StatsController < ApplicationController
     @stats = PublicActivity::Activity.order(:key)
                                      .group(:key).count
 
+    @stats['job_alert.sent'] = AlertRun.sent.count
+
     expires_in 60.minutes, public: true
   end
 end

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -1,7 +1,7 @@
 class StatsController < ApplicationController
   def index
-    @audit_summary = PublicActivity::Activity.order(:key)
-                                             .group(:key).count
+    @stats = PublicActivity::Activity.order(:key)
+                                     .group(:key).count
 
     expires_in 60.minutes, public: true
   end

--- a/app/views/stats/index.html.haml
+++ b/app/views/stats/index.html.haml
@@ -9,6 +9,6 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     %ul.govuk-list.statistics
-      - @audit_summary.each do |key, value|
+      - @stats.each do |key, value|
         %li
           #{key}: #{value}

--- a/app/views/stats/index.json.jbuilder
+++ b/app/views/stats/index.json.jbuilder
@@ -1,4 +1,4 @@
 json.teaching_jobs do
-  json.summary @audit_summary
+  json.summary @stats
   json.last_updated_at Time.zone.now
 end

--- a/spec/factories/subscriptions.rb
+++ b/spec/factories/subscriptions.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :subscription do
     expires_on { Time.zone.today.strftime('%Y-%m-%d') }
     email { Faker::Internet.email }
+    frequency { :daily }
 
     factory :daily_subscription do
       frequency { :daily }

--- a/spec/requests/stats_spec.rb
+++ b/spec/requests/stats_spec.rb
@@ -24,6 +24,16 @@ RSpec.describe 'Teaching Vacancies stats', type: :request do
 
         expect(response).to have_http_status(:ok)
       end
+
+      it 'includes job alert stats' do
+        subscription = create(:subscription)
+        _sent_alert_runs = create_list(:alert_run, 2, status: :sent, subscription: subscription)
+
+        get stats_path, headers: { 'CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json' }
+
+        json = JSON.parse(response.body)['teaching_jobs']['summary']
+        expect(json['job_alert.sent']).to eq(2)
+      end
     end
   end
 end

--- a/spec/requests/stats_spec.rb
+++ b/spec/requests/stats_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Teaching Vacancies stats', type: :request do
   context 'returns a JSON of useful information about the app' do
     context 'default usage' do
-      it 'it includes all audited information' do
+      it 'includes all audited information' do
         job = create(:vacancy)
         6.times { Auditor::Audit.new(nil, 'dfe-sign-in.authentication.success', 'sample').log_without_association }
         3.times { Auditor::Audit.new(nil, 'dfe-sign-in.authorisation.success', 'sample').log_without_association }


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/Odgbp1nK

## Changes in this PR:
- refactor existing stats variables to make this change simple to make
- using a simple count of the AlertRuns we already have rather than add a new record via the Public Activity gem or our own AuditData for Google sheets - this may not work for ever but it makes it very cheap to meet the need

## Screenshots of UI changes:

### Before

### After
![Screenshot 2019-03-21 at 17 30 21](https://user-images.githubusercontent.com/912473/54772429-3afe5180-4bff-11e9-8cd4-9be5670c6713.png)

![Screenshot 2019-03-21 at 17 30 08](https://user-images.githubusercontent.com/912473/54772420-38036100-4bff-11e9-9a82-f064d65c2091.png)
