### PR TITLE
[848] Listings dont appear in the published tab on their last day before expiry

### DIFF
--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -100,7 +100,7 @@ class Vacancy < ApplicationRecord
   scope :published_on_count, (->(date) { published.where(publish_on: date.all_day).count })
   scope :pending, (-> { published.where('publish_on > ?', Time.zone.today) })
   scope :expired, (-> { published.where('expires_on < ?', Time.zone.today) })
-  scope :live, (-> { published.where('publish_on <= ?', Time.zone.today).where('expires_on > ?', Time.zone.today) })
+  scope :live, (-> { published.where('publish_on <= ?', Time.zone.today).where('expires_on >= ?', Time.zone.today) })
 
   paginates_per 10
 

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -366,8 +366,9 @@ RSpec.describe Vacancy, type: :model do
     end
 
     describe '#live' do
+      let!(:live) { create_list(:vacancy, 5, :published) }
+
       it 'retrieves vacancies that have a status of :published, a past publish_on date & a future expires_on date' do
-        live = create_list(:vacancy, 5, :published)
         expired = build(:vacancy, :expired)
         expired.send :set_slug
         expired.save(validate: false)
@@ -375,7 +376,13 @@ RSpec.describe Vacancy, type: :model do
         create_list(:vacancy, 4, :trashed)
 
         expect(Vacancy.live.count).to eq(live.count)
-        expect(live).to_not include(expired)
+        expect(Vacancy.live).to_not include(expired)
+      end
+
+      it 'includes vacancies that expire today' do
+        expires_today = create(:vacancy, status: :published, expires_on: Time.zone.today)
+
+        expect(Vacancy.live).to include(expires_today)
       end
     end
 


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/LMjeNx09/848-listings-dont-appear-in-the-published-tab-on-their-last-day-before-expiry

## Changes in this PR:

Make jobs that expire today count as published.

**This was a hotfix and is already merged into `master` (#863).**

**DO NOT REBASE**