### PR TITLE
[816] Allow AlertResultFinder to return up-to 500 results

### DIFF
--- a/app/services/alert_result_finder.rb
+++ b/app/services/alert_result_finder.rb
@@ -1,4 +1,5 @@
 class AlertResultFinder
+  MAXIMUM_RESULTS = 500
   attr_reader :query, :results
   def initialize(search_criteria, from_date, to_date)
     filters = VacancyFilters.new(search_criteria)
@@ -7,6 +8,6 @@ class AlertResultFinder
   end
 
   def call
-    @results = ElasticSearchFinder.new.call(query[:search_query], query[:search_sort])
+    @results = ElasticSearchFinder.new.call(query[:search_query], query[:search_sort], MAXIMUM_RESULTS)
   end
 end

--- a/app/services/elastic_search_finder.rb
+++ b/app/services/elastic_search_finder.rb
@@ -1,11 +1,7 @@
 require 'elasticsearch'
 
 class ElasticSearchFinder
-  def call(query, sort)
+  def call(query, sort, size = Vacancy.default_per_page)
     Vacancy.__elasticsearch__.search(size: size, query: query, sort: sort)
-  end
-
-  def size
-    Vacancy.default_per_page
   end
 end

--- a/spec/services/alert_result_finder_spec.rb
+++ b/spec/services/alert_result_finder_spec.rb
@@ -4,19 +4,29 @@ RSpec.describe AlertResultFinder do
   let(:from_date) { 2.days.ago.strftime('%Y-%m-%d') }
   let(:to_date) { Time.zone.yesterday.strftime('%Y-%m-%d') }
 
-  it 'generates ES filters from the search_criteria' do
+  it 'generates ES filters from the search_criteria', elasticsearch: true do
     expect(VacancyFilters).to receive(:new).with({})
                                            .and_return(VacancyFilters.new({}))
 
     AlertResultFinder.new({}, from_date, to_date).call
   end
 
-  it 'correctly retrieves the expected_results for a specified time period' do
+  it 'correctly retrieves the expected_results for a specified time period', elasticsearch: true do
     build_list(:vacancy, 4, :published_slugged, publish_on: 2.days.ago).each { |v| v.save(validate: false) }
     create_list(:vacancy, 2, :published_slugged)
     Vacancy.__elasticsearch__.client.indices.flush
 
     results = AlertResultFinder.new({}, from_date, to_date).call
     expect(results.records.count).to eq(4)
+  end
+
+  context 'when there are more than 10 results' do
+    it 'correctly retrieves all the matching vacancies', elasticsearch: true do
+      build_list(:vacancy, 11, :published_slugged, publish_on: 2.days.ago).each { |v| v.save(validate: false) }
+      Vacancy.__elasticsearch__.client.indices.flush
+
+      results = AlertResultFinder.new({}, from_date, to_date).call
+      expect(results.records.count).to eq(11)
+    end
   end
 end

--- a/spec/services/elastic_search_finder_spec.rb
+++ b/spec/services/elastic_search_finder_spec.rb
@@ -12,5 +12,13 @@ RSpec.describe ElasticSearchFinder do
         .with(a_hash_including(query: {}, sort: {}))
       described_class.new.call({}, {})
     end
+
+    context 'a size override is set' do
+      it 'searches elasticsearch and asks for the overridden amount' do
+        expect(Vacancy).to receive_message_chain(:__elasticsearch__, :search)
+          .with(a_hash_including(size: 500))
+        described_class.new.call({}, {}, 500)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/EEGa5k3Q/816-investigate-why-only-up-to-10-vacancies-are-shown-on-job-alerts

## Changes in this PR:
- Fix intermittent failing spec
- Provide an optional override of `size` to ElasticSearchFinder
- AlertResultFinder uses an override of 500 maximum results
