### PR TITLE
[803] Make job alert references required and generate defaults from search criteria

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -34,7 +34,14 @@ class Subscription < ApplicationRecord
   end
 
   def search_criteria_to_h
-    @search_criteria_hash = JSON.parse(search_criteria)
+    parsed_criteria = (JSON.parse(search_criteria) if search_criteria.present?)
+    @search_criteria_hash = if parsed_criteria.is_a?(Hash)
+                              parsed_criteria
+                            else
+                              {}
+                            end
+  rescue JSON::ParserError
+    @search_criteria_hash = {}
   end
 
   def token(expiration_in_days: 2)

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -6,10 +6,9 @@ class Subscription < ApplicationRecord
   has_many :alert_runs
 
   validates :email, email_address: { presence: true }
+  validates :reference, presence: true
   validates :frequency, presence: true
   validates :search_criteria, uniqueness: { scope: %i[email expires_on frequency] }
-
-  before_save :set_reference
 
   scope :ongoing, -> { where('expires_on >= current_date') }
 
@@ -36,15 +35,6 @@ class Subscription < ApplicationRecord
 
   def search_criteria_to_h
     @search_criteria_hash = JSON.parse(search_criteria)
-  end
-
-  def set_reference
-    return if reference.present?
-
-    self.reference = loop do
-      reference = SecureRandom.hex(8)
-      break reference unless self.class.exists?(email: email, reference: reference)
-    end
   end
 
   def token(expiration_in_days: 2)

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -70,32 +70,11 @@ class Subscription < ApplicationRecord
 
   private
 
-  def needs_reference?
-    new_record? && reference.blank?
-  end
-
-  def keyword_reference_part
-    search_criteria_hash = search_criteria_to_h
-
-    search_criteria_hash['keyword'].strip.split(/\s+/).join(' ') if search_criteria_hash.key?('keyword')
-  end
-
-  def location_reference_part
-    search_criteria_hash = search_criteria_to_h
-    has_location = ['location', 'radius'].all? { |key| search_criteria_hash.key?(key) }
-
-    "within #{search_criteria_hash['radius']} miles of #{search_criteria_hash['location'].strip}" if has_location
-  end
-
   def default_reference
-    return unless needs_reference?
+    return unless new_record? && reference.blank?
 
-    keyword_part = keyword_reference_part
-    location_part = location_reference_part
+    generator = SubscriptionReferenceGenerator.new(search_criteria: search_criteria_to_h)
 
-    return if keyword_part.blank? && location_part.blank?
-
-    self.reference = keyword_part.present? ? "#{keyword_part.upcase_first} jobs" : 'Jobs'
-    self.reference += " #{location_part}" if location_part.present?
+    self.reference = generator.generate
   end
 end

--- a/app/services/subscription_reference_generator.rb
+++ b/app/services/subscription_reference_generator.rb
@@ -1,9 +1,5 @@
 class SubscriptionReferenceGenerator
   def initialize(search_criteria:)
-    update(search_criteria)
-  end
-
-  def update(search_criteria)
     @search_criteria = search_criteria
   end
 

--- a/app/services/subscription_reference_generator.rb
+++ b/app/services/subscription_reference_generator.rb
@@ -1,0 +1,32 @@
+class SubscriptionReferenceGenerator
+  def initialize(search_criteria:)
+    update(search_criteria)
+  end
+
+  def update(search_criteria)
+    @search_criteria = search_criteria
+  end
+
+  def generate
+    keyword = keyword_part
+    location = location_part
+
+    return if keyword.blank? && location.blank?
+
+    reference = keyword.present? ? "#{keyword.upcase_first} jobs" : 'Jobs'
+    reference += " #{location}" if location.present?
+    reference
+  end
+
+  private
+
+  def keyword_part
+    @search_criteria['keyword'].strip.split(/\s+/).join(' ') if @search_criteria.key?('keyword')
+  end
+
+  def location_part
+    has_location = ['location', 'radius'].all? { |key| @search_criteria.key?(key) }
+
+    "within #{@search_criteria['radius']} miles of #{@search_criteria['location'].strip}" if has_location
+  end
+end

--- a/app/services/subscription_reference_generator.rb
+++ b/app/services/subscription_reference_generator.rb
@@ -1,4 +1,6 @@
 class SubscriptionReferenceGenerator
+  attr_reader :search_criteria
+
   def initialize(search_criteria:)
     @search_criteria = search_criteria
   end
@@ -17,16 +19,16 @@ class SubscriptionReferenceGenerator
   private
 
   def keyword_part
