### PR TITLE
[818] Refactor Performance Platform jobs

### DIFF
--- a/app/jobs/performance_platform_feedback_queue_job.rb
+++ b/app/jobs/performance_platform_feedback_queue_job.rb
@@ -2,16 +2,20 @@ require 'performance_platform'
 class PerformancePlatformFeedbackQueueJob < ApplicationJob
   queue_as :performance_platform
 
+  LOG_SOURCE = 'performance_platform:submit_user_satisfaction'.freeze
+
   def perform(time_to_s)
     date = Time.zone.parse(time_to_s)
-    return if TransactionAuditor::Logger.new('performance_platform:submit_user_satisfaction', date).performed?
 
-    data = { 1 => 0, 2 => 0, 3 => 0, 4 => 0, 5 => 0 }.merge!(Feedback.published_on(date).group(:rating).count)
+    return if TransactionAuditor::Logger.new(LOG_SOURCE, date).performed?
+
+    feedback = { 1 => 0, 2 => 0, 3 => 0, 4 => 0, 5 => 0 }.merge!(Feedback.published_on(date).group(:rating).count)
     PerformancePlatform::UserSatisfaction.new(PP_USER_SATISFACTION_TOKEN)
-                                         .submit(data, date.iso8601)
-    TransactionAuditor::Logger.new('performance_platform:submit_user_satisfaction', date).log_success
+                                         .submit(feedback, date.iso8601)
+
+    TransactionAuditor::Logger.new(LOG_SOURCE, date).log_success
   rescue StandardError => e
-    TransactionAuditor::Logger.new('performance_platform:submit_user_satisfaction', date).log_failure
+    TransactionAuditor::Logger.new(LOG_SOURCE, date).log_failure
     Rails.logger.error("Sidekiq: Something went wrong and user satisfaction was not \
                        submitted to the Performance Platform': #{e.message}")
     raise

--- a/app/jobs/performance_platform_feedback_queue_job.rb
+++ b/app/jobs/performance_platform_feedback_queue_job.rb
@@ -1,23 +1,9 @@
-require 'performance_platform'
+require 'performance_platform_sender'
+
 class PerformancePlatformFeedbackQueueJob < ApplicationJob
   queue_as :performance_platform
 
-  LOG_SOURCE = 'performance_platform:submit_user_satisfaction'.freeze
-
   def perform(time_to_s)
-    date = Time.zone.parse(time_to_s)
-
-    return if TransactionAuditor::Logger.new(LOG_SOURCE, date).performed?
-
-    feedback = { 1 => 0, 2 => 0, 3 => 0, 4 => 0, 5 => 0 }.merge!(Feedback.published_on(date).group(:rating).count)
-    PerformancePlatform::UserSatisfaction.new(PP_USER_SATISFACTION_TOKEN)
-                                         .submit(feedback, date.iso8601)
-
-    TransactionAuditor::Logger.new(LOG_SOURCE, date).log_success
-  rescue StandardError => e
-    TransactionAuditor::Logger.new(LOG_SOURCE, date).log_failure
-    Rails.logger.error("Sidekiq: Something went wrong and user satisfaction was not \
-                       submitted to the Performance Platform': #{e.message}")
-    raise
+    PerformancePlatformSender::Base.by_type(:feedback).call(date: time_to_s)
   end
 end

--- a/app/jobs/performance_platform_transactions_queue_job.rb
+++ b/app/jobs/performance_platform_transactions_queue_job.rb
@@ -2,19 +2,20 @@ require 'performance_platform'
 class PerformancePlatformTransactionsQueueJob < ApplicationJob
   queue_as :performance_platform
 
-  def perform(time_to_s)
-    time = Time.zone.parse(time_to_s)
-    date = time.to_date
+  LOG_SOURCE = 'performance_platform:submit_transactions'.freeze
 
-    return if TransactionAuditor::Logger.new('performance_platform:submit_transactions', date).performed?
+  def perform(time_to_s)
+    date = Time.zone.parse(time_to_s)
+
+    return if TransactionAuditor::Logger.new(LOG_SOURCE, date).performed?
 
     no_of_transactions = Vacancy.published_on_count(date)
     PerformancePlatform::TransactionsByChannel.new(PP_TRANSACTIONS_BY_CHANNEL_TOKEN)
