### PR TITLE
[649] Enable sorting functionality in the hiring staff dashboard to improve navigation for users

### DIFF
--- a/app/assets/stylesheets/components/sortable_links.scss
+++ b/app/assets/stylesheets/components/sortable_links.scss
@@ -1,17 +1,27 @@
+.sortable-link {
+  &.active {
+    &.sortby--asc:after {
+      content: "\25B4";
+      display: inline-block;
+      padding-left: 0.2em;
+    }
+    &.sortby--desc:after {
+      content: "\25BE";
+      display: inline-block;
+      padding-left: 0.2em;
+    }
+  }
+}
+
 .sortable-links {
   @extend .govuk-body-s;
   margin-bottom: $govuk-gutter;
   a {
+    @extend .sortable-link;
     margin: 0 4px;
     &.active {
       @include govuk-font(16, $weight: bold);
       text-decoration: none;
-      &.sortby--asc:after {
-        content: ' \25B4';
-      }
-      &.sortby--desc:after {
-        content: ' \25BE';
-      }
     }
   }
 }

--- a/app/controllers/hiring_staff/schools_controller.rb
+++ b/app/controllers/hiring_staff/schools_controller.rb
@@ -2,7 +2,8 @@ class HiringStaff::SchoolsController < HiringStaff::BaseController
   def show
     @multiple_schools = session_has_multiple_schools?
     @school = SchoolPresenter.new(current_school)
-    @vacancy_presenter = SchoolVacanciesPresenter.new(@school, params[:type])
+    @sort = VacancySort.new.update(column: params[:sort_column], order: params[:sort_order])
+    @vacancy_presenter = SchoolVacanciesPresenter.new(@school, @sort, params[:type])
   end
 
   def edit

--- a/app/helpers/hiring_staff/schools_helper.rb
+++ b/app/helpers/hiring_staff/schools_helper.rb
@@ -1,5 +1,5 @@
 module HiringStaff::SchoolsHelper
-  def table_header_sort_by(title, column:, sort:)
+  def table_header_sort_by(title, type, column:, sort:)
     if column == sort.column
       order = sort.reverse_order
       active_class = ' active'
@@ -8,7 +8,7 @@ module HiringStaff::SchoolsHelper
     end
 
     link_to title,
-            jobs_with_type_school_path(school_vacancy_params(sort_column: column, sort_order: order)),
+            jobs_with_type_school_path(type, school_vacancy_params(sort_column: column, sort_order: order)),
             class: "govuk-link sortable-link sortby--#{order}#{active_class || ''}",
             'aria-label': "Sort jobs by #{title} in #{order}ending order"
   end

--- a/app/helpers/hiring_staff/schools_helper.rb
+++ b/app/helpers/hiring_staff/schools_helper.rb
@@ -1,15 +1,12 @@
 module HiringStaff::SchoolsHelper
   def table_header_sort_by(title, type, column:, sort:)
-    if column == sort.column
-      order = sort.reverse_order
-      active_class = ' active'
-    else
-      order = sort.order
-    end
+    order = column == sort.column ? sort.reverse_order : sort.order
+    extra_classes = "sortby--#{order}"
+    extra_classes += ' active' if column == sort.column
 
     link_to title,
             jobs_with_type_school_path(type, school_vacancy_params(sort_column: column, sort_order: order)),
-            class: "govuk-link sortable-link sortby--#{order}#{active_class || ''}",
+            class: "govuk-link sortable-link #{extra_classes}",
             'aria-label': t('jobs.aria_labels.sort_by_link', column: title, order: order)
   end
 

--- a/app/helpers/hiring_staff/schools_helper.rb
+++ b/app/helpers/hiring_staff/schools_helper.rb
@@ -9,7 +9,7 @@ module HiringStaff::SchoolsHelper
 
     link_to title,
             jobs_with_type_school_path(school_vacancy_params(sort_column: column, sort_order: order)),
-            class: "govuk-link sortby--#{order}#{active_class || ''}",
+            class: "govuk-link sortable-link sortby--#{order}#{active_class || ''}",
             'aria-label': "Sort jobs by #{title} in #{order}ending order"
   end
 

