### PR TITLE
Update working pattern to allow for more than one

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,6 +16,11 @@ Rails:
 Rails/HasManyOrHasOneDependent:
     Enabled: false
 
+Rails/HasAndBelongsToMany:
+    Exclude:
+      - 'app/models/vacancy.rb'
+      - 'app/models/working_pattern.rb'
+
 Bundler/OrderedGems:
     Enabled: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ gem 'google_drive', require: false
 gem 'google-api-client'
 gem 'browser'
 gem 'mail-notify'
+gem 'deep_cloneable', '~> 2.4.0'
 
 gem 'sidekiq'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,6 +106,8 @@ GEM
     database_cleaner (1.7.0)
     declarative (0.0.10)
     declarative-option (0.1.0)
+    deep_cloneable (2.4.0)
+      activerecord (>= 3.1.0, < 6)
     diff-lcs (1.3)
     elasticsearch (6.2.0)
       elasticsearch-api (= 6.2.0)
@@ -501,6 +503,7 @@ DEPENDENCIES
   coffee-rails
   colorize
   database_cleaner
+  deep_cloneable (~> 2.4.0)
   elasticsearch-extensions
   elasticsearch-model
   factory_bot_rails

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -24,6 +24,7 @@ $govuk-image-url-function: 'image-url';
 @import 'components/og-preview';
 @import 'components/hiring-staff';
 @import 'components/tabs';
+@import 'components/checkboxes';
 @import 'ie';
 
 input[type='search'] {

--- a/app/assets/stylesheets/components/checkboxes.scss
+++ b/app/assets/stylesheets/components/checkboxes.scss
@@ -1,0 +1,6 @@
+.govuk-checkboxes {
+  .collection_check_boxes {
+    @extend .govuk-label;
+    @extend .govuk-checkboxes__label;
+  }
+}

--- a/app/controllers/hiring_staff/vacancies/application_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/application_controller.rb
@@ -56,7 +56,8 @@ class HiringStaff::Vacancies::ApplicationController < HiringStaff::BaseControlle
   end
 
   def retrieve_job_from_db
-    school.vacancies.published.find(vacancy_id).attributes
+    vacancy = school.vacancies.published.find(vacancy_id)
+    vacancy.attributes.merge!(working_pattern_ids: vacancy.working_patterns.pluck(:id))
   end
 
   def source_update?

--- a/app/controllers/hiring_staff/vacancies/job_specification_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/job_specification_controller.rb
@@ -54,12 +54,13 @@ class HiringStaff::Vacancies::JobSpecificationController < HiringStaff::Vacancie
 
   def job_specification_form
     params.require(:job_specification_form).permit(:job_title, :job_description, :leadership_id,
-                                                   :minimum_salary, :maximum_salary, :working_pattern,
+                                                   :minimum_salary, :maximum_salary,
                                                    :benefits, :weekly_hours, :subject_id, :min_pay_scale_id,
                                                    :max_pay_scale_id, :starts_on_dd, :starts_on_mm,
                                                    :starts_on_yyyy, :ends_on_dd, :ends_on_mm, :ends_on_yyyy,
                                                    :flexible_working, :newly_qualified_teacher,
-                                                   :first_supporting_subject_id, :second_supporting_subject_id)
+                                                   :first_supporting_subject_id, :second_supporting_subject_id,
+                                                   working_pattern_ids: [])
   end
 
   def save_vacancy_without_validation

--- a/app/controllers/hiring_staff/vacancies_controller.rb
+++ b/app/controllers/hiring_staff/vacancies_controller.rb
@@ -31,7 +31,7 @@ class HiringStaff::VacanciesController < HiringStaff::Vacancies::ApplicationCont
     end
 
     session[:current_step] = :review
-    store_vacancy_attributes(@vacancy.attributes.compact)
+    store_vacancy_attributes(vacancy_attributes)
     @vacancy = VacancyPresenter.new(@vacancy)
     @vacancy.valid? if params[:source]&.eql?('publish')
   end
@@ -83,5 +83,9 @@ class HiringStaff::VacanciesController < HiringStaff::Vacancies::ApplicationCont
 
   def set_vacancy
     @vacancy = school.vacancies.active.find(vacancy_id)
+  end
+
+  def vacancy_attributes
+    @vacancy.attributes.compact.merge!(working_pattern_ids: @vacancy.working_patterns.pluck(:id))
   end
 end

--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -18,7 +18,6 @@ class VacanciesController < ApplicationController
     @filters = VacancyFilters.new(search_params)
     @sort = VacancySort.new.update(column: sort_column, order: sort_order)
     @vacancies = VacanciesFinder.new(@filters, @sort, page_number).vacancies
-
     expires_in 5.minutes, public: true
   end
 

--- a/app/form_models/job_specification_form.rb
+++ b/app/form_models/job_specification_form.rb
@@ -1,4 +1,5 @@
 class JobSpecificationForm < VacancyForm
