### PR TITLE
[838] Amend education phase as a search option so that it is multi select

### DIFF
--- a/app/assets/stylesheets/components/filter_vacancies.scss
+++ b/app/assets/stylesheets/components/filter_vacancies.scss
@@ -37,14 +37,24 @@
 
   .filters-form .checkbox-group {
     &--scrollable {
-      height: 160px;
+      height: 170px;
       overflow: auto;
     }
     padding: 10px 10px 0 10px;
-    border: 2px solid govuk-colour("black");
+    border: 2px solid govuk-colour("grey-1");
+    box-sizing: border-box;
+    width: 100%;
     label {
       background: govuk-colour("white");
       font-size: $small-font-size;
+    }
+    &__divider {
+      $govuk-divider-size: 40px;
+      @include govuk-font($size: 19);
+      @include govuk-text-colour;
+      width: $govuk-divider-size;
+      margin-bottom: govuk-spacing(2);
+      text-align: center;
     }
   }
   .filters-form .checkbox-group:after {

--- a/app/assets/stylesheets/components/filter_vacancies.scss
+++ b/app/assets/stylesheets/components/filter_vacancies.scss
@@ -34,4 +34,22 @@
        }
     }
   }
+
+  .filters-form .checkbox-group {
+    &--scrollable {
+      height: 160px;
+      overflow: auto;
+    }
+    padding: 10px 10px 0 10px;
+    border: 2px solid govuk-colour("black");
+    label {
+      background: govuk-colour("white");
+      font-size: $small-font-size;
+    }
+  }
+  .filters-form .checkbox-group:after {
+    content: "";
+    height: 10px;
+    display: block;
+  }
 }

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -1,12 +1,6 @@
 class SubscriptionsController < ApplicationController
   include ParameterSanitiser
 
-  PERMITTED_SEARCH_CRITERIA_PARAMS = []
-                                     .concat(VacancyAlertFilters::AVAILABLE_FILTERS)
-                                     .concat(VacanciesController::PERMITTED_SEARCH_PARAMS)
-                                     .uniq
-                                     .freeze
-
   before_action :check_feature_flag, except: :unsubscribe
 
   def new
@@ -52,7 +46,13 @@ class SubscriptionsController < ApplicationController
   end
 
   def search_criteria_params
-    params.require(:search_criteria).permit(*PERMITTED_SEARCH_CRITERIA_PARAMS)
+    params.require(:search_criteria).permit(*permitted_search_criteria_params)
+  end
+
+  def permitted_search_criteria_params
+    [].concat(VacancyAlertFilters::AVAILABLE_FILTERS)
+      .concat(VacanciesController::PERMITTED_SEARCH_PARAMS)
+      .uniq
   end
 
   def check_feature_flag

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -1,10 +1,16 @@
 class SubscriptionsController < ApplicationController
   include ParameterSanitiser
 
+  PERMITTED_SEARCH_CRITERIA_PARAMS = []
+                                     .concat(VacancyAlertFilters::AVAILABLE_FILTERS)
+                                     .concat(VacanciesController::PERMITTED_SEARCH_PARAMS)
+                                     .uniq
+                                     .freeze
+
   before_action :check_feature_flag, except: :unsubscribe
 
   def new
-    subscription = Subscription.new(search_criteria: search_criteria.to_json)
+    subscription = Subscription.new(search_criteria: search_criteria_params.to_json)
     @subscription = SubscriptionPresenter.new(subscription)
     Auditor::Audit.new(nil, 'subscription.daily_alert.new', current_session_id).log_without_association
   end
@@ -45,8 +51,8 @@ class SubscriptionsController < ApplicationController
                               frequency: :daily)
   end
 
-  def search_criteria
-    params.require(:search_criteria).permit(*VacancyAlertFilters::AVAILABLE_FILTERS)
+  def search_criteria_params
+    params.require(:search_criteria).permit(*PERMITTED_SEARCH_CRITERIA_PARAMS)
   end
 
   def check_feature_flag

--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -120,7 +120,7 @@ class VacanciesController < ApplicationController
   def any_phase?
     return true if phases_to_a.blank?
 
-    phases_to_a.select(&:present?).empty?
+    phases_to_a.reject(&:blank?).any?
   end
 
   def set_headers

--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -9,6 +9,7 @@ class VacanciesController < ApplicationController
                 :minimum_salary,
                 :working_pattern,
                 :phases,
+                :any_phase?,
                 :newly_qualified_teacher,
                 :radius,
                 :sort_column,
@@ -84,8 +85,16 @@ class VacanciesController < ApplicationController
     params[:working_pattern]
   end
 
+  def phases_to_a
+    raw_phases = params[:phases]
+    parsed_phases = JSON.parse(raw_phases) if raw_phases.present?
+    parsed_phases.is_a?(Array) ? parsed_phases : []
+  rescue JSON::ParserError
+    []
+  end
+
   def phases
-    params[:phases]
+    phases_to_a
   end
 
   def newly_qualified_teacher
@@ -102,6 +111,12 @@ class VacanciesController < ApplicationController
 
   def sort_order
     params[:sort_order]
+  end
+
+  def any_phase?
+    return true if phases_to_a.blank?
+
+    phases_to_a.select(&:present?).empty?
   end
 
   def set_headers

--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -8,7 +8,7 @@ class VacanciesController < ApplicationController
                 :job_title,
                 :minimum_salary,
                 :working_pattern,
-                :phase,
+                :phases,
                 :newly_qualified_teacher,
                 :radius,
                 :sort_column,
@@ -84,8 +84,8 @@ class VacanciesController < ApplicationController
     params[:working_pattern]
   end
 
-  def phase
-    params[:phase]
+  def phases
+    params[:phases]
   end
 
   def newly_qualified_teacher

--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -1,6 +1,10 @@
 class VacanciesController < ApplicationController
   include ParameterSanitiser
 
+  PERMITTED_SEARCH_PARAMS = [phases: []]
+                            .concat(VacancyFilters::AVAILABLE_FILTERS)
+                            .uniq
+                            .freeze
   DEFAULT_RADIUS = 20
 
   helper_method :location,
@@ -16,7 +20,7 @@ class VacanciesController < ApplicationController
                 :sort_order
 
   def index
