### PR TITLE
[817] Send Performance Platform data in GMT rather than UTC 

### DIFF
--- a/app/jobs/performance_platform_feedback_queue_job.rb
+++ b/app/jobs/performance_platform_feedback_queue_job.rb
@@ -8,7 +8,7 @@ class PerformancePlatformFeedbackQueueJob < ApplicationJob
 
     data = { 1 => 0, 2 => 0, 3 => 0, 4 => 0, 5 => 0 }.merge!(Feedback.published_on(date).group(:rating).count)
     PerformancePlatform::UserSatisfaction.new(PP_USER_SATISFACTION_TOKEN)
-                                         .submit(data, date.utc.iso8601)
+                                         .submit(data, date.iso8601)
     TransactionAuditor::Logger.new('performance_platform:submit_user_satisfaction', date).log_success
   rescue StandardError => e
     TransactionAuditor::Logger.new('performance_platform:submit_user_satisfaction', date).log_failure

--- a/app/jobs/performance_platform_transactions_queue_job.rb
+++ b/app/jobs/performance_platform_transactions_queue_job.rb
@@ -3,13 +3,14 @@ class PerformancePlatformTransactionsQueueJob < ApplicationJob
   queue_as :performance_platform
 
   def perform(time_to_s)
-    date = Time.zone.parse(time_to_s)
+    time = Time.zone.parse(time_to_s)
+    date = time.to_date
 
     return if TransactionAuditor::Logger.new('performance_platform:submit_transactions', date).performed?
 
     no_of_transactions = Vacancy.published_on_count(date)
     PerformancePlatform::TransactionsByChannel.new(PP_TRANSACTIONS_BY_CHANNEL_TOKEN)
-                                              .submit_transactions(no_of_transactions, date.utc.iso8601)
+                                              .submit_transactions(no_of_transactions, time.iso8601)
 
     TransactionAuditor::Logger.new('performance_platform:submit_transactions', date).log_success
   rescue StandardError => e

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -4,7 +4,7 @@ class Feedback < ApplicationRecord
 
   validates :rating, presence: true
 