+  attr_writer :working_pattern_ids
   # rubocop:disable Lint/AmbiguousOperator
   delegate *['starts_on_yyyy', 'starts_on_mm', 'starts_on_dd',
              'ends_on_dd', 'ends_on_mm', 'ends_on_yyyy',
@@ -6,4 +7,16 @@ class JobSpecificationForm < VacancyForm
   # rubocop:enable Lint/AmbiguousOperator
 
   include VacancyJobSpecificationValidations
+
+  def initialize(params = {})
+    if params[:working_pattern_ids].present?
+      @working_pattern_ids = params[:working_pattern_ids]
+      params[:working_patterns] = @working_pattern_ids.map { |id| WorkingPattern.find(id) }
+    end
+    super(params)
+  end
+
+  def working_pattern_ids
+    @working_pattern_ids ||= vacancy.working_patterns.pluck(:id)
+  end
 end

--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -9,7 +9,7 @@ module VacanciesHelper
   }.freeze
 
   def working_pattern_options
-    Vacancy.working_patterns.keys.map { |key| [key.humanize, key] }
+    WorkingPattern.all.map { |working_pattern| [working_pattern.label, working_pattern.id] }
   end
 
   def school_phase_options

--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -12,6 +12,10 @@ module VacanciesHelper
     WorkingPattern.all.map { |working_pattern| [working_pattern.label, working_pattern.id] }
   end
 
+  def working_pattern_filters
+    WorkingPattern.all.map { |working_pattern| [working_pattern.label, working_pattern.slug] }
+  end
+
   def school_phase_options
     School.phases.keys.map { |key| [key.humanize, key] }
   end

--- a/app/models/concerns/vacancy_job_specification_validations.rb
+++ b/app/models/concerns/vacancy_job_specification_validations.rb
@@ -10,7 +10,7 @@ module VacancyJobSpecificationValidations
     validates :minimum_salary, salary: { presence: true, minimum_value: false }
     validates :maximum_salary, salary: { presence: false }, if: :minimum_valid_and_maximum_salary_present?
     validate :maximum_salary_greater_than_minimum, if: :minimum_and_maximum_salary_present_and_valid?
-    validates :working_pattern, presence: true
+    validates :working_pattern_ids, presence: true
     validate :working_hours
 
     validate :starts_on_in_future?, if: :starts_on?

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -86,6 +86,7 @@ class Vacancy < ApplicationRecord
   belongs_to :min_pay_scale, class_name: 'PayScale', optional: true
   belongs_to :max_pay_scale, class_name: 'PayScale', optional: true
   belongs_to :leadership, optional: true
+  has_and_belongs_to_many :working_patterns, optional: false
 
   has_one :feedback
 

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -59,6 +59,10 @@ class Vacancy < ApplicationRecord
         indexes :name, type: :text
       end
 
+      indexes :working_patterns do
+        indexes :slug, type: :keyword
+      end
+
       indexes :expires_on, type: :date
       indexes :starts_on, type: :date
       indexes :updated_at, type: :date
@@ -146,7 +150,8 @@ class Vacancy < ApplicationRecord
         school: { only: %i[phase name postcode address town] },
         subject: { only: %i[name] },
         first_supporting_subject: { only: %i[name] },
-        second_supporting_subject: { only: %i[name] }
+        second_supporting_subject: { only: %i[name] },
+        working_patterns: { only: %i[slug] },
       }
     )
   end

--- a/app/models/working_pattern.rb
+++ b/app/models/working_pattern.rb
@@ -1,0 +1,3 @@
+class WorkingPattern < ApplicationRecord
+  has_and_belongs_to_many :vacancies
+end

--- a/app/presenters/vacancy_presenter.rb
+++ b/app/presenters/vacancy_presenter.rb
@@ -121,11 +121,11 @@ class VacancyPresenter < BasePresenter
   # rubocop:enable Rails/OutputSafety
 
   def working_pattern
-    model.working_pattern.sub('_', ' ').humanize
+    model.working_patterns.pluck(:label).join(', ')
   end
 
   def working_pattern_for_job_schema
-    model.working_pattern.upcase
+    model.working_patterns.pluck(:slug).join(', ').upcase
   end
 
   def review_page_title

--- a/app/services/copy_vacancy.rb
+++ b/app/services/copy_vacancy.rb
@@ -4,7 +4,7 @@ class CopyVacancy
   end
 
   def call
-    new_vacancy = @proposed_vacancy.dup
+    new_vacancy = @proposed_vacancy.deep_clone(include: :working_patterns)
     new_vacancy.job_title = @proposed_vacancy.job_title
     new_vacancy.starts_on = @proposed_vacancy.starts_on
     new_vacancy.ends_on = @proposed_vacancy.ends_on

--- a/app/services/vacancy_filters.rb
+++ b/app/services/vacancy_filters.rb
@@ -43,6 +43,6 @@ class VacancyFilters
   private
 
   def extract_working_pattern(params)
-    Vacancy.working_patterns.include?(params[:working_pattern]) ? params[:working_pattern] : nil
+    WorkingPattern.find_by(slug: params[:working_pattern])&.slug if params[:working_pattern].present?
   end
 end

--- a/app/services/vacancy_search_builder.rb
+++ b/app/services/vacancy_search_builder.rb
@@ -134,7 +134,7 @@ class VacancySearchBuilder
       bool: {
         filter: {
           terms: {
-            working_pattern: [working_pattern.to_s],
+            'working_patterns.slug': [working_pattern.to_s],
           },
         },
       },

--- a/app/views/hiring_staff/vacancies/edit.html.haml
+++ b/app/views/hiring_staff/vacancies/edit.html.haml
@@ -64,7 +64,7 @@
         %dt.app-check-your-answers__question
           = t('jobs.working_pattern')
         %dd.app-check-your-answers__answer
