### PR TITLE
Revise the reference hint text

### DIFF
--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -65,4 +65,4 @@ en:
         reference: 'Your reference'
     hints:
       defaults:
-        reference: Enter a short description for this job alert. This will appear in the subject line of the email we send you when a new job matches your criteria.
+        reference: This text will appear in the subject line of the email we send you when a new job matches your criteria. Feel free to change it.


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/npmtxxuy/803-reference-numbers-for-job-alerts-should-not-be-machine-generated-but-a-mandatory-human-reference-so-that-the-alert-reference-is

## Changes in this PR:

New reference text based on feedback from Fiona.