-                                              .submit_transactions(no_of_transactions, time.iso8601)
+                                              .submit_transactions(no_of_transactions, date.iso8601)
 
-    TransactionAuditor::Logger.new('performance_platform:submit_transactions', date).log_success
+    TransactionAuditor::Logger.new(LOG_SOURCE, date).log_success
   rescue StandardError => e
-    TransactionAuditor::Logger.new('performance_platform:submit_transactions', date).log_failure
+    TransactionAuditor::Logger.new(LOG_SOURCE, date).log_failure
     Rails.logger.error("Sidekiq: Something went wrong and transactions were not submitted \
                         to the Performance Platform: #{e.message}")
     raise

--- a/app/jobs/performance_platform_transactions_queue_job.rb
+++ b/app/jobs/performance_platform_transactions_queue_job.rb
@@ -11,7 +11,7 @@ class PerformancePlatformTransactionsQueueJob < ApplicationJob
 
     no_of_transactions = Vacancy.published_on_count(date)
     PerformancePlatform::TransactionsByChannel.new(PP_TRANSACTIONS_BY_CHANNEL_TOKEN)
-                                              .submit_transactions(no_of_transactions, date.iso8601)
+                                              .submit(no_of_transactions, date.iso8601)
 
     TransactionAuditor::Logger.new(LOG_SOURCE, date).log_success
   rescue StandardError => e

--- a/lib/performance_platform.rb
+++ b/lib/performance_platform.rb
@@ -26,11 +26,11 @@ module PerformancePlatform
       '/data/teaching-jobs-job-listings/transactions-by-channel'
     end
 
-    def data_map(timestamp, period, data)
+    def data_map(timestamp, period, count)
       { _timestamp: timestamp,
         service: 'teaching_jobs_listings',
         channel: 'digital',
-        count: data,
+        count: count,
         dataType: 'transactions-by-channel',
         period: period }.to_json
     end
@@ -43,15 +43,15 @@ module PerformancePlatform
       '/data/teaching-jobs-job-listings/user-satisfaction'
     end
 
-    def data_map(timestamp, period, data)
+    def data_map(timestamp, period, rating_counts)
       { _timestamp: timestamp,
-        rating_1: data[1],
-        rating_2: data[2],
-        rating_3: data[3],
-        rating_4: data[4],
-        rating_5: data[5],
+        rating_1: rating_counts[1],
+        rating_2: rating_counts[2],
+        rating_3: rating_counts[3],
+        rating_4: rating_counts[4],
+        rating_5: rating_counts[5],
         service: 'teaching_jobs_listings',
-        total: data.values.inject(:+),
+        total: rating_counts.values.inject(:+),
         dataType: 'user-satisfaction',
         period: period }.to_json
     end

--- a/lib/performance_platform.rb
+++ b/lib/performance_platform.rb
@@ -11,56 +11,49 @@ module PerformancePlatform
       @headers = { 'Authorization' => "Bearer #{token}",
                    'Content-Type' => 'application/json' }
     end
+
+    def submit(data, timestamp = Time.zone.now.iso8601, period = 'day')
+      HTTParty.post("#{PP_DOMAIN}#{transaction_endpoint}",
+                    body: data_map(timestamp, period, data),
+                    headers: headers)
+    end
   end
 
   class TransactionsByChannel < Base
-    def submit_transactions(count, timestamp = Time.zone.now.iso8601, period = 'day')
-      HTTParty.post("#{PP_DOMAIN}#{transaction_endpoint}",
-                    body: data(timestamp, period, count),
-                    headers: headers)
-    end
-
     private
 
     def transaction_endpoint
       '/data/teaching-jobs-job-listings/transactions-by-channel'
     end
 
-    def data(timestamp, period, count)
+    def data_map(timestamp, period, data)
       { _timestamp: timestamp,
         service: 'teaching_jobs_listings',
         channel: 'digital',
-        count: count,
+        count: data,
         dataType: 'transactions-by-channel',
         period: period }.to_json
     end
   end
 
   class UserSatisfaction < Base
-    def submit(rating_counts, timestamp = Time.zone.now.iso8601, period = 'day')
-      HTTParty.post("#{PP_DOMAIN}#{transaction_endpoint}",
-                    body: data(timestamp, period, rating_counts.values.inject(:+), rating_counts),
-                    headers: headers)
-    end
-
     private
 
     def transaction_endpoint
       '/data/teaching-jobs-job-listings/user-satisfaction'
     end
 