-    @filters = VacancyFilters.new(search_params)
+    @filters = VacancyFilters.new(search_params.to_hash)
     @sort = VacancySort.new.update(column: sort_column, order: sort_order)
     @vacancies = VacanciesFinder.new(@filters, @sort, page_number).vacancies
 
@@ -48,7 +52,7 @@ class VacanciesController < ApplicationController
   private
 
   def search_params
-    params.permit(*VacancyFilters::AVAILABLE_FILTERS).to_hash
+    params.permit(*PERMITTED_SEARCH_PARAMS)
   end
 
   def old_vacancy_path?(vacancy)

--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -46,11 +46,17 @@ module VacanciesHelper
     @pay_scale_options ||= PayScale.all
   end
 
-  def nqt_suitable_checked?(newly_qualified_teacher)
-    newly_qualified_teacher == 'true'
-  end
-
   def subject_options
     @subject_options ||= Subject.all
+  end
+
+  def phase_checked?(phase)
+    return false if phases.blank?
+
+    JSON.parse(phases).include?(phase)
+  end
+
+  def nqt_suitable_checked?(newly_qualified_teacher)
+    newly_qualified_teacher == 'true'
   end
 end

--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -53,7 +53,7 @@ module VacanciesHelper
   def phase_checked?(phase)
     return false if phases.blank?
 
-    JSON.parse(phases).include?(phase)
+    phases.include?(phase)
   end
 
   def nqt_suitable_checked?(newly_qualified_teacher)

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -113,6 +113,14 @@ class Vacancy < ApplicationRecord
   counter :page_view_counter
   counter :get_more_info_counter
 
+  def self.public_search(filters:, sort:)
+    query = VacancySearchBuilder.new(filters: filters, sort: sort).call
+    results = ElasticSearchFinder.new.call(query[:search_query], query[:search_sort])
+
+    Rollbar.log(:info, 'A search returned 0 results', filters.to_hash) if results.count.zero?
+    results
+  end
+
   def location
     @location ||= SchoolPresenter.new(school).location
   end
@@ -124,14 +132,6 @@ class Vacancy < ApplicationRecord
       lat: school_geolocation.x.to_f,
       lon: school_geolocation.y.to_f
     }
-  end
-
-  def self.public_search(filters:, sort:)
-    query = VacancySearchBuilder.new(filters: filters, sort: sort).call
-    results = ElasticSearchFinder.new.call(query[:search_query], query[:search_sort])
-
-    Rollbar.log(:info, 'A search returned 0 results', filters.to_hash) if results.count.zero?
-    results
   end
 
   def listed?

--- a/app/presenters/subscription_presenter.rb
+++ b/app/presenters/subscription_presenter.rb
@@ -1,11 +1,30 @@
 class SubscriptionPresenter < BasePresenter
   include ApplicationHelper
 
+  SEARCH_CRITERIA_SORT_ORDER = %w[location radius keyword subject job_title minimum_salary maximum_salary
+                                  working_pattern phases newly_qualified_teacher].freeze
+
   def filtered_search_criteria
-    @filtered_search_criteria ||= search_criteria_to_h.each_with_object({}) do |(field, value), criteria|
-      search_field = search_criteria_field(field, value)
-      criteria.merge!(search_field) if search_field.present?
-    end.stringify_keys
+    @filtered_search_criteria ||= begin
+                                    criteria = {}
+                                    sorted_criteria = search_criteria_to_h.sort do |(a, _), (b, _)|
+                                      a_index = SEARCH_CRITERIA_SORT_ORDER.find_index(a)
+                                      b_index = SEARCH_CRITERIA_SORT_ORDER.find_index(b)
+
+                                      next 0 if a_index.nil? && b_index.nil?
+                                      next 1 if a_index.nil?
+                                      next -1 if b_index.nil?
+
+                                      a_index <=> b_index
+                                    end
+
+                                    sorted_criteria.each do |field, value|
+                                      search_field = search_criteria_field(field, value)
+                                      criteria.merge!(search_field) if search_field.present?
+                                    end
+
+                                    criteria.stringify_keys
+                                  end
   end
 
   def to_row

--- a/app/presenters/subscription_presenter.rb
+++ b/app/presenters/subscription_presenter.rb
@@ -12,7 +12,10 @@ class SubscriptionPresenter < BasePresenter
   end
 
   def to_row
-    extended_search_criteria.merge(reference: reference)
+    full_search_criteria.merge!(reference: reference)
+                        .transform_values! do |value|
+      value.is_a?(Array) ? value.join(', ') : value
+    end
   end
 
   private
@@ -30,8 +33,8 @@ class SubscriptionPresenter < BasePresenter
     end.to_h
   end
 
-  def extended_search_criteria
-    available_filter_hash.merge(search_criteria_to_h.symbolize_keys)
+  def full_search_criteria
+    available_filter_hash.merge(sorted_search_criteria.symbolize_keys)
   end
 
   def available_filter_hash

--- a/app/presenters/subscription_presenter.rb
+++ b/app/presenters/subscription_presenter.rb
@@ -5,26 +5,10 @@ class SubscriptionPresenter < BasePresenter
                                   working_pattern phases newly_qualified_teacher].freeze
 
   def filtered_search_criteria
-    @filtered_search_criteria ||= begin
-                                    criteria = {}
-                                    sorted_criteria = search_criteria_to_h.sort do |(a, _), (b, _)|
-                                      a_index = SEARCH_CRITERIA_SORT_ORDER.find_index(a)
-                                      b_index = SEARCH_CRITERIA_SORT_ORDER.find_index(b)
-
-                                      next 0 if a_index.nil? && b_index.nil?
-                                      next 1 if a_index.nil?
-                                      next -1 if b_index.nil?
-
-                                      a_index <=> b_index
-                                    end
-
-                                    sorted_criteria.each do |field, value|
-                                      search_field = search_criteria_field(field, value)
-                                      criteria.merge!(search_field) if search_field.present?
-                                    end
-
-                                    criteria.stringify_keys
-                                  end
+    @filtered_search_criteria ||= sorted_search_criteria.each_with_object({}) do |(field, value), criteria|
+      search_field = search_criteria_field(field, value)
+      criteria.merge!(search_field) if search_field.present?
+    end.stringify_keys
   end
 
   def to_row
