### PR TITLE
Make bin/terraform-deploy deploy the latest version more reliably

### DIFF
--- a/bin/terraform-deploy
+++ b/bin/terraform-deploy
@@ -41,10 +41,10 @@ terraform workspace select "$TERRAFORM_WORKSPACE"
 
 echo "-> Fetching latest git changes …"
 git fetch
-git pull origin $GIT_BRANCH
 
-echo "-> Checking out branch $GIT_BRANCH …"
+echo "-> Checking out and pulling branch $GIT_BRANCH …"
 git checkout $GIT_BRANCH
+git pull origin $GIT_BRANCH
 
 echo "-> Applying Terraform command on the $TERRAFORM_WORKSPACE workspace …"
 terraform apply -var-file="workspace-variables/$TERRAFORM_WORKSPACE.tfvars"

--- a/bin/terraform-deploy
+++ b/bin/terraform-deploy
@@ -39,9 +39,6 @@ fi
 echo "-> Checking out terraform workspace $TERRAFORM_WORKSPACE …"
 terraform workspace select "$TERRAFORM_WORKSPACE"
 
-echo "-> Fetching latest git changes …"
-git fetch
-
 echo "-> Checking out and pulling branch $GIT_BRANCH …"
 git checkout $GIT_BRANCH
 git pull origin $GIT_BRANCH


### PR DESCRIPTION
## Changes in this PR:

We now checkout the branch before pulling it. `git pull origin $GIT_BRANCH` pulls and merges `$GIT_BRANCH` into the currently checkout out branch. Doing that before checking out the intended branch both merges the branch into whatever the current head is, and leaves the local branch unchanged, meaning we then deploy a possibly out of date version.

This change ensures we're on the branch we're intending to deploy before we pull it, updating it to the latest version.

This also removes an unneeded `git fetch` as `git pull` also fetches.

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