-    def data(timestamp, period, total, rating_counts)
-      data = { _timestamp: timestamp,
-               rating_1: rating_counts[1],
-               rating_2: rating_counts[2],
-               rating_3: rating_counts[3],
-               rating_4: rating_counts[4],
-               rating_5: rating_counts[5],
-               service: 'teaching_jobs_listings',
-               total: total,
-               dataType: 'user-satisfaction',
-               period: period }.to_json
-      data
+    def data_map(timestamp, period, data)
+      { _timestamp: timestamp,
+        rating_1: data[1],
+        rating_2: data[2],
+        rating_3: data[3],
+        rating_4: data[4],
+        rating_5: data[5],
+        service: 'teaching_jobs_listings',
+        total: data.values.inject(:+),
+        dataType: 'user-satisfaction',
+        period: period }.to_json
     end
   end
 end

--- a/lib/performance_platform_sender.rb
+++ b/lib/performance_platform_sender.rb
@@ -1,0 +1,68 @@
+require 'performance_platform'
+
+module PerformancePlatformSender
+  class Base
+    def self.by_type(type)
+      const_get('PerformancePlatformSender::' + type.to_s.capitalize).new
+    end
+
+    def call(date:)
+      @date = Time.zone.parse(date)
+
+      return if TransactionAuditor::Logger.new(log_source, date).performed?
+
+      send_data
+
+      TransactionAuditor::Logger.new(log_source, date).log_success
+    rescue StandardError => e
+      TransactionAuditor::Logger.new(log_source, date).log_failure
+      Rails.logger.error("Something went wrong and #{performance_type} were not submitted \
+                          to the Performance Platform: #{e.message}")
+      raise
+    end
+
+    private
+
+    attr_reader :date
+
+    def performance_type
+      self.class.name.demodulize
+    end
+  end
+
+  class Transactions < Base
+    private
+
+    def log_source
+      'performance_platform:submit_transactions'
+    end
+
+    def send_data
+      PerformancePlatform::TransactionsByChannel
+        .new(PP_TRANSACTIONS_BY_CHANNEL_TOKEN)
+        .submit(data, date.iso8601)
+    end
+
+    def data
+      Vacancy.published_on_count(date)
+    end
+  end
+
+  class Feedback < Base
+    private
+
+    def log_source
+      'performance_platform:submit_user_satisfaction'
+    end
+
+    def send_data
+      PerformancePlatform::UserSatisfaction
+        .new(PP_USER_SATISFACTION_TOKEN)
+        .submit(data, date.iso8601)
+    end
+
+    def data
+      { 1 => 0, 2 => 0, 3 => 0, 4 => 0, 5 => 0 }.merge!(::Feedback.published_on(date).group(:rating).count)
+    end
+  end
+end

--- a/lib/tasks/performance_platform.rake
+++ b/lib/tasks/performance_platform.rake
@@ -8,13 +8,13 @@ namespace :performance_platform do
   end
 
   task submit_transactions: :environment do
-    yesteday = Date.current.beginning_of_day.in_time_zone - 1.day
-    PerformancePlatformFeedbackQueueJob.perform_later(yesteday.to_s)
+    yesterday = Date.current.beginning_of_day.in_time_zone - 1.day
+    PerformancePlatformTransactionsQueueJob.perform_later(yesterday.to_s)
   end
 
   task submit_user_satisfaction: :environment do
     yesterday = Date.current.beginning_of_day.in_time_zone - 1.day
-    PerformancePlatformTransactionsQueueJob.perform_later(yesterday.to_s)
+    PerformancePlatformFeedbackQueueJob.perform_later(yesterday.to_s)
   end
 
   task submit_data_up_to_today: :environment do

--- a/spec/jobs/performance_platform_feedback_queue_job_spec.rb
+++ b/spec/jobs/performance_platform_feedback_queue_job_spec.rb
@@ -15,31 +15,10 @@ RSpec.describe PerformancePlatformFeedbackQueueJob, type: :job do
   end
 
   it 'executes perform' do
-    stub_const('PP_USER_SATISFACTION_TOKEN', 'user-satisfaction-token')
+    pp = instance_double(PerformancePlatformSender::Feedback)
 