--- a/app/helpers/hiring_staff/schools_helper.rb
+++ b/app/helpers/hiring_staff/schools_helper.rb
@@ -1,0 +1,23 @@
+module HiringStaff::SchoolsHelper
+  def table_header_sort_by(title, column:, sort:)
+    if column == sort.column
+      order = sort.reverse_order
+      active_class = ' active'
+    else
+      order = sort.order
+    end
+
+    link_to title,
+            jobs_with_type_school_path(school_vacancy_params(sort_column: column, sort_order: order)),
+            class: "govuk-link sortby--#{order}#{active_class || ''}",
+            'aria-label': "Sort jobs by #{title} in #{order}ending order"
+  end
+
+  def school_vacancy_params_whitelist
+    %i[sort_column sort_order]
+  end
+
+  def school_vacancy_params(overwrite = {})
+    params.merge(overwrite).permit(school_vacancy_params_whitelist)
+  end
+end

--- a/app/helpers/hiring_staff/schools_helper.rb
+++ b/app/helpers/hiring_staff/schools_helper.rb
@@ -10,7 +10,7 @@ module HiringStaff::SchoolsHelper
     link_to title,
             jobs_with_type_school_path(type, school_vacancy_params(sort_column: column, sort_order: order)),
             class: "govuk-link sortable-link sortby--#{order}#{active_class || ''}",
-            'aria-label': "Sort jobs by #{title} in #{order}ending order"
+            'aria-label': t('jobs.aria_labels.sort_by_link', column: title, order: order)
   end
 
   def school_vacancy_params_whitelist

--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -25,7 +25,7 @@ module VacanciesHelper
             jobs_path(vacancy_params(sort_column: column,
                                      sort_order: order)),
             class: "govuk-link sortby--#{order}#{active_class || ''}",
-            'aria-label': "Sort jobs by #{title} in #{order}ending order"
+            'aria-label': t('jobs.aria_labels.sort_by_link', column: title, order: order)
   end
 
   def vacancy_params_whitelist

--- a/app/presenters/school_vacancies_presenter.rb
+++ b/app/presenters/school_vacancies_presenter.rb
@@ -1,9 +1,10 @@
 class SchoolVacanciesPresenter < BasePresenter
-  attr_reader :vacancy_type, :school, :vacancies
+  attr_reader :vacancy_type, :school, :sort, :vacancies
 
-  def initialize(school, vacancy_type)
+  def initialize(school, sort, vacancy_type)
     @vacancy_type = vacancy_type&.to_sym || :published
     @school = school
+    @sort = sort
     raise ArgumentError unless self.class.valid_types.include?(@vacancy_type)
 
     @vacancies = send(@vacancy_type).map { |v| SchoolVacancyPresenter.new(v) }
@@ -16,18 +17,25 @@ class SchoolVacanciesPresenter < BasePresenter
   private
 
   def draft
-    @school.vacancies.draft
+    sort_vacancies(@school.vacancies.draft)
   end
 
   def pending
-    @school.vacancies.pending
+    sort_vacancies(@school.vacancies.pending)
   end
 
   def expired
-    @school.vacancies.expired
+    sort_vacancies(@school.vacancies.expired)
   end
 
   def published
-    @school.vacancies.live
+    sort_vacancies(@school.vacancies.live)
+  end
+
+  def sort_vacancies(vacancies)
+    vacancies = vacancies.sort_by { |vacancy| vacancy[sort.column] }
+    vacancies = vacancies.reverse! if sort.order == 'desc'
+
+    vacancies
   end
 end

--- a/app/presenters/school_vacancies_presenter.rb
+++ b/app/presenters/school_vacancies_presenter.rb
@@ -17,25 +17,18 @@ class SchoolVacanciesPresenter < BasePresenter
   private
 
   def draft
-    sort_vacancies(@school.vacancies.draft)
+    @school.vacancies.draft.order(sort.column => sort.order)
   end
 
   def pending
-    sort_vacancies(@school.vacancies.pending)
+    @school.vacancies.pending.order(sort.column => sort.order)
   end
 
   def expired
