### PR TITLE
[836] Revert temporary task to backfill historic "more info" clicks

### DIFF
--- a/terraform.tf
+++ b/terraform.tf
@@ -102,8 +102,6 @@ module "ecs" {
 
   seed_vacancies_from_api = "${var.seed_vacancies_from_api}"
 
-  backfill_info_clicks_for_vacancies_command = "${var.backfill_info_clicks_for_vacancies_command}"
-
   performance_platform_submit_task_command     = "${var.performance_platform_submit_task_command}"
   performance_platform_submit_task_schedule    = "${var.performance_platform_submit_task_schedule}"
   performance_platform_submit_all_task_command = "${var.performance_platform_submit_all_task_command}"

--- a/terraform/modules/ecs/ecs.tf
+++ b/terraform/modules/ecs/ecs.tf
@@ -369,35 +369,6 @@ data "template_file" "seed_vacancies_from_api_container_definition" {
   }
 }
 
-/* backfill_info_clicks_for_vacancies task definition */
-
-data "template_file" "backfill_info_clicks_for_vacancies_command_container_definition" {
-  template = "${file(var.ecs_service_rake_container_definition_file_path)}"
-
-  vars {
-    image                    = "${aws_ecr_repository.default.repository_url}"
-    secret_key_base          = "${var.secret_key_base}"
-    project_name             = "${var.project_name}"
-    task_name                = "${var.ecs_service_web_task_name}_backfill_info_clicks_for_vacancies_command"
-    environment              = "${var.environment}"
-    rails_env                = "${var.rails_env}"
-    redis_cache_url          = "${var.redis_cache_url}"
-    redis_queue_url          = "${var.redis_queue_url}"
-    region                   = "${var.region}"
-    log_group                = "${var.aws_cloudwatch_log_group_name}"
-    database_user            = "${var.rds_username}"
-    database_password        = "${var.rds_password}"
-    database_url             = "${var.rds_address}"
-    elastic_search_url       = "${var.es_address}"
-    aws_elasticsearch_region = "${var.aws_elasticsearch_region}"
-    aws_elasticsearch_key    = "${var.aws_elasticsearch_key}"
-    aws_elasticsearch_secret = "${var.aws_elasticsearch_secret}"
-    rollbar_access_token     = "${var.rollbar_access_token}"
-    feature_import_vacancies = "${var.feature_import_vacancies}"
-    entrypoint               = "${jsonencode(var.backfill_info_clicks_for_vacancies_command)}"
-  }
-}
-
 /* performance_platform_submit task definition*/
 data "template_file" "performance_platform_submit_container_definition" {
   template = "${file(var.performance_platform_rake_container_definition_file_path)}"
@@ -676,17 +647,6 @@ resource "aws_ecs_task_definition" "reindex_vacancies_task" {
 resource "aws_ecs_task_definition" "seed_vacancies_from_api_task" {
   family                   = "${var.ecs_service_web_task_name}_seed_vacancies_from_api_task"
   container_definitions    = "${data.template_file.seed_vacancies_from_api_container_definition.rendered}"
-  requires_compatibilities = ["EC2"]
-  network_mode             = "bridge"
-  cpu                      = "256"
-  memory                   = "512"
-  execution_role_arn       = "${aws_iam_role.ecs_execution_role.arn}"
-  task_role_arn            = "${aws_iam_role.ecs_execution_role.arn}"
-}
-
-resource "aws_ecs_task_definition" "backfill_info_clicks_for_vacancies_command_task" {
-  family                   = "${var.ecs_service_web_task_name}_backfill_info_clicks_for_vacancies_command_task"
-  container_definitions    = "${data.template_file.backfill_info_clicks_for_vacancies_command_container_definition.rendered}"
   requires_compatibilities = ["EC2"]
   network_mode             = "bridge"
   cpu                      = "256"

--- a/terraform/modules/ecs/input.tf
+++ b/terraform/modules/ecs/input.tf
@@ -115,10 +115,6 @@ variable "seed_vacancies_from_api" {
   type = "list"
 }
 
-variable "backfill_info_clicks_for_vacancies_command" {
-  type = "list"
-}
-
 variable "backfill_jobseeker_alert_data_command" {
   type = "list"
 }
@@ -134,9 +130,11 @@ variable "performance_platform_submit_all_task_command" {
 variable "sessions_trim_task_schedule" {}
 variable "performance_platform_submit_task_schedule" {}
 variable "import_schools_task_schedule" {}
+
 variable "update_spreadsheets_task_command" {
   type = "list"
 }
+
 variable "update_spreadsheets_task_schedule" {}
 variable "send_job_alerts_daily_email_schedule" {}
 

--- a/variables.tf
+++ b/variables.tf
@@ -208,11 +208,6 @@ variable "seed_vacancies_from_api" {
   default     = ["rake", "verbose", "data:seed_from_api:vacancies"]
 }
 
-variable "backfill_info_clicks_for_vacancies_command" {
-  description = "The Entrypoint for the vacancies:statistics:backfill:info_clicks task"
-  default     = ["rake", "verbose", "vacancies:statistics:backfill:info_clicks"]
-}
-
 variable "performance_platform_submit_task_command" {
   description = "The Entrypoint for the performance_platform_submit task"
   default     = ["rake", "verbose", "performance_platform:submit"]


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/4bjIV6qM/836-revert-temporary-task-to-backfill-historic-more-info-clicks

## Changes in this PR:

Removes the backfill task and the related Terraform config.

## Next steps:

- [x] Terraform deployment required?