-    @search_criteria['keyword'].strip.split(/\s+/).join(' ') if @search_criteria.key?('keyword')
+    search_criteria['keyword'].strip.split(/\s+/).join(' ') if search_criteria.key?('keyword')
   end
 
   def location_part
     return unless location?
 
-    "within #{@search_criteria['radius']} miles of #{@search_criteria['location'].strip}"
+    "within #{search_criteria['radius']} miles of #{search_criteria['location'].strip}"
   end
 
   def location?
-    ['location', 'radius'].all? { |key| @search_criteria.key?(key) }
+    ['location', 'radius'].all? { |key| search_criteria.key?(key) }
   end
 end

--- a/app/services/subscription_reference_generator.rb
+++ b/app/services/subscription_reference_generator.rb
@@ -19,7 +19,13 @@ class SubscriptionReferenceGenerator
   private
 
   def keyword_part
-    search_criteria['keyword'].strip.split(/\s+/).join(' ') if search_criteria.key?('keyword')
+    return unless keyword?
+
+    search_criteria['keyword'].strip.split(/\s+/).join(' ')
+  end
+
+  def keyword?
+    search_criteria.key?('keyword')
   end
 
   def location_part

--- a/app/services/subscription_reference_generator.rb
+++ b/app/services/subscription_reference_generator.rb
@@ -25,8 +25,12 @@ class SubscriptionReferenceGenerator
   end
 
   def location_part
-    has_location = ['location', 'radius'].all? { |key| @search_criteria.key?(key) }
+    return unless location?
 
-    "within #{@search_criteria['radius']} miles of #{@search_criteria['location'].strip}" if has_location
+    "within #{@search_criteria['radius']} miles of #{@search_criteria['location'].strip}"
+  end
+
+  def location?
+    ['location', 'radius'].all? { |key| @search_criteria.key?(key) }
   end
 end

--- a/app/views/subscriptions/new.html.haml
+++ b/app/views/subscriptions/new.html.haml
@@ -34,7 +34,7 @@
                 %span{ class: 'govuk-!-font-weight-bold'} #{filter.humanize}:
               = value
       = f.input :email, as: :email, input_html: { class: 'govuk-input' }, required: true
-      = f.input :reference, as: :string, input_html: { class: 'govuk-input', placeholder: 'eg Maths jobs in Manchester' }
+      = f.input :reference, as: :string, input_html: { class: 'govuk-input', placeholder: 'e.g. Maths jobs within 20 miles of Oxford' }
 
 
       .govuk-warning-text

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -65,4 +65,4 @@ en:
         reference: 'Your reference'
     hints:
       defaults:
-        reference: Save a description for this job alert. If you don’t choose a reference we'll generate a reference number for you.
+        reference: Enter a short description for this job alert. This will appear in the subject line of the email we send you when a new job matches your criteria.

--- a/spec/factories/subscriptions.rb
+++ b/spec/factories/subscriptions.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :subscription do
     expires_on { Time.zone.today.strftime('%Y-%m-%d') }
     email { Faker::Internet.email }
-    reference { SecureRandom.hex(8) }
+    reference { Faker::Lorem.sentence }
     frequency { :daily }
 
     factory :daily_subscription do

--- a/spec/factories/subscriptions.rb
+++ b/spec/factories/subscriptions.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :subscription do
     expires_on { Time.zone.today.strftime('%Y-%m-%d') }
     email { Faker::Internet.email }
+    reference { SecureRandom.hex(8) }
     frequency { :daily }
 
     factory :daily_subscription do

--- a/spec/features/job_seekers_can_subscribe_to_a_job_alert_spec.rb
+++ b/spec/features/job_seekers_can_subscribe_to_a_job_alert_spec.rb
@@ -31,7 +31,6 @@ RSpec.feature 'A job seeker can subscribe to a job alert' do
     scenario 'subscribing to a search creates a new daily subscription audit' do
       visit new_subscription_path(search_criteria: { keyword: 'test' })
       fill_in 'subscription[email]', with: 'jane.doe@example.com'
-      fill_in 'subscription[reference]', with: 'a reference'
       click_on 'Subscribe'
 
       activity = PublicActivity::Activity.last
@@ -42,7 +41,6 @@ RSpec.feature 'A job seeker can subscribe to a job alert' do
       scenario 'when the email address is valid' do
         visit new_subscription_path(search_criteria: { keyword: 'test' })
         fill_in 'subscription[email]', with: 'jane.doe@example.com'
