### PR TITLE
[834] Terraform uses newer version to deploy

### DIFF
--- a/terraform.tf
+++ b/terraform.tf
@@ -12,7 +12,7 @@ Store infrastructure state in a remote store (instead of local machine):
 https://www.terraform.io/docs/state/purpose.html
 */
 terraform {
-  required_version = "~> 0.11.11"
+  required_version = "~> 0.11.13"
 
   backend "s3" {
     bucket  = "terraform-state-002"


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/SobmxM2m


## Changes in this PR:
* Changing to 0.11.13 as we have at least deployed out staging environment with this version, causing it to be locked from further deployments with earlier versions.
* Although this is only a patch version change, the release logs for 12 and 13 don’t have anything alarming: https://github.com/hashicorp/terraform/releases/tag/v0.11.12, https://github.com/hashicorp/terraform/releases/tag/v0.11.13

## Screenshots of UI changes:

### Before
<img width="685" alt="Screenshot 2019-04-10 at 14 06 22" src="https://user-images.githubusercontent.com/912473/55881681-0432b000-5b9b-11e9-8e0b-56fabc897176.png">

### After

<img width="741" alt="Screenshot 2019-04-10 at 14 15 24" src="https://user-images.githubusercontent.com/912473/55882004-a783c500-5b9b-11e9-8312-2c851394dab4.png">
<img width="830" alt="Screenshot 2019-04-10 at 14 19 21" src="https://user-images.githubusercontent.com/912473/55882007-a9e61f00-5b9b-11e9-8736-4fa92a1bb4a6.png">

No new unexpected changes presented from a `plan`:
<img width="830" alt="Screenshot 2019-04-10 at 14 20 09" src="https://user-images.githubusercontent.com/912473/55882119-df8b0800-5b9b-11e9-9b14-15c7cdb7c32f.png">

## Next steps:

- [x] Terraform deployment required?