@@ -32,6 +16,19 @@ class SubscriptionPresenter < BasePresenter
   end
 
   private
+
+  def sorted_search_criteria
+    search_criteria_to_h.sort do |(a, _), (b, _)|
+      a_index = SEARCH_CRITERIA_SORT_ORDER.find_index(a)
+      b_index = SEARCH_CRITERIA_SORT_ORDER.find_index(b)
+
+      next 0 if a_index.nil? && b_index.nil?
+      next 1 if a_index.nil?
+      next -1 if b_index.nil?
+
+      a_index <=> b_index
+    end.to_h
+  end
 
   def extended_search_criteria
     available_filter_hash.merge(search_criteria_to_h.symbolize_keys)

--- a/app/presenters/subscription_presenter.rb
+++ b/app/presenters/subscription_presenter.rb
@@ -21,15 +21,8 @@ class SubscriptionPresenter < BasePresenter
   private
 
   def sorted_search_criteria
-    search_criteria_to_h.sort do |(a, _), (b, _)|
-      a_index = SEARCH_CRITERIA_SORT_ORDER.find_index(a)
-      b_index = SEARCH_CRITERIA_SORT_ORDER.find_index(b)
-
-      next 0 if a_index.nil? && b_index.nil?
-      next 1 if a_index.nil?
-      next -1 if b_index.nil?
-
-      a_index <=> b_index
+    search_criteria_to_h.sort_by do |(key, _)|
+      SEARCH_CRITERIA_SORT_ORDER.find_index(key) || SEARCH_CRITERIA_SORT_ORDER.count
     end.to_h
   end
 

--- a/app/services/vacancy_filters.rb
+++ b/app/services/vacancy_filters.rb
@@ -14,7 +14,7 @@ class VacancyFilters
     @minimum_salary = args[:minimum_salary]
     @newly_qualified_teacher = args[:newly_qualified_teacher]
     @working_pattern = extract_working_pattern(args)
-    @phase = School.phases.include?(args[:phase]) ? args[:phase] : nil
+    @phase = extract_phase(args)
   end
 
   def to_hash
@@ -44,5 +44,9 @@ class VacancyFilters
 
   def extract_working_pattern(params)
     Vacancy.working_patterns.include?(params[:working_pattern]) ? params[:working_pattern] : nil
+  end
+
+  def extract_phase(params)
+    School.phases.include?(params[:phase]) ? params[:phase] : nil
   end
 end

--- a/app/services/vacancy_filters.rb
+++ b/app/services/vacancy_filters.rb
@@ -43,10 +43,12 @@ class VacancyFilters
   private
 
   def extract_working_pattern(params)
-    Vacancy.working_patterns.include?(params[:working_pattern]) ? params[:working_pattern] : nil
+    params[:working_pattern] if Vacancy.working_patterns.include?(params[:working_pattern])
   end
 
   def extract_phases(params)
-    [params[:phases]].select { |phase| School.phases.include?(phase) }.presence
+    return if params[:phases].blank?
+
+    JSON.parse(params[:phases]).select { |phase| School.phases.include?(phase) }.presence
   end
 end

--- a/app/services/vacancy_filters.rb
+++ b/app/services/vacancy_filters.rb
@@ -1,6 +1,6 @@
 class VacancyFilters
   AVAILABLE_FILTERS = %i[location radius subject job_title minimum_salary working_pattern
-                         phase newly_qualified_teacher].freeze
+                         phases newly_qualified_teacher].freeze
 
   attr_reader(*AVAILABLE_FILTERS)
 
@@ -14,7 +14,7 @@ class VacancyFilters
     @minimum_salary = args[:minimum_salary]
     @newly_qualified_teacher = args[:newly_qualified_teacher]
     @working_pattern = extract_working_pattern(args)
-    @phase = extract_phase(args)
+    @phases = extract_phases(args)
   end
 
   def to_hash
@@ -25,7 +25,7 @@ class VacancyFilters
       job_title: job_title,
       minimum_salary: minimum_salary,
       working_pattern: working_pattern,
-      phase: phase,
+      phases: phases,
       newly_qualified_teacher: newly_qualified_teacher,
     }
   end
@@ -46,7 +46,7 @@ class VacancyFilters
     Vacancy.working_patterns.include?(params[:working_pattern]) ? params[:working_pattern] : nil
   end
 
-  def extract_phase(params)
-    School.phases.include?(params[:phase]) ? params[:phase] : nil
+  def extract_phases(params)
+    [params[:phases]].select { |phase| School.phases.include?(phase) }.presence
   end
 end

--- a/app/services/vacancy_search_builder.rb
+++ b/app/services/vacancy_search_builder.rb
@@ -5,7 +5,7 @@ class VacancySearchBuilder
                 :subject,
                 :job_title,
                 :working_pattern,
-                :phase,
+                :phases,
                 :newly_qualified_teacher,
                 :minimum_salary,
                 :maximum_salary,
@@ -18,7 +18,7 @@ class VacancySearchBuilder
     self.subject = filters.subject.to_s.strip
     self.job_title = filters.job_title.to_s.strip
     self.working_pattern = filters.working_pattern
-    self.phase = filters.phase
+    self.phases = filters.phases
     self.newly_qualified_teacher = filters.newly_qualified_teacher
     self.minimum_salary = filters.minimum_salary
     self.sort = sort
@@ -167,13 +167,13 @@ class VacancySearchBuilder
   end
 
   def phase_query
