### PR TITLE
Remove expiry from subscription token

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -26,10 +26,6 @@ class Subscription < ApplicationRecord
 
   def self.find_and_verify_by_token(token)
     data = encryptor.decrypt_and_verify(token)
-    expires = data[:expires]
-
-    raise ActiveRecord::RecordNotFound if Time.current > expires
-
     find(data[:id])
   rescue ActiveSupport::MessageVerifier::InvalidSignature
     raise ActiveRecord::RecordNotFound
@@ -42,9 +38,8 @@ class Subscription < ApplicationRecord
     {}
   end
 
-  def token(expiration_in_days: 2)
-    expires = Time.current + expiration_in_days.days
-    token_values = { id: id, expires: expires }
+  def token
+    token_values = { id: id }
     self.class.encryptor.encrypt_and_sign(token_values)
   end
 

--- a/spec/features/job_seekers_can_manage_their_subscription.rb
+++ b/spec/features/job_seekers_can_manage_their_subscription.rb
@@ -13,7 +13,7 @@ RSpec.feature 'A job seeker can manage their subscription' do
     end
   end
 
-  context 'with an expired token' do
+  context 'with an old token' do
     let(:token) do
       Timecop.travel(-7.days) { subscription.token }
     end
@@ -21,7 +21,7 @@ RSpec.feature 'A job seeker can manage their subscription' do
     scenario 'cannot see subscription details' do
       visit subscription_path(token)
 
-      expect(page).to have_text('Page not found')
+      expect(page).to have_text('Manage your subscription')
     end
   end
 end

--- a/spec/features/job_seekers_can_unsubscribe_from_subscriptions_spec.rb
+++ b/spec/features/job_seekers_can_unsubscribe_from_subscriptions_spec.rb
@@ -95,13 +95,13 @@ RSpec.feature 'A job seeker can unsubscribe from subscriptions' do
     end
   end
 
-  context 'with an expired token' do
+  context 'with an old token' do
     let(:token) do
       Timecop.travel(-3.days) { subscription.token }
     end
 
-    it 'returns not found' do
-      expect(page.status_code).to eq(404)
+    scenario 'still returns 200' do
+      expect(page.status_code).to eq(200)
     end
   end
 end

--- a/spec/mailers/subscription_spec.rb
+++ b/spec/mailers/subscription_spec.rb
@@ -9,14 +9,20 @@ RSpec.describe SubscriptionMailer, type: :mailer do
   after(:each) { Timecop.return }
 
   let(:subscription) do
-    create(:daily_subscription, email: 'an@email.com',
-                                reference: 'a-reference',
-                                search_criteria: {
-                                  subject: 'English',
-                                  minimum_salary: 20000,
-                                  maximum_salary: 40000,
-                                  newly_qualified_teacher: 'true'
-                                }.to_json)
+    subscription = create(:daily_subscription, email: 'an@email.com',
+                                               reference: 'a-reference',
+                                               search_criteria: {
+                                                 subject: 'English',
+                                                 minimum_salary: 20000,
+                                                 maximum_salary: 40000,
+                                                 newly_qualified_teacher: 'true'
+                                               }.to_json)
+    # The hashing algorithm uses a random initialization vector to encrypt the token,
+    # so is different every time, so we stub the token to be the same every time, so
+    # it's clearer what we're testing when we test the unsubscribe link
+    token = subscription.token
+    allow_any_instance_of(Subscription).to receive(:token) { token }
+    subscription
   end
   let(:mail) { SubscriptionMailer.confirmation(subscription.id) }
   let(:body_lines) { mail.body.raw_source.lines }
@@ -35,6 +41,6 @@ RSpec.describe SubscriptionMailer, type: :mailer do
   end
 
   it 'has an unsubscribe link' do
-    expect(body_lines[12]).to match(%r{http:\/\/localhost:3000\/subscriptions\/[0-9a-zA-Z\-]{418}\/unsubscribe})
+    expect(body_lines[12]).to match(%r{http:\/\/localhost:3000\/subscriptions\/#{subscription.token}\/unsubscribe})
   end
 end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -100,13 +100,13 @@ RSpec.describe Subscription, type: :model do
         expect(result).to eq(subscription)
       end
 
-      context 'when token is expired' do
+      context 'when token is old' do
         let(:token) do
           Timecop.travel(-3.days) { subscription.token }
         end
 
-        it 'raises an error' do
-          expect { result }.to raise_error(ActiveRecord::RecordNotFound)
+        it 'finds by token' do
+          expect(result).to eq(subscription)
         end
       end
 
@@ -115,6 +115,18 @@ RSpec.describe Subscription, type: :model do
 
         it 'raises an error' do
           expect { result }.to raise_error(ActiveRecord::RecordNotFound)
+        end
+      end
+
+      context 'when token has extra data' do
+        let(:token) do
+          expires = Time.current + 2.days
+          token_values = { id: subscription.id, expires: expires }
+          Subscription.encryptor.encrypt_and_sign(token_values)
+        end
+
+        it 'finds by token' do
+          expect(result).to eq(subscription)
         end
       end
     end


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/vz43OJJC/820-extend-unsubscribe-limit-on-jobseeker-alert-email-so-that-users-can-unsubscribe-from-any-email-alert

## Changes in this PR:

We found this was causing problems with users expecting to be able to unsubscribe using an old token. We’ve made the decision to allow any unsubscribe link to be used, rather than expiring the token, as no user data is exposed, so the risk of any issues if a token is leaked is minimal