-  scope :published_on, (->(date) { where('date(created_at) = ?', date) })
+  scope :published_on, (->(date) { where(created_at: date.all_day) })
 
   def to_row
     [

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -97,7 +97,7 @@ class Vacancy < ApplicationRecord
   scope :applicable, (-> { where('expires_on >= ?', Time.zone.today) })
   scope :active, (-> { where(status: %i[published draft]) })
   scope :listed, (-> { published.where('publish_on <= ?', Time.zone.today) })
-  scope :published_on_count, (->(date) { published.where('date(publish_on) = ?', date).count })
+  scope :published_on_count, (->(date) { published.where(publish_on: date.all_day).count })
   scope :pending, (-> { published.where('publish_on > ?', Time.zone.today) })
   scope :expired, (-> { published.where('expires_on < ?', Time.zone.today) })
   scope :live, (-> { published.where('publish_on <= ?', Time.zone.today).where('expires_on > ?', Time.zone.today) })

--- a/lib/performance_platform.rb
+++ b/lib/performance_platform.rb
@@ -14,7 +14,7 @@ module PerformancePlatform
   end
 
   class TransactionsByChannel < Base
-    def submit_transactions(count, timestamp = Time.zone.now.utc.iso8601, period = 'day')
+    def submit_transactions(count, timestamp = Time.zone.now.iso8601, period = 'day')
       HTTParty.post("#{PP_DOMAIN}#{transaction_endpoint}",
                     body: data(timestamp, period, count),
                     headers: headers)

--- a/lib/performance_platform.rb
+++ b/lib/performance_platform.rb
@@ -37,7 +37,7 @@ module PerformancePlatform
   end
 
   class UserSatisfaction < Base
-    def submit(rating_counts, timestamp = Time.zone.now.utc.iso8601, period = 'day')
+    def submit(rating_counts, timestamp = Time.zone.now.iso8601, period = 'day')
       HTTParty.post("#{PP_DOMAIN}#{transaction_endpoint}",
                     body: data(timestamp, period, rating_counts.values.inject(:+), rating_counts),
                     headers: headers)

--- a/spec/jobs/performance_platform_feedback_queue_job_spec.rb
+++ b/spec/jobs/performance_platform_feedback_queue_job_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe PerformancePlatformFeedbackQueueJob, type: :job do
     expect(PerformancePlatform::UserSatisfaction).to receive(:new)
       .with('user-satisfaction-token')
       .and_return(user_satisfaction)
-    expect(user_satisfaction).to receive(:submit).with(ratings, date.utc.iso8601)
+    expect(user_satisfaction).to receive(:submit).with(ratings, date.iso8601)
 
     perform_enqueued_jobs { job }
   end

--- a/spec/jobs/performance_platform_feedback_queue_job_spec.rb
+++ b/spec/jobs/performance_platform_feedback_queue_job_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 RSpec.describe PerformancePlatformFeedbackQueueJob, type: :job do
   include ActiveJob::TestHelper
 
-  subject(:date) { Date.current.beginning_of_day.in_time_zone }
-  subject(:job) { described_class.perform_later(date.to_s) }
+  subject(:date_to_upload) { Date.current.beginning_of_day.in_time_zone - 1.day }
+  subject(:job) { described_class.perform_later(date_to_upload.to_s) }
 
   it 'queues the job' do
     expect { job }.to change(ActiveJob::Base.queue_adapter.enqueued_jobs, :size).by(1)
@@ -19,16 +19,27 @@ RSpec.describe PerformancePlatformFeedbackQueueJob, type: :job do
 
     user_satisfaction = double(:user_satisfaction)
 
-    feedback = create_list(:feedback, 2, rating: 3, created_at: date)
-    feedback << create_list(:feedback, 3, rating: 5, created_at: date)
-    feedback.flatten!
+    today = Date.current.beginning_of_day.in_time_zone
+    two_days_ago = today - 2.days
 
-    ratings = { 1 => 0, 2 => 0, 3 => 2, 4 => 0, 5 => 3 }
+    create_list(:feedback, 3, rating: 1, created_at: today)
+    create_list(:feedback, 4, rating: 4, created_at: two_days_ago)
+
+    rating3 = create_list(:feedback, 2, rating: 3, created_at: date_to_upload)
+    rating5 = create_list(:feedback, 3, rating: 5, created_at: date_to_upload)
+
+    ratings = {
+      1 => 0,
+      2 => 0,
+      3 => rating3.count,
+      4 => 0,
+      5 => rating5.count
+    }
 
     expect(PerformancePlatform::UserSatisfaction).to receive(:new)
       .with('user-satisfaction-token')
       .and_return(user_satisfaction)
-    expect(user_satisfaction).to receive(:submit).with(ratings, date.iso8601)
+    expect(user_satisfaction).to receive(:submit).with(ratings, date_to_upload.iso8601)
 
     perform_enqueued_jobs { job }
   end

--- a/spec/jobs/performance_platform_transactions_queue_job_spec.rb
+++ b/spec/jobs/performance_platform_transactions_queue_job_spec.rb
@@ -3,8 +3,18 @@ require 'rails_helper'
 RSpec.describe PerformancePlatformTransactionsQueueJob, type: :job do
   include ActiveJob::TestHelper
 
-  subject(:date) { Date.current.beginning_of_day.in_time_zone }
-  subject(:job) { described_class.perform_later(date.to_s) }
+  let(:runtime) { Time.new(2008, 9, 1, 13, 0, 0).utc }
+  let(:date_to_upload) { Date.current.beginning_of_day.in_time_zone - 1.day }
+
+  before do
+    Timecop.freeze(runtime)
+  end
+
+  after do
+    Timecop.return
+  end
+
+  subject(:job) { described_class.perform_later(date_to_upload.to_s) }
 
   it 'queues the job' do
     expect { job }.to change(ActiveJob::Base.queue_adapter.enqueued_jobs, :size).by(1)
@@ -14,15 +24,24 @@ RSpec.describe PerformancePlatformTransactionsQueueJob, type: :job do
     expect(PerformancePlatformTransactionsQueueJob.new.queue_name).to eq('performance_platform')
   end
 
-  it 'executes perform' do
+  it 'enqueues a job to send all published job from yesterday' do
     stub_const('PP_TRANSACTIONS_BY_CHANNEL_TOKEN', 'not-nil')
 
     pp = double(:performance_platform)
+    two_days_ago = Date.current.beginning_of_day.in_time_zone - 2.days
+    today = Date.current.beginning_of_day.in_time_zone
 
-    published = create_list(:vacancy, 3, :published, publish_on: date)
+    build(:vacancy, :past_publish, publish_on: two_days_ago).save(validate: false)
+    build(:vacancy, :past_publish, publish_on: today).save(validate: false)
+
+    jobs_published_yesterday = [
+      build(:vacancy, :past_publish, publish_on: date_to_upload).save(validate: false),
+      build(:vacancy, :past_publish, publish_on: date_to_upload).save(validate: false)
+    ]
 
     expect(PerformancePlatform::TransactionsByChannel).to receive(:new).with('not-nil').and_return(pp)
-    expect(pp).to receive(:submit_transactions).with(published.count, date.utc.iso8601)
+    expect(pp).to receive(:submit_transactions).with(jobs_published_yesterday.count, date_to_upload.iso8601)
+
     perform_enqueued_jobs { job }
   end
 end

--- a/spec/lib/performance_platform_spec.rb
+++ b/spec/lib/performance_platform_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe PerformancePlatform::UserSatisfaction do
                   'Content-Type' => 'application/json' }
 
       sample_rating_counts = { 1 => 1, 2 => 2, 3 => 0, 4 => 1, 5 => 4 }
