### PR TITLE
Remove some thrashing from the Terraform plan

### DIFF
--- a/bin/terraform-deploy
+++ b/bin/terraform-deploy
@@ -29,7 +29,7 @@ echo "Deploying…"
 echo "* Terraform workspace: $TERRAFORM_WORKSPACE"
 echo "* Git branch: $GIT_BRANCH"
 
-read -r -p "Continue (y/n)?" CONT
+read -r -p "Continue? [y/N] " CONT
 if [ "$CONT" = "y" ]; then
   echo
 else

--- a/bin/terraform-plan
+++ b/bin/terraform-plan
@@ -12,7 +12,7 @@ TERRAFORM_WORKSPACE=$1
 echo "Planning…"
 echo "* Terraform workspace: $TERRAFORM_WORKSPACE"
 
-read -r -p "Continue (y/n)?" CONT
+read -r -p "Continue? [y/N] " CONT
 if [ "$CONT" = "y" ]; then
   echo
 else

--- a/terraform/modules/core/core.tf
+++ b/terraform/modules/core/core.tf
@@ -384,7 +384,6 @@ resource "aws_autoscaling_policy" "ecs-autoscaling-up-policy" {
   cooldown                = 300
   autoscaling_group_name  = "${aws_autoscaling_group.ecs-autoscaling-group.name}"
   policy_type             = "SimpleScaling"
-  metric_aggregation_type = "Average"
 }
 
 resource "aws_autoscaling_policy" "ecs-autoscaling-down-policy" {
@@ -394,7 +393,6 @@ resource "aws_autoscaling_policy" "ecs-autoscaling-down-policy" {
   cooldown                = 300
   autoscaling_group_name  = "${aws_autoscaling_group.ecs-autoscaling-group.name}"
   policy_type             = "SimpleScaling"
-  metric_aggregation_type = "Minimum"
 }
 
 resource "aws_cloudwatch_metric_alarm" "cluster-cpu-reservation-high" {


### PR DESCRIPTION
## Changes in this PR:

`metric_aggregation_type` is only supported for StepScaling policies, but we're using SimpleScaling for `ecs-autoscaling-down-policy` and `ecs-autoscaling-up-policy`, so we have been sending configuration that has been ignored by AWS, which is why it always appears as missing. This change stops trying to set them.

## Screenshots of UI changes:

### Before

![image](https://user-images.githubusercontent.com/1027364/55955312-f80d2800-5c58-11e9-8d0c-c789c1dfba94.png)

### After

![image](https://user-images.githubusercontent.com/1027364/55955225-c4ca9900-5c58-11e9-94d0-8698ee537104.png)