-    sort_vacancies(@school.vacancies.expired)
+    @school.vacancies.expired.order(sort.column => sort.order)
   end
 
   def published
-    sort_vacancies(@school.vacancies.live)
-  end
-
-  def sort_vacancies(vacancies)
-    vacancies = vacancies.sort_by { |vacancy| vacancy[sort.column] }
-    vacancies = vacancies.reverse! if sort.order == 'desc'
-
-    vacancies
+    @school.vacancies.live.order(sort.column => sort.order)
   end
 end

--- a/app/services/vacancy_sort.rb
+++ b/app/services/vacancy_sort.rb
@@ -1,7 +1,8 @@
 class VacancySort
   attr_reader :column, :order
 
-  VALID_SORT_COLUMNS = %w[job_title expires_on starts_on publish_on].freeze
+  VALID_SORT_COLUMNS = %w[job_title date_to_be_posted expires_on expired_on starts_on publish_on
+                          page_views get_more_info_clicks draft.time_created draft.time_updated].freeze
   VALID_SORT_ORDERS = %w[desc asc].freeze
 
   def initialize(default_column: 'expires_on', default_order: 'asc')

--- a/app/services/vacancy_sort.rb
+++ b/app/services/vacancy_sort.rb
@@ -1,8 +1,8 @@
 class VacancySort
   attr_reader :column, :order
 
-  VALID_SORT_COLUMNS = %w[job_title date_to_be_posted expires_on expired_on starts_on publish_on
-                          page_views get_more_info_clicks draft.time_created draft.time_updated].freeze
+  VALID_SORT_COLUMNS = %w[job_title expires_on starts_on publish_on created_at updated_at
+                          total_pageviews total_get_more_info_clicks].freeze
   VALID_SORT_ORDERS = %w[desc asc].freeze
 
   def initialize(default_column: 'expires_on', default_order: 'asc')

--- a/app/views/hiring_staff/schools/_vacancies_draft.html.haml
+++ b/app/views/hiring_staff/schools/_vacancies_draft.html.haml
@@ -6,8 +6,8 @@
             %thead.govuk-table__head
                 %tr.govuk-table__row
                     %th.govuk-table__header= table_header_sort_by(t('jobs.job_title'), 'draft', column: 'job_title', sort: @sort)
-                    %th.govuk-table__header= table_header_sort_by(t('jobs.draft.time_created'), 'draft', column: 'draft.time_created', sort: @sort)
-                    %th.govuk-table__header= table_header_sort_by(t('jobs.draft.time_updated'), 'draft', column: 'draft.time_updated', sort: @sort)
+                    %th.govuk-table__header= table_header_sort_by(t('jobs.draft.time_created'), 'draft', column: 'created_at', sort: @sort)
+                    %th.govuk-table__header= table_header_sort_by(t('jobs.draft.time_updated'), 'draft', column: 'updated_at', sort: @sort)
                     %th.govuk-table__header{ colspan: 2}= t('jobs.actions')
             %tbody.govuk-table__body
                 - presenter.vacancies.each do |vacancy|

--- a/app/views/hiring_staff/schools/_vacancies_draft.html.haml
+++ b/app/views/hiring_staff/schools/_vacancies_draft.html.haml
@@ -5,9 +5,9 @@
         %table{class: 'vacancies govuk-table govuk-!-margin-top-4'}
             %thead.govuk-table__head
                 %tr.govuk-table__row
-                    %th.govuk-table__header= t('jobs.job_title')
-                    %th.govuk-table__header= t('jobs.draft.time_created')
-                    %th.govuk-table__header= t('jobs.draft.time_updated')
+                    %th.govuk-table__header= table_header_sort_by(t('jobs.job_title'), 'draft', column: 'job_title', sort: @sort)
+                    %th.govuk-table__header= table_header_sort_by(t('jobs.draft.time_created'), 'draft', column: 'draft.time_created', sort: @sort)
+                    %th.govuk-table__header= table_header_sort_by(t('jobs.draft.time_updated'), 'draft', column: 'draft.time_updated', sort: @sort)
                     %th.govuk-table__header{ colspan: 2}= t('jobs.actions')
             %tbody.govuk-table__body
                 - presenter.vacancies.each do |vacancy|