-          = @vacancy.working_pattern.humanize
+          = @vacancy.working_pattern
         %dd.app-check-your-answers__change
           = link_to t('buttons.change'), edit_school_job_job_specification_path(@vacancy.id, anchor: 'working_pattern'), 'aria-label': t('jobs.aria_labels.change_working_pattern'), class: 'govuk-link'
 

--- a/app/views/hiring_staff/vacancies/job_specification/edit.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/edit.html.haml
@@ -51,6 +51,7 @@
                 required: false
       %fieldset.govuk-fieldset#working_patterns
         %legend.govuk-label.govuk-label= t('jobs.working_pattern')
+        %span.govuk-hint= t('jobs.form_hints.working_pattern')
         .govuk-form-group
           = f.input :working_pattern_ids,
                     collection: working_pattern_options,

--- a/app/views/hiring_staff/vacancies/job_specification/edit.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/edit.html.haml
@@ -49,12 +49,18 @@
                 wrapper_html: {id: 'second_supporting_subject'},
                 collection: subject_options,
                 required: false
-      = f.input :working_pattern,
-                wrapper: 'select',
-                label: t('jobs.working_pattern'),
-                collection: working_pattern_options,
-                wrapper_html: {id: 'working_pattern'},
-                required: true
+      %fieldset.govuk-fieldset#working_patterns
+        %legend.govuk-label.govuk-label= t('jobs.working_pattern')
+        .govuk-form-group
+          = f.input :working_pattern_ids,
+                    collection: working_pattern_options,
+                    as: :check_boxes,
+                    label: false,
+                    wrapper: :checkboxes,
+                    include_hidden: false,
+                    wrapper_html: {id: 'working_pattern'},
+                    item_wrapper_class: 'govuk-checkboxes__item',
+                    required: true
 
       %fieldset.govuk-fieldset#pay_scale_range
         %legend.form-label.govuk-label= "#{t('jobs.pay_scale_range')} (optional)"

--- a/app/views/hiring_staff/vacancies/job_specification/new.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/new.html.haml
@@ -57,12 +57,18 @@
                   collection: subject_options,
                   required: false
 
-      = f.input :working_pattern,
-                wrapper: 'select',
-                label: t('jobs.working_pattern'),
-                collection: working_pattern_options,
-                wrapper_html: {id: 'working_pattern'},
-                required: true
+      %fieldset.govuk-fieldset#working_patterns
+        %legend.govuk-label.govuk-label= t('jobs.working_pattern')
+        .govuk-form-group
+          = f.input :working_pattern_ids,
+                    collection: working_pattern_options,
+                    as: :check_boxes,
+                    label: false,
+                    wrapper: :checkboxes,
+                    include_hidden: false,
+                    wrapper_html: {id: 'working_pattern'},
+                    item_wrapper_class: 'govuk-checkboxes__item',
+                    required: true
 
       %fieldset.govuk-fieldset#pay_scale_range
         %legend.govuk-label.govuk-label= "#{t('jobs.pay_scale_range')} (optional)"

--- a/app/views/hiring_staff/vacancies/job_specification/new.html.haml
+++ b/app/views/hiring_staff/vacancies/job_specification/new.html.haml
@@ -59,6 +59,7 @@
 
       %fieldset.govuk-fieldset#working_patterns
         %legend.govuk-label.govuk-label= t('jobs.working_pattern')
+        %span.govuk-hint= t('jobs.form_hints.working_pattern')
         .govuk-form-group
           = f.input :working_pattern_ids,
                     collection: working_pattern_options,

--- a/app/views/vacancies/_filters.html.haml
+++ b/app/views/vacancies/_filters.html.haml
@@ -20,7 +20,7 @@
       = select_tag 'maximum_salary', options_for_select(VacanciesHelper::SALARY_OPTIONS, maximum_salary), class: 'govuk-select form-control form-control-block', include_blank: 'None'
     .govuk-form-group
       = label_tag 'working_pattern', t('jobs.filters.working_pattern'), class: 'govuk-label'
-      = select_tag 'working_pattern', options_for_select(working_pattern_options, working_pattern), class: 'govuk-select form-control form-control-block', include_blank: 'Any'
+      = select_tag 'working_pattern', options_for_select(working_pattern_filters, working_pattern), class: 'govuk-select form-control form-control-block', include_blank: 'Any'
     .govuk-form-group
       = label_tag 'phase', t('jobs.filters.education_phase'), class: 'govuk-label'
       = select_tag 'phase', options_for_select(school_phase_options, phase), class: 'govuk-select form-control form-control-block', include_blank: 'Any'

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -128,6 +128,17 @@ SimpleForm.setup do |config|
     checkbox.use :hint,  :wrap_with => { :tag => 'div', :class => 'govuk-hint' }
   end
 
+  config.wrappers :checkboxes, tag: 'div',
+                               class: 'govuk-form-group',
+                               error_class: 'govuk-form-group--error' do |checkboxes|
+    checkboxes.use :html5
+    checkboxes.wrapper tag: 'div', class: 'govuk-checkboxes' do |field|
+      field.use :hint, wrap_with: {tag: 'div', class: 'govuk-hint'}
+      field.use :error, wrap_with: {tag: 'div', class: 'govuk-error-message'}
+      field.use :input, class: 'govuk-checkboxes__input'
+    end
+  end
+
   config.wrappers :money, tag: 'div',
                                 class: 'salary_field govuk-form-group',
                                 error_class: 'govuk-form-group--error' do |field|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -178,6 +178,7 @@ en:
       description: 'Briefly describe the duties and responsibilities involved in the role (minimum 10 characters)'
       subject: 'What subject will the teacher focus on?'
       salary_range: 'Enter annual pay before tax, without commas or decimal points (for example 30000)'