-        fill_in 'subscription[reference]', with: 'a reference'
         click_on 'Subscribe'
 
         expect(page).to have_content(I18n.t('subscriptions.confirmation.header'))
@@ -54,7 +52,6 @@ RSpec.feature 'A job seeker can subscribe to a job alert' do
 
         visit new_subscription_path(search_criteria: { keyword: 'math teacher' })
         fill_in 'subscription[email]', with: 'jane.doe@example.com'
-        fill_in 'subscription[reference]', with: 'a reference'
         click_on 'Subscribe'
 
         expect(page).to have_content(I18n.t('subscriptions.confirmation.header'))
@@ -67,7 +64,14 @@ RSpec.feature 'A job seeker can subscribe to a job alert' do
 
         visit new_subscription_path(search_criteria: { keyword: 'teacher' })
         fill_in 'subscription[email]', with: 'jane.doe@example.com'
-        fill_in 'subscription[reference]', with: 'a reference'
+        click_on 'Subscribe'
+
+        expect(page).to have_content(I18n.t('subscriptions.confirmation.header'))
+      end
+
+      scenario 'when no reference is set' do
+        visit new_subscription_path(search_criteria: { keyword: 'test' })
+        fill_in 'subscription[email]', with: 'jane.doe@example.com'
         click_on 'Subscribe'
 
         expect(page).to have_content(I18n.t('subscriptions.confirmation.header'))
@@ -87,7 +91,6 @@ RSpec.feature 'A job seeker can subscribe to a job alert' do
           visit new_subscription_path(search_criteria: { keyword: 'teacher',
                                                          newly_qualified_teacher: 'true' })
           fill_in 'subscription[email]', with: 'jane.doe@example.com'
-          fill_in 'subscription[reference]', with: 'a reference'
           click_on 'Subscribe'
 
           click_on 'Return to your search results'
@@ -102,20 +105,10 @@ RSpec.feature 'A job seeker can subscribe to a job alert' do
       scenario 'when the email address is invalid' do
         visit new_subscription_path(search_criteria: { keyword: 'test' })
         fill_in 'subscription[email]', with: 'jane.doe@example'
-        fill_in 'subscription[reference]', with: 'a reference'
         click_on 'Subscribe'
 
         expect(page).to have_content('Please correct the following error')
         expect(page).to have_content('Email is not a valid email address')
-      end
-
-      scenario 'when no reference is set' do
-        visit new_subscription_path(search_criteria: { keyword: 'test' })
-        fill_in 'subscription[email]', with: 'jane.doe@example.com'
-        click_on 'Subscribe'
-
-        expect(page).to have_content('Please correct the following error')
-        expect(page).to have_content('Reference can\'t be blank')
       end
 
       scenario 'when an active subcsription with the same search_criteria exists' do
@@ -126,7 +119,6 @@ RSpec.feature 'A job seeker can subscribe to a job alert' do
 
         visit new_subscription_path(search_criteria: search_criteria)
         fill_in 'subscription[email]', with: 'jane.doe@example.com'
-        fill_in 'subscription[reference]', with: 'a reference'
         click_on 'Subscribe'
 
         expect(page).to have_content('You are already subscribed to a daily email with these search criteria')

--- a/spec/features/job_seekers_can_subscribe_to_a_job_alert_spec.rb
+++ b/spec/features/job_seekers_can_subscribe_to_a_job_alert_spec.rb
@@ -31,6 +31,7 @@ RSpec.feature 'A job seeker can subscribe to a job alert' do
     scenario 'subscribing to a search creates a new daily subscription audit' do
       visit new_subscription_path(search_criteria: { keyword: 'test' })
       fill_in 'subscription[email]', with: 'jane.doe@example.com'
+      fill_in 'subscription[reference]', with: 'a reference'
       click_on 'Subscribe'
 
       activity = PublicActivity::Activity.last
@@ -41,6 +42,7 @@ RSpec.feature 'A job seeker can subscribe to a job alert' do
       scenario 'when the email address is valid' do
         visit new_subscription_path(search_criteria: { keyword: 'test' })
         fill_in 'subscription[email]', with: 'jane.doe@example.com'
+        fill_in 'subscription[reference]', with: 'a reference'
         click_on 'Subscribe'
 
         expect(page).to have_content(I18n.t('subscriptions.confirmation.header'))
@@ -52,6 +54,7 @@ RSpec.feature 'A job seeker can subscribe to a job alert' do
 
         visit new_subscription_path(search_criteria: { keyword: 'math teacher' })
         fill_in 'subscription[email]', with: 'jane.doe@example.com'
