### PR TITLE
(chore) add task definition for backfill task

### DIFF
--- a/terraform/modules/ecs/ecs.tf
+++ b/terraform/modules/ecs/ecs.tf
@@ -314,6 +314,33 @@ data "template_file" "reindex_vacancies_container_definition" {
   }
 }
 
+data "template_file" "backfill_jobseeker_alert_data_container_definition" {
+  template = "${file(var.ecs_service_rake_container_definition_file_path)}"
+
+  vars {
+    image                    = "${aws_ecr_repository.default.repository_url}"
+    secret_key_base          = "${var.secret_key_base}"
+    project_name             = "${var.project_name}"
+    task_name                = "${var.ecs_service_web_task_name}_backfill_jobseeker_alert_data"
+    environment              = "${var.environment}"
+    rails_env                = "${var.rails_env}"
+    redis_cache_url          = "${var.redis_cache_url}"
+    redis_queue_url          = "${var.redis_queue_url}"
+    region                   = "${var.region}"
+    log_group                = "${var.aws_cloudwatch_log_group_name}"
+    database_user            = "${var.rds_username}"
+    database_password        = "${var.rds_password}"
+    database_url             = "${var.rds_address}"
+    elastic_search_url       = "${var.es_address}"
+    aws_elasticsearch_region = "${var.aws_elasticsearch_region}"
+    aws_elasticsearch_key    = "${var.aws_elasticsearch_key}"
+    aws_elasticsearch_secret = "${var.aws_elasticsearch_secret}"
+    rollbar_access_token     = "${var.rollbar_access_token}"
+    feature_import_vacancies = "${var.feature_import_vacancies}"
+    entrypoint               = "${jsonencode(var.backfill_jobseeker_alert_data_command)}"
+  }
+}
+
 /* seed_vacancies_from_api_container_definition task definition*/
 data "template_file" "seed_vacancies_from_api_container_definition" {
   template = "${file(var.ecs_service_rake_container_definition_file_path)}"
@@ -593,6 +620,18 @@ resource "aws_iam_role_policy_attachment" "ecs-instance-role-attachment" {
 /*====
 ECS ONE-OFF TASKS
 ======*/
+
+resource "aws_ecs_task_definition" "backfill_jobseeker_alert_data_task" {
+  family                   = "${var.ecs_service_web_task_name}_backfill_jobseeker_alert_data_task"
+  container_definitions    = "${data.template_file.backfill_jobseeker_alert_data_container_definition.rendered}"
+  requires_compatibilities = ["EC2"]
+  network_mode             = "bridge"
+  cpu                      = "256"
+  memory                   = "512"
+  execution_role_arn       = "${aws_iam_role.ecs_execution_role.arn}"
+  task_role_arn            = "${aws_iam_role.ecs_execution_role.arn}"
+}
+
 
 resource "aws_ecs_task_definition" "reindex_vacancies_task" {
   family                   = "${var.ecs_service_web_task_name}_reindex_vacancies_task"


### PR DESCRIPTION
The variables for the rake task that backfills the Subscription signup data were set up in #841, but were named incorrectly, so got removed in #859. This puts the task definitions back in, but named correctly this time!

## Next steps:

- [x] Terraform deployment required?

- [ ] New development configuration to be shared?