+      working_pattern: 'Select which would be considered for the role'
       flexible_working: 'Tick this box if any flexible working arrangements are possible (job sharing or compressed hours, for example). Candidates will be asked to email for further information.'
       newly_qualified_teacher: 'Tick this box if it is suitable for newly qualified teachers.'
       pay_scale_range: 'What pay scale range does the job’s salary fall in?'

--- a/db/migrate/20190321172423_create_working_pattern.rb
+++ b/db/migrate/20190321172423_create_working_pattern.rb
@@ -1,0 +1,8 @@
+class CreateWorkingPattern < ActiveRecord::Migration[5.2]
+  def change
+    create_table :working_patterns, id: :uuid do |t|
+      t.string :label, null: false
+      t.string :slug, null: false, unique: true
+    end
+  end
+end

--- a/db/migrate/20190321173047_create_vacancy_working_patterns.rb
+++ b/db/migrate/20190321173047_create_vacancy_working_patterns.rb
@@ -1,0 +1,8 @@
+class CreateVacancyWorkingPatterns < ActiveRecord::Migration[5.2]
+  def change
+    create_join_table :vacancies, :working_patterns, column_options: { type: :uuid } do |t|
+      t.index [:vacancy_id, :working_pattern_id], unique: true, name: 'vacancy_working_pattern'
+      t.index [:working_pattern_id, :working_pattern_id], name: 'working_pattern_vacancy'
+    end
+  end
+end

--- a/db/migrate/20190321180503_add_working_pattern_data.rb
+++ b/db/migrate/20190321180503_add_working_pattern_data.rb
@@ -1,0 +1,7 @@
+class AddWorkingPatternData < ActiveRecord::Migration[5.2]
+  def change
+    {full_time: 'Full time', part_time: 'Part time'}.each do |slug, label|
+      WorkingPattern.find_or_create_by(slug: slug, label: label)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_19_151242) do
+ActiveRecord::Schema.define(version: 2019_03_21_173047) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -209,6 +209,8 @@ ActiveRecord::Schema.define(version: 2019_03_19_151242) do
     t.datetime "total_pageviews_updated_at"
     t.uuid "first_supporting_subject_id"
     t.uuid "second_supporting_subject_id"
+    t.integer "total_get_more_info_clicks"
+    t.datetime "total_get_more_info_clicks_updated_at"
     t.index ["expires_on"], name: "index_vacancies_on_expires_on"
     t.index ["first_supporting_subject_id"], name: "index_vacancies_on_first_supporting_subject_id"
     t.index ["leadership_id"], name: "index_vacancies_on_leadership_id"
@@ -217,6 +219,19 @@ ActiveRecord::Schema.define(version: 2019_03_19_151242) do
     t.index ["school_id"], name: "index_vacancies_on_school_id"
     t.index ["second_supporting_subject_id"], name: "index_vacancies_on_second_supporting_subject_id"
     t.index ["subject_id"], name: "index_vacancies_on_subject_id"
+  end
+
+  create_table "vacancies_working_patterns", id: false, force: :cascade do |t|
+    t.uuid "vacancy_id", null: false
+    t.uuid "working_pattern_id", null: false
+    t.index ["vacancy_id", "working_pattern_id"], name: "vacancy_working_pattern", unique: true
+    t.index ["working_pattern_id"], name: "working_pattern_vacancy"
+  end
+
+  create_table "working_patterns", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "label", null: false
+    t.string "slug", null: false
+    t.index ["slug"], name: "index_working_patterns_on_slug", unique: true
   end
 
   add_foreign_key "schools", "detailed_school_types"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_21_173047) do
+ActiveRecord::Schema.define(version: 2019_03_21_180503) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -33,6 +33,9 @@ SchoolType.create(label: 'Free School', code: '11')
 SchoolType.create(label: 'LA Maintained School', code: '4')
 SchoolType.create(label: 'Special School', code: '5')
 
+full_time = WorkingPattern.find_or_create_by(label: 'Full time', slug: 'full_time')
+part_time = WorkingPattern.find_or_create_by(label: 'Part time', slug: 'part_time')
+
 
 ealing_school = FactoryBot.create(:school, name: 'Macmillan Academy ',
                                    school_type: academy,
@@ -73,32 +76,32 @@ FactoryBot.create(:vacancy,
                    job_title: 'Maths Teacher',
                    subject: Subject.last,
                    school: bromley_school,
-                   working_pattern: :part_time,
                    minimum_salary: 30000,
                    maximum_salary: 35000,
                    min_pay_scale: payscale,
-                   leadership: leadership)
+                   leadership: leadership,
+                   working_patterns: [part_time])
 
 FactoryBot.create(:vacancy,
                    job_title: 'PE Teacher',
                    subject: Subject.last,
                    school: ealing_school,
-                   working_pattern: :part_time,
                    minimum_salary: 30000,
                    maximum_salary: 35000,
                    min_pay_scale: payscale,
-                   leadership: leadership)
+                   leadership: leadership,
+                   working_patterns: [part_time])
 
 FactoryBot.create(:vacancy,
                    job_title: 'Geography Teacher',
                    subject: Subject.last,
                    school: ealing_school,
-                   working_pattern: :part_time,
                    minimum_salary: 30000,
                    maximum_salary: 35000,
                    min_pay_scale: payscale,
                    status: 1,
-                   leadership: leadership)
+                   leadership: leadership,
+                   working_patterns: [part_time])
 
 # pending vacancy
 FactoryBot.create(:vacancy,

--- a/lib/job_posting.rb
+++ b/lib/job_posting.rb
@@ -17,7 +17,6 @@ class JobPosting
       education: @schema['educationRequirements'],
       qualifications: @schema['qualifications'],
       experience: @schema['experienceRequirements'],
-      working_pattern: @schema['employmentType'].downcase.to_sym,
       status: :published,
       weekly_hours: @schema['workHours'],
       application_link: @schema['url'],
@@ -26,7 +25,8 @@ class JobPosting
       maximum_salary: @schema.dig('baseSalary', 'value', 'maxValue'),
       publish_on: publish_on_or_today,
       expires_on: expires_on_or_future,
-      school: school_by_urn_or_random
+      school: school_by_urn_or_random,
+      working_patterns: working_patterns
     }
   end
 
