### PR TITLE
Terraform cli versioning strategy

### DIFF
--- a/documentation/deployment.md
+++ b/documentation/deployment.md
@@ -20,7 +20,7 @@ There are currently 4 long standing environments that the team have been using, 
 As we use Terraform to make 95% of our changes to the infrastructure they too should be made in the form of pull requests into the relevant git branch. [You can read about what's not covered in our set up docs](../terraform/README.md).
 
 ### Before you start
-Get a local copy of the Terraform variables from the 1Password vault and move them into `/workspace-variables`, eg. `/workspace-variables/edge.tfvars`
+1. Get a local copy of the Terraform variables from the 1Password vault and move them into `/workspace-variables`, eg. `/workspace-variables/edge.tfvars`
 
 ### Running a deployment
 This is a manual process that we've scripted to help avoid common mistakes. To know when Terraform needs to be deployed, we've included a Terraform option in our pull request templates so it's the responsibility of the author to let the merger know that this step is needed on merge.

--- a/documentation/deployment.md
+++ b/documentation/deployment.md
@@ -20,8 +20,8 @@ There are currently 4 long standing environments that the team have been using, 
 As we use Terraform to make 95% of our changes to the infrastructure they too should be made in the form of pull requests into the relevant git branch. [You can read about what's not covered in our set up docs](../terraform/README.md).
 
 ### Before you start
-1. Configure `~/.aws/credentials` with keys from your user in AWS IAM (TODO: include more verbose instructions on this)
-2. Get a local copy of the Terraform variables from the 1Password vault and move them into `/workspace-variables`, eg. `/workspace-variables/edge.tfvars`
+2. [Configure AWS on your machine](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html ) so that Terraform has permission to talk to the AWS API
+3. Get a local copy of the Terraform variables from the 1Password vault and move them into `/workspace-variables`, eg. `/workspace-variables/edge.tfvars`
 
 ### Running a deployment
 This is a manual process that we've scripted to help avoid common mistakes. To know when Terraform needs to be deployed, we've included a Terraform option in our pull request templates so it's the responsibility of the author to let the merger know that this step is needed on merge.

--- a/documentation/deployment.md
+++ b/documentation/deployment.md
@@ -14,6 +14,7 @@ There are currently 4 long standing environments that the team have been using, 
 - pull request - requires at least 1 peer review
 - force push - ask the rest of the team if you can take control of an environment
 - testing - is only updated manually by developers on the request of user researchers in order to ensure stability during sessions
+
 ## Infrastructure
 
 As we use Terraform to make 95% of our changes to the infrastructure they too should be made in the form of pull requests into the relevant git branch. [You can read about what's not covered in our set up docs](../terraform/README.md).

--- a/documentation/deployment.md
+++ b/documentation/deployment.md
@@ -20,7 +20,8 @@ There are currently 4 long standing environments that the team have been using, 
 As we use Terraform to make 95% of our changes to the infrastructure they too should be made in the form of pull requests into the relevant git branch. [You can read about what's not covered in our set up docs](../terraform/README.md).
 
 ### Before you start
-1. Get a local copy of the Terraform variables from the 1Password vault and move them into `/workspace-variables`, eg. `/workspace-variables/edge.tfvars`
+1. Configure `~/.aws/credentials` with keys from your user in AWS IAM (TODO: include more verbose instructions on this)
+2. Get a local copy of the Terraform variables from the 1Password vault and move them into `/workspace-variables`, eg. `/workspace-variables/edge.tfvars`
 
 ### Running a deployment
 This is a manual process that we've scripted to help avoid common mistakes. To know when Terraform needs to be deployed, we've included a Terraform option in our pull request templates so it's the responsibility of the author to let the merger know that this step is needed on merge.

--- a/documentation/deployment.md
+++ b/documentation/deployment.md
@@ -20,6 +20,9 @@ There are currently 4 long standing environments that the team have been using, 
 As we use Terraform to make 95% of our changes to the infrastructure they too should be made in the form of pull requests into the relevant git branch. [You can read about what's not covered in our set up docs](../terraform/README.md).
 
 ### Before you start
+1. Install the the Terraform client on your machine:
+  * [Directly from Hashicorp](https://releases.hashicorp.com/terraform/) (recommended) - select the highest _patch_ for the [_minor_ version we're pinned to](terraform.tf)
+  * [Using Brew](https://formulae.brew.sh/formula/terraform) - be mindful that there is no current way to pick what version you have with Brew so this latest version may well put you above [the version we're pinned to](terraform.tf)
 2. [Configure AWS on your machine](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html ) so that Terraform has permission to talk to the AWS API
 3. Get a local copy of the Terraform variables from the 1Password vault and move them into `/workspace-variables`, eg. `/workspace-variables/edge.tfvars`
 
@@ -48,3 +51,13 @@ Do you want to perform these actions in workspace "testing"?
 
 #### Step 3
 Once the deployment has finished, review the output of the script to ensure everything succeeded by checking AWS to make sure the expected changes were made.
+
+
+## Upgrading Terraform
+We have locked Terraform to its minor version to protect the team from accidentally running a deployment from a version not compatible with the Terraform files we have.
+
+NB. [Terraform is currently releasing 'major' changes in it's next minor version of 0.12](https://www.terraform.io/upgrade-guides/0-12.html) so we have not locked to the traditional major point which might be expected.
+
+Locking will hopefully give us explicit feedback on version issues before being presented with a barrage of Terraform errors throughout all affected files during the last phase of a production deployment.
+
+The intent is for Terraform version upgrades that require changes to be a deliberate action rather than an accident based on an individuals later install of the Terraform client.

--- a/terraform.tf
+++ b/terraform.tf
@@ -12,7 +12,7 @@ Store infrastructure state in a remote store (instead of local machine):
 https://www.terraform.io/docs/state/purpose.html
 */
 terraform {
-  required_version = "~> 0.11.11"
+  required_version = "~> 0.11.13"
 
   backend "s3" {
     bucket  = "terraform-state-002"


### PR DESCRIPTION
* Lock to the major version to be explicit about Terraform usage when files may include breaking changes
* Passing reference to the requirement of AWS credentials being set up locally too