-    return if phase.blank?
+    return if phases.blank?
 
     {
       bool: {
         filter: {
           terms: {
-            'school.phase': [phase.to_s],
+            'school.phase': phases.map(&:to_s),
           },
         }
       }

--- a/app/views/vacancies/_filters.html.haml
+++ b/app/views/vacancies/_filters.html.haml
@@ -22,13 +22,18 @@
       = label_tag 'working_pattern', t('jobs.filters.working_pattern'), class: 'govuk-label'
       = select_tag 'working_pattern', options_for_select(working_pattern_options, working_pattern), class: 'govuk-select form-control form-control-block', include_blank: 'Any'
     .govuk-form-group
-      = label_tag 'phases', t('jobs.filters.education_phase'), class: 'govuk-label'
-      = select_tag 'phases', options_for_select(school_phase_options, phases), class: 'govuk-select form-control form-control-block', include_blank: 'Any'
+      %fieldset.govuk-fieldset
+        = label_tag 'phases', t('jobs.filters.education_phase'), class: 'govuk-label'
+        .govuk-checkboxes
+          - school_phase_options.each_with_index do |phase, i|
+            .govuk-checkboxes__item
+              = check_box_tag 'phases[]', phase[1], phase_checked?(phase[1]), id: 'phases_' + phase[1]
+              = label_tag 'phases[]', phase[0], for: 'phases_' + phase[1]
     .govuk-form-group
       %fieldset.govuk-fieldset
         .govuk-checkboxes
           .govuk-checkboxes__item
-            = check_box_tag :newly_qualified_teacher, 'true', nqt_suitable_checked?(newly_qualified_teacher), class: 'govuk-checkboxes__input'
+            = check_box_tag 'newly_qualified_teacher', 'true', nqt_suitable_checked?(newly_qualified_teacher), class: 'govuk-checkboxes__input'
             = label_tag 'newly_qualified_teacher', t('jobs.filters.nqt_suitable'), class: 'govuk-label govuk-checkboxes__label'
 
     = hidden_field_tag :sort_column, sort_column

--- a/app/views/vacancies/_filters.html.haml
+++ b/app/views/vacancies/_filters.html.haml
@@ -28,6 +28,8 @@
           .govuk-checkboxes__item
             = check_box_tag 'phases[]', '', any_phase?, id: 'phases_any', class: 'govuk-checkboxes__input'
             = label_tag 'phases[]', 'Any', for: 'phases_any', class: 'govuk-label govuk-checkboxes__label'
+          .checkbox-group__divider 
+            = t('jobs.filters.education_phase_divider')
           - school_phase_options.each_with_index do |phase, i|
             .govuk-checkboxes__item
               = check_box_tag 'phases[]', phase[1], phase_checked?(phase[1]), id: 'phases_' + phase[1], class: 'govuk-checkboxes__input'

--- a/app/views/vacancies/_filters.html.haml
+++ b/app/views/vacancies/_filters.html.haml
@@ -24,7 +24,7 @@
     .govuk-form-group
       %fieldset.govuk-fieldset
         = label_tag 'phases', t('jobs.filters.education_phase'), class: 'govuk-label'
-        .govuk-checkboxes.checkbox-group.checkbox-group--scrollable
+        .govuk-checkboxes.checkbox-group{ class: ('checkbox-group--scrollable' if any_phase?) }
           .govuk-checkboxes__item
             = check_box_tag 'phases[]', '', any_phase?, id: 'phases_any', class: 'govuk-checkboxes__input'
             = label_tag 'phases[]', 'Any', for: 'phases_any', class: 'govuk-label govuk-checkboxes__label'

--- a/app/views/vacancies/_filters.html.haml
+++ b/app/views/vacancies/_filters.html.haml
@@ -22,8 +22,8 @@
       = label_tag 'working_pattern', t('jobs.filters.working_pattern'), class: 'govuk-label'
       = select_tag 'working_pattern', options_for_select(working_pattern_options, working_pattern), class: 'govuk-select form-control form-control-block', include_blank: 'Any'
     .govuk-form-group
-      = label_tag 'phase', t('jobs.filters.education_phase'), class: 'govuk-label'
-      = select_tag 'phase', options_for_select(school_phase_options, phase), class: 'govuk-select form-control form-control-block', include_blank: 'Any'
+      = label_tag 'phases', t('jobs.filters.education_phase'), class: 'govuk-label'
+      = select_tag 'phases', options_for_select(school_phase_options, phases), class: 'govuk-select form-control form-control-block', include_blank: 'Any'
     .govuk-form-group
       %fieldset.govuk-fieldset
         .govuk-checkboxes

--- a/app/views/vacancies/_filters.html.haml
+++ b/app/views/vacancies/_filters.html.haml
@@ -25,6 +25,9 @@
       %fieldset.govuk-fieldset
         = label_tag 'phases', t('jobs.filters.education_phase'), class: 'govuk-label'
         .govuk-checkboxes.checkbox-group.checkbox-group--scrollable
+          .govuk-checkboxes__item
+            = check_box_tag 'phases[]', '', any_phase?, id: 'phases_any', class: 'govuk-checkboxes__input'
+            = label_tag 'phases[]', 'Any', for: 'phases_any', class: 'govuk-label govuk-checkboxes__label'
           - school_phase_options.each_with_index do |phase, i|
             .govuk-checkboxes__item
               = check_box_tag 'phases[]', phase[1], phase_checked?(phase[1]), id: 'phases_' + phase[1], class: 'govuk-checkboxes__input'

--- a/app/views/vacancies/_filters.html.haml
+++ b/app/views/vacancies/_filters.html.haml
@@ -24,11 +24,11 @@
     .govuk-form-group
       %fieldset.govuk-fieldset
         = label_tag 'phases', t('jobs.filters.education_phase'), class: 'govuk-label'
-        .govuk-checkboxes
+        .govuk-checkboxes.checkbox-group.checkbox-group--scrollable
           - school_phase_options.each_with_index do |phase, i|
             .govuk-checkboxes__item
-              = check_box_tag 'phases[]', phase[1], phase_checked?(phase[1]), id: 'phases_' + phase[1]
-              = label_tag 'phases[]', phase[0], for: 'phases_' + phase[1]
+              = check_box_tag 'phases[]', phase[1], phase_checked?(phase[1]), id: 'phases_' + phase[1], class: 'govuk-checkboxes__input'
+              = label_tag 'phases[]', phase[0], for: 'phases_' + phase[1], class: 'govuk-label govuk-checkboxes__label'
     .govuk-form-group
       %fieldset.govuk-fieldset
         .govuk-checkboxes

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -208,6 +208,7 @@ en:
       minimum_salary: 'Minimum salary'
       working_pattern: 'Working pattern'
       education_phase: 'Education phase'
+      education_phase_divider: 'or'
       nqt_suitable: 'Suitable for NQTs'
       clear_filters: 'Reset search'
   feedback:

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -6,4 +6,23 @@ namespace :data do
       UpdateSchoolsDataFromSourceJob.perform_later
     end
   end
+
+  desc 'Migrate phase to phases'
+  namespace :phase do
+    task migrate: :environment do
+      Rails.logger.debug("Running phase migration task in #{Rails.env}")
+
+      Subscription.all.each do |subscription|
+        search_criteria = subscription.search_criteria_to_h
+
+        next unless search_criteria.key?('phase')
+        next if search_criteria.key?('phases')
+
+        search_criteria['phases'] = [search_criteria['phase']]
+        search_criteria.delete('phase')
+
+        subscription.update!(search_criteria: search_criteria.to_json)
+      end
+    end
+  end
 end

--- a/spec/controllers/vacancies_controller_spec.rb
+++ b/spec/controllers/vacancies_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe VacanciesController, type: :controller do
             subject: "<body onload=alert('test1')>Text</body>",
             location: "<img src='http://url.to.file.which/not.exist' onerror=alert(document.cookie);>",
             minimum_salary: '<xml>Foo</xml',
-            phase: '<iframe>Foo</iframe>',
+            phases: '<iframe>Foo</iframe>',
             working_pattern: '<script>Foo</script>',
           }
         end