@@ -46,5 +46,11 @@ class JobPosting
   def expires_on_or_future
     expires_on = Time.zone.parse(@schema['validThrough'])
     expires_on.future? ? expires_on : 4.months.from_now
+  end
+
+  def working_patterns
+    @schema['employmentType'].split(', ').map do |working_pattern|
+      WorkingPattern.find_or_create_by(label: working_pattern.tr('_', ' ').capitalize, slug: working_pattern.downcase)
+    end
   end
 end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -26,4 +26,17 @@ namespace :data do
       end
     end
   end
+
+  desc 'Migrate working pattern to many-to-many association'
+  namespace :working_pattern do
+    task migrate: :environment do
+      Vacancy.all.each do |vacancy|
+        working_pattern = WorkingPattern.find_by(label: vacancy.working_pattern.humanize, slug: vacancy.working_pattern)
+        vacancy.working_patterns << working_pattern if working_pattern.present?
+        vacancy.save
+      rescue ActiveRecord::RecordNotUnique
+        next
+      end
+    end
+  end
 end

--- a/spec/controllers/api/vacancies_controller_spec.rb
+++ b/spec/controllers/api/vacancies_controller_spec.rb
@@ -197,19 +197,30 @@ RSpec.describe Api::VacanciesController, type: :controller do
       end
 
       context '#employment_type' do
-        it 'FULL_TIME' do
+        it 'only FULL_TIME' do
           get :show, params: { id: vacancy.id, api_version: 1 }
 
           employment_type = { 'employmentType': 'FULL_TIME' }
           expect(json.to_h).to include(employment_type)
         end
 
-        it 'PART_TIME' do
-          vacancy = create(:vacancy, working_pattern: :part_time)
+        it 'only PART_TIME' do
+          vacancy = create(:vacancy, working_patterns: [create(:working_pattern, :part_time)])
 
           get :show, params: { id: vacancy.id, api_version: 1 }
 
           employment_type = { 'employmentType': 'PART_TIME' }
+          expect(json.to_h).to include(employment_type)
+        end
+
+        it 'both FULL_TIME and PART_TIME' do
+          part_time = create(:working_pattern, :part_time)
+          full_time = create(:working_pattern, :full_time)
+          vacancy = create(:vacancy, working_patterns: [full_time, part_time])
+
+          get :show, params: { id: vacancy.id, api_version: 1 }
+
+          employment_type = { 'employmentType': 'PART_TIME, FULL_TIME' }
           expect(json.to_h).to include(employment_type)
         end
       end

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
 
     job_title { Faker::Lorem.sentence[1...30].strip }
     working_pattern { :full_time }
-    working_patterns { [build(:working_pattern, :full_time)] }
+    working_patterns { [WorkingPattern.find_or_create_by(label: 'Full time', slug: 'full_time')] }
     job_description { Faker::Lorem.paragraph(4) }
     education { Faker::Lorem.paragraph(4) }
     qualifications { Faker::Lorem.paragraph(4) }

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
 
     job_title { Faker::Lorem.sentence[1...30].strip }
     working_pattern { :full_time }
+    working_patterns { [build(:working_pattern, :full_time)] }
     job_description { Faker::Lorem.paragraph(4) }
     education { Faker::Lorem.paragraph(4) }
     qualifications { Faker::Lorem.paragraph(4) }

--- a/spec/factories/working_patterns.rb
+++ b/spec/factories/working_patterns.rb
@@ -1,0 +1,19 @@
+FactoryBot.define do
+  factory :working_pattern do
+    labels = ['Full time', 'Part time', 'Job share']
+
+    label { labels.sample }
+
+    trait :full_time do
+      label { labels[0] }
+    end
+
+    trait :part_time do
+      label { labels[1] }
+    end
+
+    trait :job_share do
+      label { labels[2] }
+    end
+  end
+end

--- a/spec/factories/working_patterns.rb
+++ b/spec/factories/working_patterns.rb
@@ -1,19 +1,13 @@
 FactoryBot.define do
   factory :working_pattern do
-    labels = ['Full time', 'Part time', 'Job share']
+    slug { 'full_time' }
+    label { 'Full time' }
 
