### PR TITLE
Revert "Merge pull request #865 from dxw/fix/terraform-ecs-task-pinning"

### DIFF
--- a/terraform.tf
+++ b/terraform.tf
@@ -65,14 +65,12 @@ module "ecs" {
   ecs_service_web_container_definition_file_path = "${var.ecs_service_web_container_definition_file_path}"
   ecs_service_web_name                           = "${var.project_name}_${terraform.workspace}_${var.ecs_service_web_name}"
   ecs_service_web_task_name                      = "${var.project_name}_${terraform.workspace}_${var.ecs_service_web_task_name}"
-  ecs_service_web_task_revision                  = "${var.ecs_service_web_task_revision}"
   ecs_service_web_task_count                     = "${var.ecs_service_web_task_count}"
   ecs_service_web_task_port                      = "${var.ecs_service_web_task_port}"
 
   ecs_service_worker_container_definition_file_path = "${var.ecs_service_worker_container_definition_file_path}"
   ecs_service_worker_name                           = "${var.project_name}_${terraform.workspace}_${var.ecs_service_worker_name}"
   ecs_service_worker_task_name                      = "${var.project_name}_${terraform.workspace}_${var.ecs_service_worker_task_name}"
-  ecs_service_worker_task_revision                  = "${var.ecs_service_worker_task_revision}"
   ecs_service_worker_task_port                      = "${var.ecs_service_worker_task_port}"
 
   worker_command = "${var.worker_command}"

--- a/terraform/modules/ecs/ecs.tf
+++ b/terraform/modules/ecs/ecs.tf
@@ -43,7 +43,7 @@ resource "aws_ecs_service" "web" {
   name            = "${var.ecs_service_web_name}"
   iam_role        = "${aws_iam_role.ecs_role.arn}"
   cluster         = "${aws_ecs_cluster.cluster.id}"
-  task_definition = "${replace("${aws_ecs_task_definition.web.arn}", "/:${aws_ecs_task_definition.web.revision}$$/", ":${var.ecs_service_web_task_revision}")}"
+  task_definition = "${aws_ecs_task_definition.web.arn}"
   desired_count   = "${var.ecs_service_web_task_count}"
 
   deployment_minimum_healthy_percent = 50
@@ -82,7 +82,7 @@ resource "aws_ecs_service" "logspout" {
 resource "aws_ecs_service" "worker" {
   name            = "${var.ecs_service_worker_name}"
   cluster         = "${aws_ecs_cluster.cluster.id}"
-  task_definition = "${replace("${aws_ecs_task_definition.worker.arn}", "/:${aws_ecs_task_definition.worker.revision}$$/", ":${var.ecs_service_worker_task_revision}")}"
+  task_definition = "${aws_ecs_task_definition.worker.arn}"
   desired_count   = "${var.ecs_service_web_task_count}"
 
   deployment_minimum_healthy_percent = 50

--- a/terraform/modules/ecs/input.tf
+++ b/terraform/modules/ecs/input.tf
@@ -9,7 +9,6 @@ variable "ecs_service_web_container_definition_file_path" {}
 
 variable "ecs_service_web_name" {}
 variable "ecs_service_web_task_name" {}
-variable "ecs_service_web_task_revision" {}
 variable "ecs_service_web_task_count" {}
 variable "ecs_service_web_task_port" {}
 
@@ -18,7 +17,6 @@ variable "ecs_service_worker_container_definition_file_path" {}
 
 variable "ecs_service_worker_name" {}
 variable "ecs_service_worker_task_name" {}
-variable "ecs_service_worker_task_revision" {}
 variable "ecs_service_worker_task_port" {}
 
 # Rake task container definitions

--- a/variables.tf
+++ b/variables.tf
@@ -99,11 +99,6 @@ variable "ecs_service_web_task_name" {
   default = "web"
 }
 
-variable "ecs_service_web_task_revision" {
-  description = "The revision of the web task definition to use"
-  default     = "latest"
-}
-
 variable "ecs_service_web_task_count" {
   description = "The number of containers to run for this service"
   default     = 1
@@ -120,11 +115,6 @@ variable "ecs_service_worker_name" {
 
 variable "ecs_service_worker_task_name" {
   default = "worker"
-}
-
-variable "ecs_service_worker_task_revision" {
-  description = "The revision of the worker task definition to use"
-  default     = "latest"
 }
 
 variable "ecs_service_worker_task_port" {


### PR DESCRIPTION
Turns out the the changes in #865 don't work because `latest` is an invalid revision, and Terraform doesn't know about this until AWS rejects it at the deploy stage