### PR TITLE
Make bin/drebuild work properly

### DIFF
--- a/bin/drebuild
+++ b/bin/drebuild
@@ -1,29 +1,25 @@
 #!/bin/sh
 
+run_with_pretty_print()
+{
+  echo "\n\033[36m===> $1\033[0m\n"
+  eval $1
+}
+
 echo "Remove all unused images before we build new ones…"
-echo "\n\033[36m===> docker image prune -f\033[0m\n"
-docker image prune -f
+run_with_pretty_print 'docker image prune -f'
 
 echo "Rebuilding the test server…"
-echo "\n\033[36m===> docker-compose --file=docker-compose.test.yml down -v --remove-orphans\033[0m\n"
-docker-compose --file=docker-compose.test.yml down -v --remove-orphans
-echo "\n\033[36m===> docker-compose --file=docker-compose.test.yml build\033[0m\n"
-docker-compose --file=docker-compose.test.yml build
-echo "\n\033[36m===> bin/dtest-server\033[0m\n"
-bin/dtest-server
+run_with_pretty_print 'docker-compose --file=docker-compose.test.yml down -v --remove-orphans'
+run_with_pretty_print 'docker-compose --file=docker-compose.test.yml build'
+run_with_pretty_print 'bin/dtest-server'
 echo "Rebuilt and started the testing server for TVS."
 
 echo "Rebuilding the web server…"
-echo "\n\033[36m===> docker-compose down -v --remove-orphans\033[0m\n"
-docker-compose down -v --remove-orphans
-echo "\n\033[36m===> docker-compose build\033[0m\n"
-docker-compose build
-echo "\n\033[36m===> docker-compose run web bin/dsetup\033[0m\n"
-docker-compose run web bin/dsetup
-echo "\n\033[36m===> docker-compose run web rake db:seed\033[0m\n"
-docker-compose run web rake db:seed
-echo "\n\033[36m===> bin/drake elasticsearch:vacancies:index\033[0m\n"
-bin/drake elasticsearch:vacancies:index
+run_with_pretty_print 'docker-compose down -v --remove-orphans'
+run_with_pretty_print 'docker-compose build'
+run_with_pretty_print 'docker-compose run web bin/dsetup'
+run_with_pretty_print 'docker-compose run web rake db:seed'
+run_with_pretty_print 'bin/drake elasticsearch:vacancies:index'
 echo "Rebuilt and starting the web server for TVS."
-echo "\n\033[36m===> bin/dstart\033[0m\n"
-bin/dstart
+run_with_pretty_print 'bin/dstart'

--- a/bin/drebuild
+++ b/bin/drebuild
@@ -1,18 +1,27 @@
 #!/bin/sh
 
 echo "Remove all unused images before we build new ones…"
+echo "\n\033[36m===> docker image prune -f\033[0m\n"
 docker image prune -f
 
 echo "Rebuilding the test server…"
+echo "\n\033[36m===> docker-compose --file=docker-compose.test.yml down -v --remove-orphans\033[0m\n"
 docker-compose --file=docker-compose.test.yml down -v --remove-orphans
+echo "\n\033[36m===> docker-compose --file=docker-compose.test.yml build\033[0m\n"
 docker-compose --file=docker-compose.test.yml build
+echo "\n\033[36m===> bin/dtest-server\033[0m\n"
 bin/dtest-server
 echo "Rebuilt and started the testing server for TVS."
 
 echo "Rebuilding the web server…"
+echo "\n\033[36m===> docker-compose down -v --remove-orphans\033[0m\n"
 docker-compose down -v --remove-orphans
+echo "\n\033[36m===> docker-compose build\033[0m\n"
 docker-compose build
+echo "\n\033[36m===> docker-compose run --rm web rake db:seed\033[0m\n"
 docker-compose run --rm web rake db:seed
+echo "\n\033[36m===> bin/drake elasticsearch:vacancies:index\033[0m\n"
 bin/drake elasticsearch:vacancies:index
 echo "Rebuilt and starting the web server for TVS."
+echo "\n\033[36m===> bin/dstart\033[0m\n"
 bin/dstart

--- a/bin/drebuild
+++ b/bin/drebuild
@@ -18,8 +18,10 @@ echo "\n\033[36m===> docker-compose down -v --remove-orphans\033[0m\n"
 docker-compose down -v --remove-orphans
 echo "\n\033[36m===> docker-compose build\033[0m\n"
 docker-compose build
-echo "\n\033[36m===> docker-compose run --rm web rake db:seed\033[0m\n"
-docker-compose run --rm web rake db:seed
+echo "\n\033[36m===> docker-compose run web bin/dsetup\033[0m\n"
+docker-compose run web bin/dsetup
+echo "\n\033[36m===> docker-compose run web rake db:seed\033[0m\n"
+docker-compose run web rake db:seed
 echo "\n\033[36m===> bin/drake elasticsearch:vacancies:index\033[0m\n"
 bin/drake elasticsearch:vacancies:index
 echo "Rebuilt and starting the web server for TVS."

--- a/bin/drebuild
+++ b/bin/drebuild
@@ -11,7 +11,6 @@ run_with_pretty_print 'docker image prune -f'
 
 echo "Rebuilding the test server…"
 run_with_pretty_print 'docker-compose --file=docker-compose.test.yml down -v --remove-orphans'
-run_with_pretty_print 'docker-compose --file=docker-compose.test.yml build'
 run_with_pretty_print 'bin/dtest-server'
 echo "Rebuilt and started the testing server for TVS."
 

--- a/docker-compose.env.sample
+++ b/docker-compose.env.sample
@@ -1,6 +1,4 @@
 GOOGLE_MAPS_API_KEY=
-ELASTICSEARCH_URL=http://elasticsearch:9200
-DATABASE_URL=postgres://postgres@db:5432/tvs_development?template=template0&pool=5&encoding=unicode
 REDIS_QUEUE_URL=redis://redis_queue:6379
 REDIS_CACHE_URL=redis://redis_cache:6379
 DFE_SIGN_IN_ISSUER=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
     container_name: teacher-vacancy-service_web_1
     environment:
       RAILS_ENV: "development"
+      DATABASE_URL: "postgres://postgres@db:5432/tvs_development?template=template0&pool=5&encoding=unicode"
+      ELASTICSEARCH_URL: "http://elasticsearch:9200"
     env_file:
       - docker-compose.env
     depends_on:


### PR DESCRIPTION
## Changes in this PR:

- `bin/drebuild` now echos out the commands it's running to make debugging easier.
- The config for development database and elasticsearch were moved to `docker-compose.yml`. `env_file` overrides `environment`, so both the test and development images were using the same DB and ES (the ones specified in the `.env` file). Specifying `DATABASE_URL` and `ELASTICSEARCH_URL` in `docker-compose.env` will still override the defaults set in `docker-compose.yml` and `docker-compose.test.yml`.
- `bin/drebuild` now explicitly sets up the development database by running `bin/dsetup` (which feels badly named as the rest of the `bin/d*` scripts run docker commands, but `bin/dsetup` runs `rake` directly). Previously it relied on the test setup setting up the dev database. This had the useful side-effect of giving ES time to start before seeding the database and creating the index (at least on my machine).

## Next steps:

- [ ] Terraform deployment required?

- [x] New development configuration to be shared?

Recommend removing `DATABASE_URL` and `ELASTICSEARCH_URL` from `docker-compose.env`.