-    label { labels.sample }
-
-    trait :full_time do
-      label { labels[0] }
-    end
+    trait(:full_time) {}
 
     trait :part_time do
-      label { labels[1] }
-    end
-
-    trait :job_share do
-      label { labels[2] }
+      slug { 'part_time' }
+      label { 'Part time' }
     end
   end
 end

--- a/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
+++ b/spec/features/hiring_staff_can_publish_a_vacancy_spec.rb
@@ -26,6 +26,7 @@ RSpec.feature 'Creating a vacancy' do
     let!(:pay_scales) { create_list(:pay_scale, 3) }
     let!(:subjects) { create_list(:subject, 3) }
     let!(:leaderships) { create_list(:leadership, 3) }
+    let!(:working_patterns) { [create(:working_pattern, :full_time)] }
     let(:vacancy) do
       VacancyPresenter.new(build(:vacancy, :complete,
                                  min_pay_scale: pay_scales.sample,
@@ -33,7 +34,8 @@ RSpec.feature 'Creating a vacancy' do
                                  subject: subjects[0],
                                  first_supporting_subject: subjects[1],
                                  second_supporting_subject: subjects[2],
-                                 leadership: leaderships.sample))
+                                 leadership: leaderships.sample,
+                                 working_patterns: working_patterns))
     end
 
     scenario 'redirects to step 1, job specification' do
@@ -66,7 +68,7 @@ RSpec.feature 'Creating a vacancy' do
           expect(page).to have_content(I18n.t('activerecord.errors.models.vacancy.attributes.minimum_salary.blank'))
         end
 
-        within_row_for(text: I18n.t('jobs.working_pattern')) do
+        within_row_for(element: 'legend', text: I18n.t('jobs.working_pattern')) do
           expect(page).to have_content(I18n.t('activerecord.errors.models.vacancy.attributes.working_pattern.blank'))
         end
       end

--- a/spec/features/job_seekers_can_filter_vacancies_spec.rb
+++ b/spec/features/job_seekers_can_filter_vacancies_spec.rb
@@ -57,8 +57,11 @@ RSpec.feature 'Filtering vacancies' do
   end
 
   scenario 'Filterable by working pattern', elasticsearch: true do
-    part_time_vacancy = create(:vacancy, :published, working_pattern: :part_time)
-    full_time_vacancy = create(:vacancy, :published, working_pattern: :full_time)
+    part_time = create(:working_pattern, :part_time)
+    full_time = create(:working_pattern, :full_time)
+    part_time_vacancy = create(:vacancy, :published, working_patterns: [part_time])
+    full_time_vacancy = create(:vacancy, :published, working_patterns: [full_time])
+    full_and_part_time_vacancy = create(:vacancy, :published, working_patterns: [full_time, part_time])
 
     Vacancy.__elasticsearch__.client.indices.flush
     visit jobs_path
@@ -69,6 +72,7 @@ RSpec.feature 'Filtering vacancies' do
     end
 
     expect(page).to have_content(part_time_vacancy.job_title)
+    expect(page).to have_content(full_and_part_time_vacancy.job_title)
     expect(page).not_to have_content(full_time_vacancy.job_title)
   end
 

--- a/spec/form_models/job_specification_form_spec.rb
+++ b/spec/form_models/job_specification_form_spec.rb
@@ -6,12 +6,12 @@ RSpec.describe JobSpecificationForm, type: :model do
     it { should validate_presence_of(:job_title) }
     it { should validate_presence_of(:job_description) }
     it { should validate_presence_of(:minimum_salary) }
-    it { should validate_presence_of(:working_pattern) }
+    it { should validate_presence_of(:working_pattern_ids) }
 
     describe '#maximum_salary' do
       let(:job_specification) do
         JobSpecificationForm.new(job_title: 'job title',
-                                 job_description: 'description', working_pattern: :full_time,
+                                 job_description: 'description',
                                  minimum_salary: 20, maximum_salary: 10)
       end
 
@@ -94,11 +94,12 @@ RSpec.describe JobSpecificationForm, type: :model do
     let(:max_pay_scale) { create(:pay_scale) }
     let(:main_subject) { create(:subject) }
     let(:leadership) { create(:leadership) }