+        fill_in 'subscription[reference]', with: 'a reference'
         click_on 'Subscribe'
 
         expect(page).to have_content(I18n.t('subscriptions.confirmation.header'))
@@ -64,23 +67,13 @@ RSpec.feature 'A job seeker can subscribe to a job alert' do
 
         visit new_subscription_path(search_criteria: { keyword: 'teacher' })
         fill_in 'subscription[email]', with: 'jane.doe@example.com'
+        fill_in 'subscription[reference]', with: 'a reference'
         click_on 'Subscribe'
 
         expect(page).to have_content(I18n.t('subscriptions.confirmation.header'))
       end
 
       context 'and is redirected to the confirmation page' do
-        scenario 'without setting a reference number' do
-          visit new_subscription_path(search_criteria: { keyword: 'teacher' })
-          fill_in 'subscription[email]', with: 'jane.doe@example.com'
-          click_on 'Subscribe'
-
-          expect(page).to have_content(I18n.t('subscriptions.confirmation.header'))
-          expect(page).to have_content('jane.doe@example.com')
-          expect(page).to have_content(/Your reference [a-z]*/)
-          expect(page).to have_content('Keyword: teacher')
-        end
-
         scenario 'when setting a reference number' do
           visit new_subscription_path(search_criteria: { keyword: 'teacher' })
           fill_in 'subscription[email]', with: 'jane.doe@example.com'
@@ -94,6 +87,7 @@ RSpec.feature 'A job seeker can subscribe to a job alert' do
           visit new_subscription_path(search_criteria: { keyword: 'teacher',
                                                          newly_qualified_teacher: 'true' })
           fill_in 'subscription[email]', with: 'jane.doe@example.com'
+          fill_in 'subscription[reference]', with: 'a reference'
           click_on 'Subscribe'
 
           click_on 'Return to your search results'
@@ -108,10 +102,20 @@ RSpec.feature 'A job seeker can subscribe to a job alert' do
       scenario 'when the email address is invalid' do
         visit new_subscription_path(search_criteria: { keyword: 'test' })
         fill_in 'subscription[email]', with: 'jane.doe@example'
+        fill_in 'subscription[reference]', with: 'a reference'
         click_on 'Subscribe'
 
         expect(page).to have_content('Please correct the following error')
         expect(page).to have_content('Email is not a valid email address')
+      end
+
+      scenario 'when no reference is set' do
+        visit new_subscription_path(search_criteria: { keyword: 'test' })
+        fill_in 'subscription[email]', with: 'jane.doe@example.com'
+        click_on 'Subscribe'
+
+        expect(page).to have_content('Please correct the following error')
+        expect(page).to have_content('Reference can\'t be blank')
       end
 
       scenario 'when an active subcsription with the same search_criteria exists' do
@@ -122,6 +126,7 @@ RSpec.feature 'A job seeker can subscribe to a job alert' do
 
         visit new_subscription_path(search_criteria: search_criteria)
         fill_in 'subscription[email]', with: 'jane.doe@example.com'
+        fill_in 'subscription[reference]', with: 'a reference'
         click_on 'Subscribe'
 
         expect(page).to have_content('You are already subscribed to a daily email with these search criteria')

--- a/spec/features/job_seekers_can_unsubscribe_from_subscriptions_spec.rb
+++ b/spec/features/job_seekers_can_unsubscribe_from_subscriptions_spec.rb
@@ -4,8 +4,10 @@ RSpec.feature 'A job seeker can unsubscribe from subscriptions' do
   before { allow(EmailAlertsFeature).to receive(:enabled?) { true } }
 
   let(:search_criteria) { { keyword: 'English', location: 'SW1A1AA', radius: 20 } }
+  let(:reference) { 'A reference' }
   let(:subscription) do
     create(:subscription,
+           reference: reference,
            frequency: :daily,
            search_criteria: search_criteria.to_json)
   end
@@ -42,24 +44,21 @@ RSpec.feature 'A job seeker can unsubscribe from subscriptions' do
     end
 
     context 'with a generated reference' do
+      let(:reference) { SecureRandom.hex(8) }
+
       it 'does not show the reference' do
-        expect(page).to_not have_content(subscription.reference)
+        expect(page).to_not have_content(reference)
         expect(page).to have_content(I18n.t('subscriptions.deletion.confirmation'))
       end
     end
 
     context 'with a custom reference' do