--- a/app/views/hiring_staff/schools/_vacancies_expired.html.haml
+++ b/app/views/hiring_staff/schools/_vacancies_expired.html.haml
@@ -6,11 +6,11 @@
         %table{class: 'vacancies govuk-table govuk-!-margin-top-4'}
             %thead.govuk-table__head
                 %tr.govuk-table__row
-                    %th.govuk-table__header= t('jobs.job_title')
-                    %th.govuk-table__header= t('jobs.date_to_be_posted')
-                    %th.govuk-table__header= t('jobs.expired_on')
-                    %th.govuk-table__header= t('jobs.page_views')
-                    %th.govuk-table__header= t('jobs.get_more_info_clicks')
+                    %th.govuk-table__header= table_header_sort_by(t('jobs.job_title'), 'expired', column: 'job_title', sort: @sort)
+                    %th.govuk-table__header= table_header_sort_by(t('jobs.date_to_be_posted'), 'expired', column: 'date_to_be_posted', sort: @sort)
+                    %th.govuk-table__header= table_header_sort_by(t('jobs.expired_on'), 'expired', column: 'expired_on', sort: @sort)
+                    %th.govuk-table__header= table_header_sort_by(t('jobs.page_views'), 'expired', column: 'page_views', sort: @sort)
+                    %th.govuk-table__header= table_header_sort_by(t('jobs.get_more_info_clicks'), 'expired', column: 'get_more_info_clicks', sort: @sort)
                     %th.govuk-table__header{ colspan: 2 }= t('jobs.actions')
             %tbody.govuk-table__body
                 - presenter.vacancies.each do |vacancy|

--- a/app/views/hiring_staff/schools/_vacancies_expired.html.haml
+++ b/app/views/hiring_staff/schools/_vacancies_expired.html.haml
@@ -7,7 +7,7 @@
             %thead.govuk-table__head
                 %tr.govuk-table__row
                     %th.govuk-table__header= table_header_sort_by(t('jobs.job_title'), 'expired', column: 'job_title', sort: @sort)
-                    %th.govuk-table__header= table_header_sort_by(t('jobs.date_to_be_posted'), 'expired', column: 'date_to_be_posted', sort: @sort)
+                    %th.govuk-table__header= table_header_sort_by(t('jobs.publish_on'), 'expired', column: 'publish_on', sort: @sort)
                     %th.govuk-table__header= table_header_sort_by(t('jobs.expired_on'), 'expired', column: 'expired_on', sort: @sort)
                     %th.govuk-table__header= table_header_sort_by(t('jobs.page_views'), 'expired', column: 'page_views', sort: @sort)
                     %th.govuk-table__header= table_header_sort_by(t('jobs.get_more_info_clicks'), 'expired', column: 'get_more_info_clicks', sort: @sort)

--- a/app/views/hiring_staff/schools/_vacancies_expired.html.haml
+++ b/app/views/hiring_staff/schools/_vacancies_expired.html.haml
@@ -8,9 +8,9 @@
                 %tr.govuk-table__row
                     %th.govuk-table__header= table_header_sort_by(t('jobs.job_title'), 'expired', column: 'job_title', sort: @sort)
                     %th.govuk-table__header= table_header_sort_by(t('jobs.publish_on'), 'expired', column: 'publish_on', sort: @sort)
-                    %th.govuk-table__header= table_header_sort_by(t('jobs.expired_on'), 'expired', column: 'expired_on', sort: @sort)
-                    %th.govuk-table__header= table_header_sort_by(t('jobs.page_views'), 'expired', column: 'page_views', sort: @sort)
-                    %th.govuk-table__header= table_header_sort_by(t('jobs.get_more_info_clicks'), 'expired', column: 'get_more_info_clicks', sort: @sort)
+                    %th.govuk-table__header= table_header_sort_by(t('jobs.expired_on'), 'expired', column: 'expires_on', sort: @sort)
+                    %th.govuk-table__header= table_header_sort_by(t('jobs.page_views'), 'expired', column: 'total_pageviews', sort: @sort)
+                    %th.govuk-table__header= table_header_sort_by(t('jobs.get_more_info_clicks'), 'expired', column: 'total_get_more_info_clicks', sort: @sort)
                     %th.govuk-table__header{ colspan: 2 }= t('jobs.actions')
             %tbody.govuk-table__body
                 - presenter.vacancies.each do |vacancy|