+    let(:full_time) { create(:working_pattern, :full_time) }
 
     it 'a JobSpecificationForm can be converted to a vacancy' do
       job_specification_form = JobSpecificationForm.new(job_title: 'English Teacher',
                                                         job_description: 'description',
-                                                        working_pattern: :full_time,
+                                                        working_pattern_ids: [full_time.id],
                                                         minimum_salary: 20000, maximum_salary: 40000,
                                                         benefits: 'benefits', subject_id: main_subject.id,
                                                         min_pay_scale_id: min_pay_scale.id,
@@ -109,7 +110,7 @@ RSpec.describe JobSpecificationForm, type: :model do
       expect(job_specification_form.valid?).to be true
       expect(job_specification_form.vacancy.job_title).to eq('English Teacher')
       expect(job_specification_form.vacancy.job_description).to eq('description')
-      expect(job_specification_form.vacancy.working_pattern).to eq('full_time')
+      expect(job_specification_form.vacancy.working_pattern_ids).to eq([full_time.id])
       expect(job_specification_form.vacancy.minimum_salary).to eq('20000')
       expect(job_specification_form.vacancy.maximum_salary).to eq('40000')
       expect(job_specification_form.vacancy.benefits).to eq('benefits')

--- a/spec/helpers/vacancies_helper_spec.rb
+++ b/spec/helpers/vacancies_helper_spec.rb
@@ -13,8 +13,18 @@ RSpec.describe VacanciesHelper, type: :helper do
   end
 
   describe '#working_pattern_options' do
-    it 'returns an array of vacancy working patterns' do
-      expect(helper.working_pattern_options).to eq([['Full time', 'full_time'], ['Part time', 'part_time']])
+    let!(:full_time) { create(:working_pattern, :full_time) }
+    let!(:part_time) { create(:working_pattern, :part_time) }
+    it 'returns an array of vacancy working patterns for vacancy form' do
+      expect(helper.working_pattern_options).to eq([[full_time.label, full_time.id], [part_time.label, part_time.id]])
+    end
+  end
+
+  describe '#working_pattern_filters' do
+    let!(:full_time) { create(:working_pattern, :full_time) }
+    let!(:part_time) { create(:working_pattern, :part_time) }
+    it 'returns an array of vacancy working patterns for search filters' do
+      expect(helper.working_pattern_filters).to eq([['Full time', 'full_time'], ['Part time', 'part_time']])
     end
   end
 

--- a/spec/lib/job_posting_spec.rb
+++ b/spec/lib/job_posting_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe JobPosting do
       'educationRequirements' => '<p>Relevant degree</p>',
       'qualifications' => '<p>Qualified Teacher Status</p>',
       'experienceRequirements' => '<p>Excellent classroom practitioner</p>',
-      'employmentType' => 'FULL_TIME',
+      'employmentType' => 'FULL_TIME, PART_TIME',
       'industry' => 'Education',
       'url' => 'https://teaching-vacancies.service.gov.uk/jobs/teacher-of-english-gosforth-academy',
       'baseSalary' => {

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 RSpec.describe Vacancy, type: :model do
   subject { Vacancy.new(school: build(:school)) }
   it { should belong_to(:school) }
+  it { should have_and_belong_to_many(:working_patterns) }
 
   describe '.public_search' do
     context 'when there were no results' do
@@ -28,7 +29,6 @@ RSpec.describe Vacancy, type: :model do
 
   describe 'validations' do
     context 'a new record' do
-      it { should validate_presence_of(:working_pattern) }
       it { should validate_presence_of(:job_title) }
       it { should validate_presence_of(:job_description) }
       it { should validate_presence_of(:minimum_salary) }

--- a/spec/services/copy_vacancy_spec.rb
+++ b/spec/services/copy_vacancy_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe CopyVacancy do
     it 'creates a new vacancy as draft' do
       original_vacancy = FactoryBot.build(:vacancy, job_title: 'Maths teacher')
       original_vacancy.save
-      new_vacancy = original_vacancy.dup
+      new_vacancy = original_vacancy.deep_clone(include: :working_patterns)
 
       result = described_class.new(proposed_vacancy: new_vacancy)
                               .call
@@ -21,7 +21,7 @@ RSpec.describe CopyVacancy do
       Timecop.freeze(Time.zone.local(2008, 9, 1, 12, 0, 0))
 
       original_vacancy = FactoryBot.create(:vacancy, job_title: 'Maths teacher')
-      new_vacancy = original_vacancy.dup
+      new_vacancy = original_vacancy.deep_clone(include: :working_patterns)
 
       described_class.new(proposed_vacancy: new_vacancy)
                      .call
@@ -35,7 +35,7 @@ RSpec.describe CopyVacancy do
     context 'when a new job_title is provided' do
       it 'creates a new vacancy with a new job title' do
         original_vacancy = FactoryBot.create(:vacancy, job_title: 'Maths teacher')
-        new_vacancy = original_vacancy.dup
+        new_vacancy = original_vacancy.deep_clone(include: :working_patterns)
         new_vacancy.job_title = 'English teacher'
 
         result = described_class.new(proposed_vacancy: new_vacancy)
@@ -48,7 +48,7 @@ RSpec.describe CopyVacancy do
     context 'when new dates are provided' do
       it 'creates a new vacancy with the new dates' do
         original_vacancy = FactoryBot.create(:vacancy, job_title: 'Maths teacher')
-        new_vacancy = original_vacancy.dup
+        new_vacancy = original_vacancy.deep_clone(include: :working_patterns)
         new_vacancy.starts_on = 60.days.from_now
         new_vacancy.ends_on = 100.days.from_now
         new_vacancy.publish_on = 0.days.from_now

--- a/spec/services/vacancy_filters_spec.rb
+++ b/spec/services/vacancy_filters_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe VacancyFilters do
     end
 
     it 'sets the working pattern filter if provided and valid' do
+      create(:working_pattern, :full_time)
       vacancy_filters = VacancyFilters.new(working_pattern: 'full_time')
       expect(vacancy_filters.working_pattern).to eq('full_time')
     end

--- a/spec/services/vacancy_search_builder_spec.rb
+++ b/spec/services/vacancy_search_builder_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe VacancySearchBuilder do
         bool: {
           filter: {
             terms: {
-              working_pattern: ['part_time'],
+              'working_patterns.slug': ['part_time'],
             },
           },
         },

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -2,7 +2,9 @@ module VacancyHelpers
   def fill_in_job_specification_form_fields(vacancy)
     fill_in 'job_specification_form[job_title]', with: vacancy.job_title
     fill_in 'job_specification_form[job_description]', with: vacancy.job_description
-    select vacancy.working_pattern, from: 'job_specification_form[working_pattern]'
+    vacancy.working_patterns.each do |working_pattern|
+      check working_pattern.label
+    end
     select vacancy.min_pay_scale.label, from: 'job_specification_form[min_pay_scale_id]'
     select vacancy.max_pay_scale.label, from: 'job_specification_form[max_pay_scale_id]'
     select vacancy.subject.name, from: 'job_specification_form[subject_id]'
@@ -62,7 +64,9 @@ module VacancyHelpers
     expect(page).to have_content(vacancy.subject.name)
     expect(page).to have_content(vacancy.other_subjects)
     expect(page).to have_content(vacancy.salary_range)
-    expect(page).to have_content(vacancy.working_pattern)
+    vacancy.working_patterns.each do |working_pattern|
+      expect(page).to have_content(working_pattern.label)
+    end
     expect(page).to have_content('Flexible working') if vacancy.flexible_working?
     expect(page).to have_content('Suitable')
     expect(page.html).to include(vacancy.benefits)

--- a/terraform.tf
+++ b/terraform.tf
@@ -90,6 +90,7 @@ module "ecs" {
   sessions_trim_task_schedule = "${var.sessions_trim_task_schedule}"
 
   reindex_vacancies_task_command = "${var.reindex_vacancies_task_command}"
+  migrate_vacancy_working_pattern = "${var.migrate_vacancy_working_pattern}"
 
   backfill_audit_data_for_vacancy_publish_events = "${var.backfill_audit_data_for_vacancy_publish_events}"
   seed_vacancies_from_api = "${var.seed_vacancies_from_api}"

--- a/terraform/modules/ecs/ecs.tf
+++ b/terraform/modules/ecs/ecs.tf
@@ -370,6 +370,34 @@ data "template_file" "seed_vacancies_from_api_container_definition" {
   }
 }
 
+/* migrate_vacancy_working_pattern_container_definition task definition*/
+data "template_file" "migrate_vacancy_working_pattern_container_definition" {
+  template = "${file(var.ecs_service_rake_container_definition_file_path)}"
+
+  vars {
+    image                    = "${aws_ecr_repository.default.repository_url}"
+    secret_key_base          = "${var.secret_key_base}"
+    project_name             = "${var.project_name}"
+    task_name                = "${var.ecs_service_web_task_name}_migrate_vacancy_working_pattern"
+    environment              = "${var.environment}"
+    rails_env                = "${var.rails_env}"
+    redis_cache_url          = "${var.redis_cache_url}"
+    redis_queue_url          = "${var.redis_queue_url}"
+    region                   = "${var.region}"
+    log_group                = "${var.aws_cloudwatch_log_group_name}"
+    database_user            = "${var.rds_username}"
+    database_password        = "${var.rds_password}"
+    database_url             = "${var.rds_address}"
+    elastic_search_url       = "${var.es_address}"
+    aws_elasticsearch_region = "${var.aws_elasticsearch_region}"
+    aws_elasticsearch_key    = "${var.aws_elasticsearch_key}"
+    aws_elasticsearch_secret = "${var.aws_elasticsearch_secret}"
+    rollbar_access_token     = "${var.rollbar_access_token}"
+    feature_import_vacancies = "${var.feature_import_vacancies}"
+    entrypoint               = "${jsonencode(var.migrate_vacancy_working_pattern)}"
+  }
+}
+
 /* performance_platform_submit task definition*/
 data "template_file" "performance_platform_submit_container_definition" {
   template = "${file(var.performance_platform_rake_container_definition_file_path)}"

--- a/terraform/modules/ecs/input.tf
+++ b/terraform/modules/ecs/input.tf
@@ -118,6 +118,10 @@ variable "seed_vacancies_from_api" {
   type = "list"
 }
 
+variable "migrate_vacancy_working_pattern" {
+  type = "list"
+}
+
 variable "performance_platform_submit_task_command" {
   type = "list"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -208,6 +208,11 @@ variable "seed_vacancies_from_api" {
   default     = ["rake", "verbose", "data:seed_from_api:vacancies"]
 }
 
+variable "migrate_vacancy_working_pattern" {
+  description = "The Entrypoint for the data:working_pattern:migrate task"
+  default     = ["rake", "verbose", "data:working_pattern:migrate"]
+}
+
 variable "performance_platform_submit_task_command" {
   description = "The Entrypoint for the performance_platform_submit task"
   default     = ["rake", "verbose", "performance_platform:submit"]


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/4owuXmAO/762-update-working-pattern-options-so-there-is-more-flexibility-around-types-of-role-reflecting-the-needs-of-jobseekers-schools

## Changes in this PR:

- Add a WorkingPattern many-to-many association to Vacancy
- Rake task to migrate all vacancies to use new association
- Update hiring staff UI to reflect new association and allow multiple selections
- Update ElasticSearch mappings
- Fixes to some specs

## Screenshots of UI changes:

### Before
<img width="613" alt="Screenshot 2019-03-28 at 19 16 50" src="https://user-images.githubusercontent.com/2804149/55186310-25a09e80-518e-11e9-8ead-00285f2f287c.png">

### After
<img width="620" alt="Screenshot 2019-03-28 at 19 15 38" src="https://user-images.githubusercontent.com/2804149/55186317-2b967f80-518e-11e9-9495-be66f40ec086.png">

## Next steps:

- [x] Terraform deployment required?