@@ -28,7 +28,7 @@ RSpec.describe VacanciesController, type: :controller do
             'subject' => 'Text',
             'location' => '',
             'minimum_salary' => 'Foo',
-            'phase' => '',
+            'phases' => '',
             'working_pattern' => '',
           }
 

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -14,6 +14,10 @@ FactoryBot.define do
     easting { '1' }
     northing { '1' }
 
+    trait :nursery do
+      phase { :nursery }
+    end
+
     trait :primary do
       phase { :primary }
     end

--- a/spec/features/job_seekers_can_filter_vacancies_spec.rb
+++ b/spec/features/job_seekers_can_filter_vacancies_spec.rb
@@ -105,7 +105,7 @@ RSpec.feature 'Filtering vacancies' do
     visit jobs_path
 
     within '.filters-form' do
-      select 'Primary', from: 'phase'
+      select 'Primary', from: 'phases'
       page.find('.govuk-button[type=submit]').click
     end
 

--- a/spec/features/job_seekers_can_filter_vacancies_spec.rb
+++ b/spec/features/job_seekers_can_filter_vacancies_spec.rb
@@ -97,20 +97,52 @@ RSpec.feature 'Filtering vacancies' do
     expect(page).not_to have_content(full_time_vacancy.job_title)
   end
 
-  scenario 'Filterable by education phase', elasticsearch: true do
-    primary_vacancy = create(:vacancy, :published, school: build(:school, :primary))
-    secondary_vacancy = create(:vacancy, :published, school: build(:school, :secondary))
+  context 'with jobs with education phases', elasticsearch: true do
+    let!(:nursery_vacancy) { create(:vacancy, :published, school: build(:school, :nursery)) }
+    let!(:primary_vacancy) { create(:vacancy, :published, school: build(:school, :primary)) }
+    let!(:secondary_vacancy) { create(:vacancy, :published, school: build(:school, :secondary)) }
 
-    Vacancy.__elasticsearch__.client.indices.flush
-    visit jobs_path
+    before(:each) { Vacancy.__elasticsearch__.client.indices.flush }
 
-    within '.filters-form' do
-      check 'Primary', name: 'phases[]'
-      page.find('.govuk-button[type=submit]').click
+    scenario 'Filterable by single education phase selection' do
+      visit jobs_path
+
+      within '.filters-form' do
+        check 'Primary', name: 'phases[]'
+        page.find('.govuk-button[type=submit]').click
+      end
+
+      expect(page).not_to have_content(nursery_vacancy.job_title)
+      expect(page).to have_content(primary_vacancy.job_title)
+      expect(page).not_to have_content(secondary_vacancy.job_title)
     end
 
-    expect(page).to have_content(primary_vacancy.job_title)
-    expect(page).not_to have_content(secondary_vacancy.job_title)
+    scenario 'Filterable by multiple education phase selections' do
+      visit jobs_path
+
+      within '.filters-form' do
+        check 'Primary', name: 'phases[]'
+        check 'Secondary', name: 'phases[]'
+        page.find('.govuk-button[type=submit]').click
+      end
+
+      expect(page).not_to have_content(nursery_vacancy.job_title)
+      expect(page).to have_content(primary_vacancy.job_title)
+      expect(page).to have_content(secondary_vacancy.job_title)
+    end
+
+    scenario 'Display all available jobs when "Any" education phase selected' do
+      visit jobs_path
+
+      within '.filters-form' do
+        check 'Any', name: 'phases[]'
+        page.find('.govuk-button[type=submit]').click
+      end
+
+      expect(page).to have_content(nursery_vacancy.job_title)
+      expect(page).to have_content(primary_vacancy.job_title)
+      expect(page).to have_content(secondary_vacancy.job_title)
+    end
   end
 
   scenario 'Filterable by minimum salary', elasticsearch: true do

--- a/spec/features/job_seekers_can_filter_vacancies_spec.rb
+++ b/spec/features/job_seekers_can_filter_vacancies_spec.rb
@@ -105,7 +105,7 @@ RSpec.feature 'Filtering vacancies' do
     visit jobs_path
 
     within '.filters-form' do
-      select 'Primary', from: 'phases'
+      check 'Primary', name: 'phases[]'
       page.find('.govuk-button[type=submit]').click
     end
 

--- a/spec/features/job_seekers_can_filter_vacancies_spec.rb
+++ b/spec/features/job_seekers_can_filter_vacancies_spec.rb
@@ -147,7 +147,7 @@ RSpec.feature 'Filtering vacancies' do
       expect(page).to have_field('newly_qualified_teacher', checked: true)
     end
 
-    scenario 'Display all available jobs when NQT suitable is unchecked' do
+    scenario 'Display all available jobs when NQT suitable is unchecked', elasticsearch: true do
       nqt_suitable_vacancy = create(:vacancy, :published, newly_qualified_teacher: true)
       not_nqt_suitable_vacancy = create(:vacancy, :published, newly_qualified_teacher: false)
 
@@ -190,7 +190,7 @@ RSpec.feature 'Filtering vacancies' do
       end
     end
 