--- a/app/views/hiring_staff/schools/_vacancies_pending.html.haml
+++ b/app/views/hiring_staff/schools/_vacancies_pending.html.haml
@@ -6,9 +6,9 @@
         %table{class: 'vacancies govuk-table govuk-!-margin-top-4'}
             %thead.govuk-table__head
                 %tr.govuk-table__row
-                    %th.govuk-table__header= t('jobs.job_title')
-                    %th.govuk-table__header= t('jobs.date_to_be_posted')
-                    %th.govuk-table__header= t('jobs.expires_on')
+                    %th.govuk-table__header= table_header_sort_by(t('jobs.job_title'), 'pending', column: 'job_title', sort: @sort)
+                    %th.govuk-table__header= table_header_sort_by(t('jobs.date_to_be_posted'), 'pending', column: 'date_to_be_posted', sort: @sort)
+                    %th.govuk-table__header= table_header_sort_by(t('jobs.expires_on'), 'pending', column: 'expires_on', sort: @sort)
                     %th.govuk-table__header{ colspan: 3}= t('jobs.actions')
             %tbody.govuk-table__body
                 - presenter.vacancies.each do |vacancy|

--- a/app/views/hiring_staff/schools/_vacancies_pending.html.haml
+++ b/app/views/hiring_staff/schools/_vacancies_pending.html.haml
@@ -7,7 +7,7 @@
             %thead.govuk-table__head
                 %tr.govuk-table__row
                     %th.govuk-table__header= table_header_sort_by(t('jobs.job_title'), 'pending', column: 'job_title', sort: @sort)
-                    %th.govuk-table__header= table_header_sort_by(t('jobs.date_to_be_posted'), 'pending', column: 'date_to_be_posted', sort: @sort)
+                    %th.govuk-table__header= table_header_sort_by(t('jobs.date_to_be_posted'), 'pending', column: 'publish_on', sort: @sort)
                     %th.govuk-table__header= table_header_sort_by(t('jobs.expires_on'), 'pending', column: 'expires_on', sort: @sort)
                     %th.govuk-table__header{ colspan: 3}= t('jobs.actions')
             %tbody.govuk-table__body

--- a/app/views/hiring_staff/schools/_vacancies_published.html.haml
+++ b/app/views/hiring_staff/schools/_vacancies_published.html.haml
@@ -8,8 +8,8 @@
                     %th.govuk-table__header= table_header_sort_by(t('jobs.job_title'), 'published', column: 'job_title', sort: @sort)
                     %th.govuk-table__header= table_header_sort_by(t('jobs.publish_on'), 'published', column: 'publish_on', sort: @sort)
                     %th.govuk-table__header= table_header_sort_by(t('jobs.expires_on'), 'published', column: 'expires_on', sort: @sort)
-                    %th.govuk-table__header= table_header_sort_by(t('jobs.page_views'), 'published', column: 'page_views', sort: @sort)
-                    %th.govuk-table__header= table_header_sort_by(t('jobs.get_more_info_clicks'), 'published', column: 'get_more_info_clicks', sort: @sort)
+                    %th.govuk-table__header= table_header_sort_by(t('jobs.page_views'), 'published', column: 'total_pageviews', sort: @sort)
+                    %th.govuk-table__header= table_header_sort_by(t('jobs.get_more_info_clicks'), 'published', column: 'total_get_more_info_clicks', sort: @sort)
                     %th.govuk-table__header{ colspan: 3}= t('jobs.actions')
             %tbody.govuk-table__body
                 - presenter.vacancies.each do |vacancy|

--- a/app/views/hiring_staff/schools/_vacancies_published.html.haml
+++ b/app/views/hiring_staff/schools/_vacancies_published.html.haml
@@ -5,9 +5,9 @@
         %table{class: 'vacancies govuk-table govuk-!-margin-top-4'}
             %thead.govuk-table__head
                 %tr.govuk-table__row
