### PR TITLE
Pin to latest instead of a specific task revisions

### DIFF
--- a/terraform.tf
+++ b/terraform.tf
@@ -65,12 +65,14 @@ module "ecs" {
   ecs_service_web_container_definition_file_path = "${var.ecs_service_web_container_definition_file_path}"
   ecs_service_web_name                           = "${var.project_name}_${terraform.workspace}_${var.ecs_service_web_name}"
   ecs_service_web_task_name                      = "${var.project_name}_${terraform.workspace}_${var.ecs_service_web_task_name}"
+  ecs_service_web_task_revision                  = "${var.ecs_service_web_task_revision}"
   ecs_service_web_task_count                     = "${var.ecs_service_web_task_count}"
   ecs_service_web_task_port                      = "${var.ecs_service_web_task_port}"
 
   ecs_service_worker_container_definition_file_path = "${var.ecs_service_worker_container_definition_file_path}"
   ecs_service_worker_name                           = "${var.project_name}_${terraform.workspace}_${var.ecs_service_worker_name}"
   ecs_service_worker_task_name                      = "${var.project_name}_${terraform.workspace}_${var.ecs_service_worker_task_name}"
+  ecs_service_worker_task_revision                  = "${var.ecs_service_worker_task_revision}"
   ecs_service_worker_task_port                      = "${var.ecs_service_worker_task_port}"
 
   worker_command = "${var.worker_command}"

--- a/terraform/modules/ecs/ecs.tf
+++ b/terraform/modules/ecs/ecs.tf
@@ -43,7 +43,7 @@ resource "aws_ecs_service" "web" {
   name            = "${var.ecs_service_web_name}"
   iam_role        = "${aws_iam_role.ecs_role.arn}"
   cluster         = "${aws_ecs_cluster.cluster.id}"
-  task_definition = "${aws_ecs_task_definition.web.arn}"
+  task_definition = "${replace("${aws_ecs_task_definition.web.arn}", "/:${aws_ecs_task_definition.web.revision}$$/", ":${var.ecs_service_web_task_revision}")}"
   desired_count   = "${var.ecs_service_web_task_count}"
 
   deployment_minimum_healthy_percent = 50
@@ -82,7 +82,7 @@ resource "aws_ecs_service" "logspout" {
 resource "aws_ecs_service" "worker" {
   name            = "${var.ecs_service_worker_name}"
   cluster         = "${aws_ecs_cluster.cluster.id}"
-  task_definition = "${aws_ecs_task_definition.worker.arn}"
+  task_definition = "${replace("${aws_ecs_task_definition.worker.arn}", "/:${aws_ecs_task_definition.worker.revision}$$/", ":${var.ecs_service_worker_task_revision}")}"
   desired_count   = "${var.ecs_service_web_task_count}"
 
   deployment_minimum_healthy_percent = 50

--- a/terraform/modules/ecs/input.tf
+++ b/terraform/modules/ecs/input.tf
@@ -9,6 +9,7 @@ variable "ecs_service_web_container_definition_file_path" {}
 
 variable "ecs_service_web_name" {}
 variable "ecs_service_web_task_name" {}
+variable "ecs_service_web_task_revision" {}
 variable "ecs_service_web_task_count" {}
 variable "ecs_service_web_task_port" {}
 
@@ -17,6 +18,7 @@ variable "ecs_service_worker_container_definition_file_path" {}
 
 variable "ecs_service_worker_name" {}
 variable "ecs_service_worker_task_name" {}
+variable "ecs_service_worker_task_revision" {}
 variable "ecs_service_worker_task_port" {}
 
 # Rake task container definitions

--- a/variables.tf
+++ b/variables.tf
@@ -99,6 +99,11 @@ variable "ecs_service_web_task_name" {
   default = "web"
 }
 
+variable "ecs_service_web_task_revision" {
+  description = "The revision of the web task definition to use"
+  default     = "latest"
+}
+
 variable "ecs_service_web_task_count" {
   description = "The number of containers to run for this service"
   default     = 1
@@ -115,6 +120,11 @@ variable "ecs_service_worker_name" {
 
 variable "ecs_service_worker_task_name" {
   default = "worker"
+}
+
+variable "ecs_service_worker_task_revision" {
+  description = "The revision of the worker task definition to use"
+  default     = "latest"
 }
 
 variable "ecs_service_worker_task_port" {


### PR DESCRIPTION
## Changes in this PR:

My hunch is that our deployment process is creating new task
definitions, but Terraform doesn't pick up on them because it's a
computed property of a task definiton. Because we were pinning to
specific task revisions, we were rolling back to the last revision
Terraform knew about, which was the last revision it created. This
change makes it so that we pin to latest, which will always be the
most recent definition.

The revisions are pinned to latest by default, but are
overridable.

## Screenshots of UI changes:

### Before

<img width="648" alt="image" src="https://user-images.githubusercontent.com/1027364/56357450-b558cc00-61d3-11e9-9094-87ce9b2abef4.png">

### After

<img width="648" alt="image" src="https://user-images.githubusercontent.com/1027364/56357461-bf7aca80-61d3-11e9-9d3c-dda0ddb0d169.png">

## Next steps:

- [x] Terraform deployment required?