-      expected_data = { _timestamp: now.utc.iso8601,
+      expected_data = { _timestamp: now.iso8601,
                         rating_1: 1,
                         rating_2: 2,
                         rating_3: 0,

--- a/spec/lib/performance_platform_spec.rb
+++ b/spec/lib/performance_platform_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe PerformancePlatform::TransactionsByChannel do
                   'Content-Type' => 'application/json' }
 
       sample_data = {
-        _timestamp: now.utc.iso8601,
+        _timestamp: now.iso8601,
         service: 'teaching_jobs_listings',
         channel: 'digital',
         count: 2,


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/aj6ikgAo

## Changes in this PR:
* Thanks to a test failing today it's brought our attention to a problem with how we are sending data to the performance platform, this is fixed and the driver for this work
* Previously this was using UTC and now we have moved to BST this
continuously fails the test `spec/jobs/performance_platform_transactions_queue_job_spec.rb:17`
* Currently (and fortunately) AWS has scheduled this job to happen
around 14:10 GMT so this does not looked to have caused an issue on production. However should this job change schedule to around midnight there could be issues where it's always trying to run the job on listings created 2 days ago!
* This ran the day after the clocks ran with the correct date and
without error ([the numbers generally in PP look very odd though](https://www.performance.service.gov.uk/data/teaching-jobs-job-listings/transactions-by-channel?duration=52&collect=count%3Asum&group_by=channel&period=day&&format=json)):
```
Apr 01 14:10:33 Production ecs-tvs2_production_worker-48-tvs2productionweb-fadce1ed94d2e3dd2100: Performed PerformancePlatformTransactionsQueueJob (Job ID: 1b2f5acf-0bdb-425e-89e6-7495dc24f378) from Sidekiq(performance_platform) in 489.38ms
```
* There is nothing I can find in the documentation of the Performance Platform that specifies we must use UTC [1], however it accepts a the iso8601 format which implies that whatever is using the timestamp is zone aware which gives me some confidence that this won’t break it
* There is nothing I can find in the original commit on the subject of using UTC or GMT [2]
* `TransactionAuditor` and `Vacancy.published_on_count` both expect a Date object however they were receiving a Time object, so this change fixes some behaviour. `published_on_count` caused a particular problem in returning an incorrect 0 count when doing a date lookup with a time value (perhaps this has been contributing to weird data in PP):
```
[2] pry(#<PerformancePlatformTransactionsQueueJob>)> Vacancy.pluck(:publish_on)
=> [Mon, 01 Apr 2019, Mon, 01 Apr 2019, Mon, 01 Apr 2019]
[4] pry(#<PerformancePlatformTransactionsQueueJob>)> Vacancy.published_on_count(date)
=> 0
[5] pry(#<PerformancePlatformTransactionsQueueJob>)> date
=> Mon, 01 Apr 2019 00:00:00 BST +01:00
```
* The fact that the rake task injects a date parameter into this job that is 1 day behind of the current date took me down the wrong path of removing this wasn’t counting all the jobs published on a given day. It seems this has been done as there are 2 different ways the job is being called, short of refactoring this all I’ve tried to be more expressive with the test variables. In particular that the runtime of the task and the date_to_upload dates are different values.

[1] https://performance-platform.readthedocs.io/en/latest/api/write-api.html
https://github.com/alphagov/performanceplatform-client.py
[2] https://github.com/dxw/teacher-vacancy-service/commit/e6632ccd3f7ec4cb4f605354dbfc4190a6a9bbd4#diff-c995bd0b523d3323e79766b163320d94