-                    %th.govuk-table__header= t('jobs.job_title')
-                    %th.govuk-table__header= t('jobs.publish_on')
-                    %th.govuk-table__header= t('jobs.expires_on')
+                    %th.govuk-table__header= table_header_sort_by(t('jobs.job_title'), column: 'job_title', sort: @sort)
+                    %th.govuk-table__header= table_header_sort_by(t('jobs.publish_on'), column: 'publish_on', sort: @sort)
+                    %th.govuk-table__header= table_header_sort_by(t('jobs.expires_on'), column: 'expires_on', sort: @sort)
                     %th.govuk-table__header= t('jobs.page_views')
                     %th.govuk-table__header= t('jobs.get_more_info_clicks')
                     %th.govuk-table__header{ colspan: 3}= t('jobs.actions')

--- a/app/views/hiring_staff/schools/_vacancies_published.html.haml
+++ b/app/views/hiring_staff/schools/_vacancies_published.html.haml
@@ -5,11 +5,11 @@
         %table{class: 'vacancies govuk-table govuk-!-margin-top-4'}
             %thead.govuk-table__head
                 %tr.govuk-table__row
-                    %th.govuk-table__header= table_header_sort_by(t('jobs.job_title'), column: 'job_title', sort: @sort)
-                    %th.govuk-table__header= table_header_sort_by(t('jobs.publish_on'), column: 'publish_on', sort: @sort)
-                    %th.govuk-table__header= table_header_sort_by(t('jobs.expires_on'), column: 'expires_on', sort: @sort)
-                    %th.govuk-table__header= t('jobs.page_views')
-                    %th.govuk-table__header= t('jobs.get_more_info_clicks')
+                    %th.govuk-table__header= table_header_sort_by(t('jobs.job_title'), 'published', column: 'job_title', sort: @sort)
+                    %th.govuk-table__header= table_header_sort_by(t('jobs.publish_on'), 'published', column: 'publish_on', sort: @sort)
+                    %th.govuk-table__header= table_header_sort_by(t('jobs.expires_on'), 'published', column: 'expires_on', sort: @sort)
+                    %th.govuk-table__header= table_header_sort_by(t('jobs.page_views'), 'published', column: 'page_views', sort: @sort)
+                    %th.govuk-table__header= table_header_sort_by(t('jobs.get_more_info_clicks'), 'published', column: 'get_more_info_clicks', sort: @sort)
                     %th.govuk-table__header{ colspan: 3}= t('jobs.actions')
             %tbody.govuk-table__body
                 - presenter.vacancies.each do |vacancy|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -175,6 +175,7 @@ en:
       application_link_url: 'Link for more information (link opens external website in a new window) — %{url}'
       flexible_working: 'Flexible working (optional)'
       newly_qualified_teacher: 'Newly qualified teacher (optional)'
+      sort_by_link: Sort jobs by %{column} in %{order}ending order
     form_hints:
       job_title: "For secondary school roles include subject and, if relevant, level of seniority ('Subject leader for science', for example)."
       description: 'Briefly describe the duties and responsibilities involved in the role (minimum 10 characters)'

--- a/spec/helpers/hiring_staff/schools_helper_spec.rb
+++ b/spec/helpers/hiring_staff/schools_helper_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe HiringStaff::SchoolsHelper, type: :helper do
       result = helper.table_header_sort_by('foo', column: 'job_title', sort: sort)
 
       expect(result).to eq(
-        '<a class="govuk-link sortby--asc" aria-label="Sort jobs by foo in ascending order" '\
+        '<a class="govuk-link sortable-link sortby--asc" aria-label="Sort jobs by foo in ascending order" '\
         'href="/school/jobs?sort_column=job_title&amp;sort_order=asc">foo</a>'
       )
     end
