### PR TITLE
[811] Match feedback array items regardless of order

### DIFF
--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -11,10 +11,10 @@ RSpec.describe Feedback, type: :model do
       feedback_the_other_day = create_list(:feedback, 4, created_at: 2.days.ago)
       feedback_some_other_day = create_list(:feedback, 6, created_at: 1.month.ago)
 
-      expect(Feedback.published_on(Time.zone.today).all).to eq(feedback_today)
-      expect(Feedback.published_on(1.day.ago)).to eq(feedback_yesterday)
-      expect(Feedback.published_on(2.days.ago)).to eq(feedback_the_other_day)
-      expect(Feedback.published_on(1.month.ago)).to eq(feedback_some_other_day)
+      expect(Feedback.published_on(Time.zone.today).all).to match_array(feedback_today)
+      expect(Feedback.published_on(1.day.ago)).to match_array(feedback_yesterday)
+      expect(Feedback.published_on(2.days.ago)).to match_array(feedback_the_other_day)
+      expect(Feedback.published_on(1.month.ago)).to match_array(feedback_some_other_day)
     end
   end
 


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/7xii0viN/811-intermittent-test-failure-for-feedback

## Changes in this PR:

From the failure output it looks like the arrays are in different orders which would result in a failure.

```
expect([1,2,3,4]).to eq([4,3,1,2]) #failure
```

However we can use the `match_array` matcher to match the items of the array match regardless of order.

```
expect([1,2,3,4]).to match_array([4,3,1,2]) #pass
```

I don't think the order matters in this spec so it should be fine.

It's worth mentioning, I couldn't recreate the error, this is a best guess at a fix