-      let(:subscription) do
-        create(:subscription,
-               frequency: :daily,
-               search_criteria: search_criteria.to_json,
-               reference: 'English teacher jobs')
-      end
+      let(:reference) { 'English teacher jobs' }
 
       it 'shows my reference' do
-        expect(page).to have_content(subscription.reference)
+        expect(page).to have_content(reference)
         expect(page).to have_content(I18n.t('subscriptions.deletion.confirmation_with_reference',
-                                            reference: subscription.reference))
+                                            reference: reference))
       end
     end
   end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -20,6 +20,15 @@ RSpec.describe Subscription, type: :model do
       end
     end
 
+    context 'reference' do
+      it 'ensures a reference is set' do
+        subscription = Subscription.new
+
+        expect(subscription.valid?).to eq(false)
+        expect(subscription.errors.messages[:reference]).to eq(['can\'t be blank'])
+      end
+    end
+
     context 'unique index' do
       it 'validates uniqueness of email, expires_on, frequency and search_criteria' do
         create(:subscription, email: 'jane@doe.com',
@@ -49,21 +58,6 @@ RSpec.describe Subscription, type: :model do
       it 'retrieves all valid active subscriptions' do
         expect(Subscription.ongoing.count).to eq(3)
       end
-    end
-  end
-
-  context 'reference' do
-    it 'generates a reference if one is not set' do
-      expect(SecureRandom).to receive(:hex).and_return('ABCDEF')
-      subscription = create(:subscription, frequency: :daily)
-
-      expect(subscription.reference).to eq('ABCDEF')
-    end
-
-    it 'does not generate a reference if one is set' do
-      subscription = create(:subscription, reference: 'A-reference', frequency: :daily)
-
-      expect(subscription.reference).to eq('A-reference')
     end
   end
 

--- a/spec/services/subscription_reference_generator_spec.rb
+++ b/spec/services/subscription_reference_generator_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe SubscriptionReferenceGenerator do
+  describe '.new' do
+    it 'should be initialised with a hash of search criteria' do
+      service = described_class.new(search_criteria: { 'keyword' => 'Maths', 'radius' => 20 })
+      expect(service).to be_an_instance_of(described_class)
+    end
+  end
+
+  describe '#generate' do
+    context 'with no common fields in search criteria' do
+      let(:params) { { search_criteria: { 'radius' => 20, 'phase' => 'primary', 'working_pattern' => 'full_time' } } }
+
+      it 'returns nil' do
+        service = described_class.new(params)
+
+        expect(service.generate).to eq(nil)
+      end
+    end
+
+    context 'with keyword in search criteria' do
+      let(:params) { { search_criteria: { 'keyword' => 'maths and science', 'radius' => 20 } } }
+
+      it 'returns a reference containing the keyword' do
+        service = described_class.new(params)
+
+        expect(service.generate).to include('Maths and science jobs')
+      end
+    end
+
+    context 'with location in search criteria' do
+      let(:params) { { search_criteria: { 'location' => 'London', 'radius' => 40 } } }
+
+      it 'returns a reference containing the keyword' do
+        service = described_class.new(params)
+
+        expect(service.generate).to include('within 40 miles of London')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/npmtxxuy/803-reference-numbers-for-job-alerts-should-not-be-machine-generated-but-a-mandatory-human-reference-so-that-the-alert-reference-is

## Changes in this PR:

- Removes the reference setter in favour of requiring presence.
- Update the reference hint copy.
- Generate a default reference from keyword and location search criteria, if present. If neither are present, leave the field blank for the user to fill. Location and keyword were chosen as 93% of searches include location and 44% keyword, the top two optional fields.
- Default to an empty hash when requesting a hash of search criteria in the case where the cirteria is missing or malformed.

## Screenshots of UI changes:

### Before

<img width="629" alt="Screenshot 2019-04-04 at 14 12 13" src="https://user-images.githubusercontent.com/1027364/55558880-e968c300-56e4-11e9-9deb-9e1ecd7acc58.png">

### After

<img width="632" alt="Screenshot 2019-04-04 at 14 08 50" src="https://user-images.githubusercontent.com/1027364/55558892-ef5ea400-56e4-11e9-9a91-3017d0a1bdc8.png">
<img width="623" alt="Screenshot 2019-04-04 at 14 08 20" src="https://user-images.githubusercontent.com/1027364/55558902-f5548500-56e4-11e9-9306-c2241d55bf9d.png">
<img width="626" alt="Screenshot 2019-04-04 at 14 07 31" src="https://user-images.githubusercontent.com/1027364/55558905-f685b200-56e4-11e9-8b36-b50aeafa5d0a.png">