-    scenario 'correctly logs the total results when pagination is used' do
+    scenario 'correctly logs the total results when pagination is used', elasticsearch: true do
       create_list(:vacancy, 12, :published, job_title: 'Math', newly_qualified_teacher: true)
       timestamp = Time.zone.now.iso8601
 
@@ -213,7 +213,7 @@ RSpec.feature 'Filtering vacancies' do
     end
   end
 
-  context 'Resetting search filters' do
+  context 'Resetting search filters', elasticsearch: true do
     it 'Hiring staff can reset search after filtering' do
       create(:vacancy, :published, job_title: 'Physics Teacher')
 

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Subscription, type: :model do
 
     context 'when no common search criteria is provided' do
       it 'does not set a default reference' do
-        subscription = Subscription.new(search_criteria: { radius: 20, phase: 'primary' }.to_json)
+        subscription = Subscription.new(search_criteria: { radius: 20, minimum_salary: 30000 }.to_json)
 
         expect(subscription.reference).to be_nil
       end

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Vacancy, type: :model do
                 minimum_salary: nil,
                 working_pattern: nil,
                 newly_qualified_teacher: nil,
-                phase: nil)
+                phases: nil)
 
         results = Vacancy.public_search(filters: filters, sort: VacancySort.new)
 

--- a/spec/presenters/subscription_presenter_spec.rb
+++ b/spec/presenters/subscription_presenter_spec.rb
@@ -55,6 +55,35 @@ RSpec.describe SubscriptionPresenter do
         expect(presenter.filtered_search_criteria['']).to eq('Suitable for NQTs')
       end
     end
+
+    context 'with unsorted filters' do
+      let(:search_criteria) do
+        {
+          phases: ['secondary', 'sixteen_plus'],
+          maximum_salary: '2000',
+          radius: '10',
+          job_title: 'leader',
+          newly_qualified_teacher: 'true',
+          location: 'EC2 9AN',
+          minimum_salary: '10',
+          working_pattern: 'part_time',
+          subject: 'maths'
+        }
+      end
+
+      it 'returns the filters in sort order' do
+        expect(presenter.filtered_search_criteria).to eq(
+          'location' => 'Within 10 miles of EC2 9AN',
+          'subject' => 'maths',
+          'job_title' => 'leader',
+          'minimum_salary' => '£10',
+          'maximum_salary' => '£2,000',
+          'working_pattern' => 'Part time',
+          'phases' => 'Secondary, Sixteen plus',
+          '' => 'Suitable for NQTs'
+        )
+      end
+    end
   end
 
   describe '#extended_search_criteria' do

--- a/spec/presenters/subscription_presenter_spec.rb
+++ b/spec/presenters/subscription_presenter_spec.rb
@@ -86,13 +86,13 @@ RSpec.describe SubscriptionPresenter do
     end
   end
 
-  describe '#extended_search_criteria' do
-    let(:extended_search_criteria) { presenter.send(:extended_search_criteria) }
+  describe '#full_search_criteria' do
+    let(:full_search_criteria) { presenter.send(:full_search_criteria) }
 
     it 'adds all possible search criteria to subscription criteria' do
-      expect(extended_search_criteria.count).to eq(VacancyAlertFilters::AVAILABLE_FILTERS.count)
-      expect(extended_search_criteria.keys).to match_array(VacancyAlertFilters::AVAILABLE_FILTERS)
-      expect(extended_search_criteria[:keyword]).to eq(search_criteria[:keyword])
+      expect(full_search_criteria.count).to eq(VacancyAlertFilters::AVAILABLE_FILTERS.count)
+      expect(full_search_criteria.keys).to match_array(VacancyAlertFilters::AVAILABLE_FILTERS)
+      expect(full_search_criteria[:keyword]).to eq(search_criteria[:keyword])
     end
   end
 
@@ -111,6 +111,14 @@ RSpec.describe SubscriptionPresenter do
     it 'returns the search criteria' do
       expect(to_row[:working_pattern]).to eq(nil)
       expect(to_row.keys.last).to eq(:reference)
+    end
+
+    context 'when array values in search criteria' do
+      let(:search_criteria) { { phases: ['primary', 'secondary', 'sixteen_plus'] } }
+
+      it 'makes them human readable' do
+        expect(to_row[:phases]).to eq('primary, secondary, sixteen_plus')
+      end
     end
   end
 end

--- a/spec/presenters/subscription_presenter_spec.rb
+++ b/spec/presenters/subscription_presenter_spec.rb
@@ -84,6 +84,31 @@ RSpec.describe SubscriptionPresenter do
         )
       end
     end
+
+    context 'with unknown filters' do
+      let(:search_criteria) do
+        {
+          radius: '10',
+          something: 'test',
+          job_title: 'leader',
+          newly_qualified_teacher: 'true',
+          something_else: 'testing',
+          location: 'EC2 9AN',
+          subject: 'maths'
+        }
+      end
+
+      it 'returns the unknown filters last' do
+        expect(presenter.filtered_search_criteria).to eq(
+          'location' => 'Within 10 miles of EC2 9AN',
+          'subject' => 'maths',
+          'job_title' => 'leader',
+          '' => 'Suitable for NQTs',
+          'something' => 'test',
+          'something_else' => 'testing'
+        )
+      end
+    end
   end
 
   describe '#full_search_criteria' do

--- a/spec/presenters/subscription_presenter_spec.rb
+++ b/spec/presenters/subscription_presenter_spec.rb
@@ -40,6 +40,14 @@ RSpec.describe SubscriptionPresenter do
       end
     end
 
+    context 'with the phases filter' do
+      let(:search_criteria) { { phases: ['secondary', 'sixteen_plus'] } }
+
+      it 'formats and returns the phases' do
+        expect(presenter.filtered_search_criteria['phases']).to eq('Secondary, Sixteen plus')
+      end
+    end
+
     context 'with the NQT filter' do
       let(:search_criteria) { { newly_qualified_teacher: 'true' } }
 

--- a/spec/services/subscription_reference_generator_spec.rb
+++ b/spec/services/subscription_reference_generator_spec.rb
@@ -10,7 +10,9 @@ RSpec.describe SubscriptionReferenceGenerator do
 
   describe '#generate' do
     context 'with no common fields in search criteria' do