@@ -18,7 +18,7 @@ RSpec.describe HiringStaff::SchoolsHelper, type: :helper do
         result = helper.table_header_sort_by('foo', column: 'job_title', sort: sort)
 
         expect(result).to eq(
-          '<a class="govuk-link sortby--desc active" aria-label="Sort jobs by foo in descending order" '\
+          '<a class="govuk-link sortable-link sortby--desc active" aria-label="Sort jobs by foo in descending order" '\
           'href="/school/jobs?sort_column=job_title&amp;sort_order=desc">foo</a>'
         )
       end

--- a/spec/helpers/hiring_staff/schools_helper_spec.rb
+++ b/spec/helpers/hiring_staff/schools_helper_spec.rb
@@ -4,18 +4,18 @@ RSpec.describe HiringStaff::SchoolsHelper, type: :helper do
   describe '#table_header_sort_by' do
     it 'returns a link to the hiring staff index with the new parameters' do
       sort = VacancySort.new
-      result = helper.table_header_sort_by('foo', column: 'job_title', sort: sort)
+      result = helper.table_header_sort_by('foo', 'pending', column: 'job_title', sort: sort)
 
       expect(result).to eq(
         '<a class="govuk-link sortable-link sortby--asc" aria-label="Sort jobs by foo in ascending order" '\
-        'href="/school/jobs?sort_column=job_title&amp;sort_order=asc">foo</a>'
+        'href="/school/jobs/pending?sort_column=job_title&amp;sort_order=asc">foo</a>'
       )
     end
 
     context 'the current sort column is the same as the given column' do
       it 'outputs an active class and reverses the sort order' do
         sort = VacancySort.new(default_column: 'job_title', default_order: 'asc')