-    user_satisfaction = double(:user_satisfaction)
-
-    today = Date.current.beginning_of_day.in_time_zone
-    two_days_ago = today - 2.days
-
-    create_list(:feedback, 3, rating: 1, created_at: today)
-    create_list(:feedback, 4, rating: 4, created_at: two_days_ago)
-
-    rating3 = create_list(:feedback, 2, rating: 3, created_at: date_to_upload)
-    rating5 = create_list(:feedback, 3, rating: 5, created_at: date_to_upload)
-
-    ratings = {
-      1 => 0,
-      2 => 0,
-      3 => rating3.count,
-      4 => 0,
-      5 => rating5.count
-    }
-
-    expect(PerformancePlatform::UserSatisfaction).to receive(:new)
-      .with('user-satisfaction-token')
-      .and_return(user_satisfaction)
-    expect(user_satisfaction).to receive(:submit).with(ratings, date_to_upload.iso8601)
+    expect(PerformancePlatformSender::Base).to receive(:by_type).with(:feedback).and_return(pp)
+    expect(pp).to receive(:call).with(date: date_to_upload.to_s)
 
     perform_enqueued_jobs { job }
   end

--- a/spec/jobs/performance_platform_transactions_queue_job_spec.rb
+++ b/spec/jobs/performance_platform_transactions_queue_job_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe PerformancePlatformTransactionsQueueJob, type: :job do
     ]
 
     expect(PerformancePlatform::TransactionsByChannel).to receive(:new).with('not-nil').and_return(pp)
-    expect(pp).to receive(:submit_transactions).with(jobs_published_yesterday.count, date_to_upload.iso8601)
+    expect(pp).to receive(:submit).with(jobs_published_yesterday.count, date_to_upload.iso8601)
 
     perform_enqueued_jobs { job }
   end

--- a/spec/jobs/performance_platform_transactions_queue_job_spec.rb
+++ b/spec/jobs/performance_platform_transactions_queue_job_spec.rb
@@ -3,16 +3,7 @@ require 'rails_helper'
 RSpec.describe PerformancePlatformTransactionsQueueJob, type: :job do
   include ActiveJob::TestHelper
 
-  let(:runtime) { Time.new(2008, 9, 1, 13, 0, 0).utc }
   let(:date_to_upload) { Date.current.beginning_of_day.in_time_zone - 1.day }
-
-  before do
-    Timecop.freeze(runtime)
-  end
-
-  after do
-    Timecop.return
-  end
 
   subject(:job) { described_class.perform_later(date_to_upload.to_s) }
 
@@ -25,22 +16,10 @@ RSpec.describe PerformancePlatformTransactionsQueueJob, type: :job do
   end
 
   it 'enqueues a job to send all published job from yesterday' do
-    stub_const('PP_TRANSACTIONS_BY_CHANNEL_TOKEN', 'not-nil')
+    pp = instance_double(PerformancePlatformSender::Transactions)
 
-    pp = double(:performance_platform)
-    two_days_ago = Date.current.beginning_of_day.in_time_zone - 2.days
-    today = Date.current.beginning_of_day.in_time_zone
-
-    build(:vacancy, :past_publish, publish_on: two_days_ago).save(validate: false)
-    build(:vacancy, :past_publish, publish_on: today).save(validate: false)
-
-    jobs_published_yesterday = [
-      build(:vacancy, :past_publish, publish_on: date_to_upload).save(validate: false),
-      build(:vacancy, :past_publish, publish_on: date_to_upload).save(validate: false)
-    ]
-
-    expect(PerformancePlatform::TransactionsByChannel).to receive(:new).with('not-nil').and_return(pp)
-    expect(pp).to receive(:submit).with(jobs_published_yesterday.count, date_to_upload.iso8601)
+    expect(PerformancePlatformSender::Base).to receive(:by_type).with(:transactions).and_return(pp)
+    expect(pp).to receive(:call).with(date: date_to_upload.to_s)
 
     perform_enqueued_jobs { job }
   end