-      let(:params) { { search_criteria: { 'radius' => 20, 'phase' => 'primary', 'working_pattern' => 'full_time' } } }
+      let(:params) do
+        { search_criteria: { 'radius' => 20, 'minimum_salary' => 30000, 'working_pattern' => 'full_time' } }
+      end
 
       it 'returns nil' do
         service = described_class.new(params)

--- a/spec/services/vacancy_alert_filters_spec.rb
+++ b/spec/services/vacancy_alert_filters_spec.rb
@@ -48,13 +48,13 @@ RSpec.describe VacancyAlertFilters do
     end
 
     it 'sets the education phase filter if provided and valid' do
-      vacancy_filters = described_class.new(phase: 'primary')
-      expect(vacancy_filters.phase).to eq('primary')
+      vacancy_filters = described_class.new(phases: 'primary')
+      expect(vacancy_filters.phases).to eq(['primary'])
     end
 
     it 'does not set the education phase filter if invalid' do
-      vacancy_filters = described_class.new(phase: 'kindergarten')
-      expect(vacancy_filters.phase).to be_nil
+      vacancy_filters = described_class.new(phases: 'kindergarten')
+      expect(vacancy_filters.phases).to be_nil
     end
 
     it 'does not set filters for any other given params' do
@@ -75,7 +75,7 @@ RSpec.describe VacancyAlertFilters do
         maximum_salary: 'maximum_salary',
         working_pattern: :full_time,
         newly_qualified_teacher: false,
-        phase: :primary,
+        phases: :primary,
       )
 
       result = filters.to_hash
@@ -90,7 +90,7 @@ RSpec.describe VacancyAlertFilters do
         maximum_salary: 'maximum_salary',
         working_pattern: :full_time,
         newly_qualified_teacher: false,
-        phase: :primary,
+        phases: [:primary],
       )
     end
   end

--- a/spec/services/vacancy_alert_filters_spec.rb
+++ b/spec/services/vacancy_alert_filters_spec.rb
@@ -48,12 +48,12 @@ RSpec.describe VacancyAlertFilters do
     end
 
     it 'sets the education phase filter if provided and valid' do
-      vacancy_filters = described_class.new(phases: 'primary')
+      vacancy_filters = described_class.new(phases: '["primary"]')
       expect(vacancy_filters.phases).to eq(['primary'])
     end
 
     it 'does not set the education phase filter if invalid' do
-      vacancy_filters = described_class.new(phases: 'kindergarten')
+      vacancy_filters = described_class.new(phases: '["kindergarten"]')
       expect(vacancy_filters.phases).to be_nil
     end
 
@@ -73,9 +73,9 @@ RSpec.describe VacancyAlertFilters do
         radius: 20,
         minimum_salary: 'minimum_salary',
         maximum_salary: 'maximum_salary',
-        working_pattern: :full_time,
+        working_pattern: 'full_time',
         newly_qualified_teacher: false,
-        phases: :primary,
+        phases: '["primary"]',
       )
 
       result = filters.to_hash
@@ -88,9 +88,9 @@ RSpec.describe VacancyAlertFilters do
         radius: '20',
         minimum_salary: 'minimum_salary',
         maximum_salary: 'maximum_salary',
-        working_pattern: :full_time,
+        working_pattern: 'full_time',
         newly_qualified_teacher: false,
-        phases: [:primary],
+        phases: ['primary'],
       )
     end
   end

--- a/spec/services/vacancy_filters_spec.rb
+++ b/spec/services/vacancy_filters_spec.rb
@@ -38,12 +38,12 @@ RSpec.describe VacancyFilters do
     end
 
     it 'sets the education phase filter if provided and valid' do
-      vacancy_filters = described_class.new(phases: 'primary')
+      vacancy_filters = described_class.new(phases: '["primary"]')
       expect(vacancy_filters.phases).to eq(['primary'])
     end
 
     it 'does not set the education phase filter if invalid' do
-      vacancy_filters = described_class.new(phases: 'kindergarten')
+      vacancy_filters = described_class.new(phases: '["kindergarten"]')
       expect(vacancy_filters.phases).to be_nil
     end
 
@@ -63,7 +63,7 @@ RSpec.describe VacancyFilters do
         minimum_salary: 'minimum_salary',
         working_pattern: 'full_time',
         newly_qualified_teacher: false,
-        phases: :primary,
+        phases: '["primary"]',
       )
 
       result = filters.to_hash
@@ -76,7 +76,7 @@ RSpec.describe VacancyFilters do
         minimum_salary: 'minimum_salary',
         working_pattern: 'full_time',
         newly_qualified_teacher: false,
-        phases: [:primary],
+        phases: ['primary'],
       )
     end
   end

--- a/spec/services/vacancy_filters_spec.rb
+++ b/spec/services/vacancy_filters_spec.rb
@@ -38,13 +38,13 @@ RSpec.describe VacancyFilters do
     end
 
     it 'sets the education phase filter if provided and valid' do
-      vacancy_filters = described_class.new(phase: 'primary')
-      expect(vacancy_filters.phase).to eq('primary')
+      vacancy_filters = described_class.new(phases: 'primary')
+      expect(vacancy_filters.phases).to eq(['primary'])
     end
 
     it 'does not set the education phase filter if invalid' do
-      vacancy_filters = described_class.new(phase: 'kindergarten')
-      expect(vacancy_filters.phase).to be_nil
+      vacancy_filters = described_class.new(phases: 'kindergarten')
+      expect(vacancy_filters.phases).to be_nil
     end
 
     it 'does not set filters for any other given params' do
@@ -63,7 +63,7 @@ RSpec.describe VacancyFilters do
         minimum_salary: 'minimum_salary',
         working_pattern: 'full_time',
         newly_qualified_teacher: false,
-        phase: :primary,
+        phases: :primary,
       )
 
       result = filters.to_hash
@@ -76,7 +76,7 @@ RSpec.describe VacancyFilters do
         minimum_salary: 'minimum_salary',
         working_pattern: 'full_time',
         newly_qualified_teacher: false,
-        phase: :primary,
+        phases: [:primary],
       )
     end
   end

--- a/spec/services/vacancy_search_builder_spec.rb
+++ b/spec/services/vacancy_search_builder_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe VacancySearchBuilder do
 
     it 'builds an education phase query when one is provided' do
       sort = OpenStruct.new(column: :expires_on, order: :desc)