-        result = helper.table_header_sort_by('foo', column: 'job_title', sort: sort)
+        result = helper.table_header_sort_by('foo', 'published', column: 'job_title', sort: sort)
 
         expect(result).to eq(
           '<a class="govuk-link sortable-link sortby--desc active" aria-label="Sort jobs by foo in descending order" '\

--- a/spec/helpers/hiring_staff/schools_helper_spec.rb
+++ b/spec/helpers/hiring_staff/schools_helper_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe HiringStaff::SchoolsHelper, type: :helper do
+  describe '#table_header_sort_by' do
+    it 'returns a link to the hiring staff index with the new parameters' do
+      sort = VacancySort.new
+      result = helper.table_header_sort_by('foo', column: 'job_title', sort: sort)
+
+      expect(result).to eq(
+        '<a class="govuk-link sortby--asc" aria-label="Sort jobs by foo in ascending order" '\
+        'href="/school/jobs?sort_column=job_title&amp;sort_order=asc">foo</a>'
+      )
+    end
+
+    context 'the current sort column is the same as the given column' do
+      it 'outputs an active class and reverses the sort order' do
+        sort = VacancySort.new(default_column: 'job_title', default_order: 'asc')
+        result = helper.table_header_sort_by('foo', column: 'job_title', sort: sort)
+
+        expect(result).to eq(
+          '<a class="govuk-link sortby--desc active" aria-label="Sort jobs by foo in descending order" '\
+          'href="/school/jobs?sort_column=job_title&amp;sort_order=desc">foo</a>'
+        )
+      end
+    end
+  end
+end

--- a/spec/presenters/school_vacancies_presenter_spec.rb
+++ b/spec/presenters/school_vacancies_presenter_spec.rb
@@ -1,8 +1,9 @@
 require 'rails_helper'
 RSpec.describe SchoolVacanciesPresenter do
   let(:school) { create(:school) }
+  let(:sort) { VacancySort.new }
   let(:type) { 'published' }
-  let(:presenter) { described_class.new(school, type) }
+  let(:presenter) { described_class.new(school, sort, type) }
 
   let!(:draft_vacancies) { create_list(:vacancy, 5, :draft, school: school) }
   let!(:pending_vacancies) { create_list(:vacancy, 2, :future_publish, school: school) }

--- a/spec/presenters/school_vacancies_presenter_spec.rb
+++ b/spec/presenters/school_vacancies_presenter_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe SchoolVacanciesPresenter do
   let(:presenter) { described_class.new(school, sort, type) }
 
   let!(:draft_vacancies) { create_list(:vacancy, 5, :draft, school: school) }
-  let!(:pending_vacancies) { create_list(:vacancy, 2, :future_publish, school: school) }
+  let!(:pending_vacancies) { create_list(:vacancy, 4, :future_publish, school: school) }
   let!(:expired_vacancies) do
     expired_vacancies = []
     3.times do
@@ -16,7 +16,7 @@ RSpec.describe SchoolVacanciesPresenter do
     end
     expired_vacancies
   end
-  let!(:live_vacancies) { create_list(:vacancy, 7, :published, school: school) }
+  let!(:published_vacancies) { create_list(:vacancy, 7, :published, school: school) }
 
   it 'returns the school' do
     expect(presenter.school).to eq(school)
@@ -32,6 +32,11 @@ RSpec.describe SchoolVacanciesPresenter do
     it 'returns draft vacancies' do
       expect(presenter.vacancies.count).to eq(draft_vacancies.count)
     end
+
+    it 'returns sorted draft vacancies' do
+      sort.update(column: 'job_title', order: 'desc')
+      expect(presenter.vacancies).to eq(draft_vacancies.sort_by { |vacancy| vacancy['job_title'] }.reverse)
+    end
   end
 
   context 'when type is pending' do
@@ -41,8 +46,13 @@ RSpec.describe SchoolVacanciesPresenter do
       expect(presenter.vacancy_type).to eq(:pending)
     end
 
-    it 'returns draft vacancies' do
+    it 'returns pending vacancies' do
       expect(presenter.vacancies.count).to eq(pending_vacancies.count)
+    end
+
+    it 'returns sorted pending vacancies' do
+      sort.update(column: 'job_title', order: 'desc')
+      expect(presenter.vacancies).to eq(pending_vacancies.sort_by { |vacancy| vacancy['job_title'] }.reverse)
     end
   end
 
@@ -56,6 +66,11 @@ RSpec.describe SchoolVacanciesPresenter do
     it 'returns expired vacancies' do
       expect(presenter.vacancies.count).to eq(expired_vacancies.count)
     end
+
+    it 'returns sorted expired vacancies' do
+      sort.update(column: 'job_title', order: 'desc')
+      expect(presenter.vacancies).to eq(expired_vacancies.sort_by { |vacancy| vacancy['job_title'] }.reverse)
+    end
   end
 
   context 'when type is published' do
@@ -65,8 +80,13 @@ RSpec.describe SchoolVacanciesPresenter do
       expect(presenter.vacancy_type).to eq(:published)
     end
 
-    it 'returns draft vacancies' do
-      expect(presenter.vacancies.count).to eq(live_vacancies.count)
+    it 'returns published vacancies' do
+      expect(presenter.vacancies.count).to eq(published_vacancies.count)
+    end
+
+    it 'returns sorted published vacancies' do
+      sort.update(column: 'job_title', order: 'desc')
+      expect(presenter.vacancies).to eq(published_vacancies.sort_by { |vacancy| vacancy['job_title'] }.reverse)
     end
   end
 


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/yFSXUE63/649-enable-sorting-functionality-in-the-hiring-staff-dashboard-to-improve-navigation-for-users

## Changes in this PR:

This change adds sorting to all the data columns of the hiring staff vacancy view.
- `SchoolVacanciesPresenter` now requires a `sort` argument. This mirrors the behaviour of `VacanciesFinder`.
- `VacancySort` was reused with some minor changes to add some more valid sort columns.
- A new `HiringStaff::SchoolsHelper` was created to generate sorting links, in a similar way to `VacanciesHelper`.
- The existing CSS for sorting was refactored to allow for reuse without all of the link styling. There is a small change to the implementation, using padding rather than a space in the `:after` block. This is needed to avoid underlining the arrow.

## Screenshots of UI changes:

### Before

<img width="869" alt="Screenshot 2019-04-01 at 13 46 53" src="https://user-images.githubusercontent.com/1027364/55328593-a7d9dd00-5484-11e9-8925-b0787d712588.png">

### After

<img width="871" alt="Screenshot 2019-04-01 at 13 44 25" src="https://user-images.githubusercontent.com/1027364/55328608-ad372780-5484-11e9-9ad4-405f602b3106.png">