--- a/spec/lib/performance_platform_sender_spec.rb
+++ b/spec/lib/performance_platform_sender_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+require 'performance_platform_sender'
+
+RSpec.describe PerformancePlatformSender::Base do
+  let(:type) { :transactions }
+  let(:date) { (Date.current.beginning_of_day.in_time_zone - 1.day).to_s }
+  let(:parsed_date) { Time.zone.parse(date) }
+
+  subject { described_class.by_type(type) }
+
+  it 'will return the correct class for type' do
+    expect(subject).to be_a(PerformancePlatformSender::Transactions)
+  end
+
+  context 'transactions' do
+    subject { described_class.by_type(type).call(date: date) }
+
+    it 'will submit transaction data' do
+      data = {}
+
+      expect(Vacancy).to receive(:published_on_count).and_return(data)
+
+      transaction_by_channel = instance_double(PerformancePlatform::TransactionsByChannel)
+      expect(PerformancePlatform::TransactionsByChannel).to receive(:new).and_return(transaction_by_channel)
+      expect(transaction_by_channel).to receive(:submit).with(data, parsed_date)
+
+      subject
+
+      expect(TransactionAuditor.last.success?).to be true
+    end
+
+    it 'will be idempotent' do
+      TransactionAuditor::Logger.new('performance_platform:submit_transactions', parsed_date).log_success
+
+      expect(PerformancePlatform::TransactionsByChannel).to_not receive(:new)
+      expect(Vacancy).to_not receive(:published_on_count)
+
+      subject
+    end
+
+    it 'will log a failure' do
+      allow_any_instance_of(PerformancePlatform::TransactionsByChannel)
+        .to receive(:submit).and_raise(RuntimeError.new('Error'))
+
+      expect { subject }.to raise_error(RuntimeError)
+
+      expect(TransactionAuditor.last.success?).to be false
+    end
+  end
+
+  context 'feedback' do
+    let(:type) { :feedback }
+
+    subject { described_class.by_type(type).call(date: date) }
+
+    it 'will submit feedback data' do
+      data = { 1 => 0, 2 => 0, 3 => 0, 4 => 0, 5 => 0 }
+
+      expect(Feedback).to receive_message_chain(:published_on, :group, :count).and_return(data)
+
+      user_feedback = instance_double(PerformancePlatform::UserSatisfaction)
+      expect(PerformancePlatform::UserSatisfaction).to receive(:new).and_return(user_feedback)
+      expect(user_feedback).to receive(:submit).with(data, parsed_date)
+
+      subject
+
+      expect(TransactionAuditor.last.success?).to be true
+    end
+  end
+end

--- a/spec/lib/performance_platform_spec.rb
+++ b/spec/lib/performance_platform_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe PerformancePlatform::TransactionsByChannel do
                                               headers: headers)
 
       performance_platform = PerformancePlatform::TransactionsByChannel.new('some-token')
-      performance_platform.submit_transactions(2)
+      performance_platform.submit(2)
     end
   end
 end

--- a/spec/lib/tasks/performance_platform_rake_spec.rb
+++ b/spec/lib/tasks/performance_platform_rake_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'rake performance_platform:submit_transactions', type: :task do
     today = Date.current.beginning_of_day.in_time_zone
     expect(Date).to receive_message_chain(:current, :beginning_of_day).and_return(today)
 
-    expect(PerformancePlatformFeedbackQueueJob).to receive(:perform_later).with((today - 1.day).to_s)
+    expect(PerformancePlatformTransactionsQueueJob).to receive(:perform_later).with((today - 1.day).to_s)
 
     task.invoke
   end
@@ -15,7 +15,7 @@ RSpec.describe 'rake performance_platform:submit_user_satisfaction', type: :task
     today = Date.current.beginning_of_day.in_time_zone
     expect(Date).to receive_message_chain(:current, :beginning_of_day).and_return(today)
 
-    expect(PerformancePlatformTransactionsQueueJob).to receive(:perform_later).with((today - 1.day).to_s)
+    expect(PerformancePlatformFeedbackQueueJob).to receive(:perform_later).with((today - 1.day).to_s)
 
     task.invoke
   end


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/hkhh0Vfc/818-refactor-performance-platform-jobs

## Changes in this PR:

* Made the `PerformancePlatform` class a little more consistent for both Transactions and Feedback. Both now have a `submit` method in the base class, with variations in the subclasses, such as data manipulation.
* Add `PerformancePlatformSender` which takes the bulk of the logic out of the jobs, and dry's things up to work for both transactions and feedback.
* Integrate `PerformancePlatformSender` into the background jobs for transactions and feedback.