### PR TITLE
[788] Rails and Rollbar receive device and browser information

### DIFF
--- a/terraform/modules/cloudfront/cloudfront.tf
+++ b/terraform/modules/cloudfront/cloudfront.tf
@@ -49,7 +49,9 @@ resource "aws_cloudfront_distribution" "default" {
         "Accept-Charset",
         "Accept-DateTime",
         "Accept-Encoding",
-        "Accept-Language"
+        "Accept-Language",
+        "CloudFront-Forwarded-Proto",
+        "User-Agent",
       ]
 
       cookies {


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/2ny4G9zQ

## Changes in this PR:
* The index+phone and show+phone templates should be shown again when the device is a mobile, particularly important to the home page where the count of job listings should appear at the top of the page
* Whilst ensuring `cache-control` is still respected and can be used to control client level caching
* Cloudfront-Forwarded-Proto added during the investigation to mirror our default CF configuration, following our best practice

## Screenshots of UI changes:

### Before
![Screenshot 2019-03-28 at 16 48 40](https://user-images.githubusercontent.com/912473/55176624-617d3900-5179-11e9-96e3-023337403f67.png)
![Screenshot 2019-03-28 at 16 43 08](https://user-images.githubusercontent.com/912473/55176250-b1a7cb80-5178-11e9-96ab-c9c0038f522d.png)

### After
![Screenshot 2019-03-28 at 16 48 28](https://user-images.githubusercontent.com/912473/55176619-5f1adf00-5179-11e9-8c56-3cad7b8cecd0.png)
![Screenshot 2019-03-28 at 16 42 57](https://user-images.githubusercontent.com/912473/55176259-b5d3e900-5178-11e9-8bc2-88436a481b1d.png)
![Screenshot 2019-03-28 at 16 42 29](https://user-images.githubusercontent.com/912473/55176269-bb313380-5178-11e9-8384-da36a42342b3.png)

## Next steps:

- [x] Terraform deployment required?