-      filters = OpenStruct.new(phase: 'primary')
+      filters = OpenStruct.new(phases: ['primary'])
       builder = described_class.new(filters: filters, sort: sort).call
 
       expected_hash = {

--- a/terraform.tf
+++ b/terraform.tf
@@ -104,6 +104,8 @@ module "ecs" {
   performance_platform_submit_task_schedule    = "${var.performance_platform_submit_task_schedule}"
   performance_platform_submit_all_task_command = "${var.performance_platform_submit_all_task_command}"
 
+  migrate_phase_to_phases_task_command = "${var.migrate_phase_to_phases_task_command}"
+
   vacancies_statistics_refresh_cache_task_command  = "${var.vacancies_statistics_refresh_cache_task_command}"
   vacancies_statistics_refresh_cache_task_schedule = "${var.vacancies_statistics_refresh_cache_task_schedule}"
 

--- a/terraform/modules/ecs/ecs.tf
+++ b/terraform/modules/ecs/ecs.tf
@@ -409,6 +409,33 @@ data "template_file" "performance_platform_submit_all_container_definition" {
   }
 }
 
+/* migrate_phase_to_phases task definition*/
+data "template_file" "migrate_phase_to_phases_container_definition" {
+  template = "${file(var.ecs_service_rake_container_definition_file_path)}"
+
+  vars {
+    image                    = "${aws_ecr_repository.default.repository_url}"
+    secret_key_base          = "${var.secret_key_base}"
+    project_name             = "${var.project_name}"
+    task_name                = "${var.ecs_service_web_task_name}_migrate_phase_to_phases"
+    environment              = "${var.environment}"
+    rails_env                = "${var.rails_env}"
+    redis_cache_url          = "${var.redis_cache_url}"
+    redis_queue_url          = "${var.redis_queue_url}"
+    region                   = "${var.region}"
+    log_group                = "${var.aws_cloudwatch_log_group_name}"
+    database_user            = "${var.rds_username}"
+    database_password        = "${var.rds_password}"
+    database_url             = "${var.rds_address}"
+    elastic_search_url       = "${var.es_address}"
+    aws_elasticsearch_region = "${var.aws_elasticsearch_region}"
+    aws_elasticsearch_key    = "${var.aws_elasticsearch_key}"
+    aws_elasticsearch_secret = "${var.aws_elasticsearch_secret}"
+    rollbar_access_token     = "${var.rollbar_access_token}"
+    feature_import_vacancies = "${var.feature_import_vacancies}"
+    entrypoint               = "${jsonencode(var.migrate_phase_to_phases_task_command)}"
+  }
+}
 
 /* vacancies pageviews refresh cache task definition*/
 data "template_file" "vacancies_statistics_refresh_cache_container_definition" {
@@ -643,6 +670,17 @@ resource "aws_ecs_task_definition" "seed_vacancies_from_api_task" {
 resource "aws_ecs_task_definition" "performance_platform_submit_all_task" {
   family                   = "${var.ecs_service_web_task_name}_performance_platform_submit_all_task"
   container_definitions    = "${data.template_file.performance_platform_submit_all_container_definition.rendered}"
+  requires_compatibilities = ["EC2"]
+  network_mode             = "bridge"
+  cpu                      = "256"
+  memory                   = "512"
+  execution_role_arn       = "${aws_iam_role.ecs_execution_role.arn}"
+  task_role_arn            = "${aws_iam_role.ecs_execution_role.arn}"
+}
+
+resource "aws_ecs_task_definition" "migrate_phase_to_phases_task" {
+  family                   = "${var.ecs_service_web_task_name}_migrate_phase_to_phases_task"
+  container_definitions    = "${data.template_file.migrate_phase_to_phases_container_definition.rendered}"
   requires_compatibilities = ["EC2"]
   network_mode             = "bridge"
   cpu                      = "256"

--- a/terraform/modules/ecs/input.tf
+++ b/terraform/modules/ecs/input.tf
@@ -125,6 +125,10 @@ variable "performance_platform_submit_all_task_command" {
   type = "list"
 }
 
+variable "migrate_phase_to_phases_task_command" {
+  type = "list"
+}
+
 variable "sessions_trim_task_schedule" {}
 variable "performance_platform_submit_task_schedule" {}
 variable "import_schools_task_schedule" {}

--- a/variables.tf
+++ b/variables.tf
@@ -218,6 +218,11 @@ variable "performance_platform_submit_all_task_command" {
   default     = ["rake", "verbose", "performance_platform:submit_data_up_to_today"]
 }
 
+variable "migrate_phase_to_phases_task_command" {
+  description = "The Entrypoint for the migrate_phase_to_phases task"
+  default     = ["rake", "verbose", "data:phase:migrate"]
+}
+
 variable "vacancies_statistics_refresh_cache_task_command" {
   description = "The Entrypoint for the vacancies_statistics_refresh_cache task"
   default     = ["rake", "verbose", "vacancies:statistics:refresh_cache"]


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/deNkehnc/838-amend-educational-phase-as-a-search-option-so-that-it-is-multi-select

## Changes in this PR:

- Change the education phase filter in the search into a multi-select checkbox. See Trello card for discussion.
- Create a rake task to migrate from `phase` to `phases`.
- Sort search criteria intentionally when presenting them for a subscription.

## Screenshots of UI changes:

### Before

<img width="270" alt="image" src="https://user-images.githubusercontent.com/1027364/56584605-fb4ad100-65d3-11e9-80e2-b1593e75c567.png">
<img width="437" alt="image" src="https://user-images.githubusercontent.com/1027364/56584647-1289be80-65d4-11e9-866f-ef0e9683d068.png">

### After

<img width="265" alt="image" src="https://user-images.githubusercontent.com/1027364/56584862-9479e780-65d4-11e9-9a4a-ccef19565c69.png">
<img width="267" alt="image" src="https://user-images.githubusercontent.com/1027364/56584889-a3609a00-65d4-11e9-926e-9bcd2e7e8889.png">
<img width="440" alt="image" src="https://user-images.githubusercontent.com/1027364/56584914-b1161f80-65d4-11e9-8c8e-bef5a6bab16d.png">

## Next steps:

- [ ] Deploy Terraform
- [ ] Run migration task
- [ ] Remove migration task