### PR TITLE
[819] Rails receives the correct client IP address

### DIFF
--- a/lib/modules/aws_ip_ranges.rb
+++ b/lib/modules/aws_ip_ranges.rb
@@ -1,6 +1,7 @@
 module AWSIpRanges
   # Used based on this AWS instruction: https://forums.aws.amazon.com/ann.jspa?annID=2051
   PATH = 'https://ip-ranges.amazonaws.com/ip-ranges.json'.freeze
+  COMPATIBLE_REGIONS = ['GLOBAL', 'eu-west-2'].freeze
 
   def self.cloudfront_ips
     uri = URI(PATH)
@@ -22,8 +23,9 @@ module AWSIpRanges
 
   def self.parse_json_for_ips(response)
     aws_ip_ranges = JSON.parse(response)
+
     cloudfront_ip_blocks = aws_ip_ranges['prefixes'].select do |record|
-      record['region'] == 'GLOBAL' && record['service'] == 'CLOUDFRONT'
+      COMPATIBLE_REGIONS.include?(record['region']) && record['service'] == 'CLOUDFRONT'
     end
     cloudfront_ip_blocks.map { |cloudfront_ip| cloudfront_ip['ip_prefix'] }
   rescue JSON::ParserError

--- a/spec/lib/modules/aws_ip_ranges_spec.rb
+++ b/spec/lib/modules/aws_ip_ranges_spec.rb
@@ -10,11 +10,12 @@ RSpec.describe AWSIpRanges do
         .to_return(body: aws_ip_ranges, status: 200)
     end
 
-    it 'returns the CLOUDFRONT ip in the GLOBAL area' do
+    it 'returns the CLOUDFRONT ip in the GLOBAL or eu-west-2 area' do
       expected_result = [
         '13.32.0.0/15',
         '13.35.0.0/16',
         '52.46.0.0/18',
+        '52.56.127.0/25',
         '52.84.0.0/15',
         '52.124.128.0/17',
         '52.222.128.0/17',


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/IvJtATi7

## Changes in this PR:
* Change of logic to ensure we trust the current IP address of cloudfront. Through trusting we enable the Rails method `request.remote_ip` to access the correct client IP address from the X-Forwarded-For header. With that, it is used as the IP in logs, and forwarded to Rollbar
* The current IP address by our CloudFront install is not in the GLOBAL and is part of eu-west-2 region which is the regions our environments are configured to use. Found as the value for `region` within the relevant .tfvars. Presumably this has been moved by AWS and we’ve only just noticed the change

## Screenshots of UI changes:
<img width="339" alt="Screenshot 2019-04-02 at 12 10 52" src="https://user-images.githubusercontent.com/912473/55417725-28720980-5569-11e9-87f2-f297fac5440a.png">

### Before
<img width="1610" alt="Screenshot 2019-04-02 at 17 00 52" src="https://user-images.githubusercontent.com/912473/55417633-fcef1f00-5568-11e9-8fdf-f0656e007129.png">

### After
<img width="1612" alt="Screenshot 2019-04-02 at 17 00 42" src="https://user-images.githubusercontent.com/912473/55417657-08424a80-5569-11e9-975b-e3011c69c3e9.png">
