### PR TITLE
Fix flickering tests

### DIFF
--- a/spec/database_cleaner_helper.rb
+++ b/spec/database_cleaner_helper.rb
@@ -21,4 +21,12 @@ RSpec.configure do |config|
   config.after(:each) do
     DatabaseCleaner.clean
   end
+
+  config.before(:all) do
+    DatabaseCleaner.start
+  end
+
+  config.after(:all) do
+    DatabaseCleaner.clean
+  end
 end

--- a/spec/presenters/school_vacancies_presenter_spec.rb
+++ b/spec/presenters/school_vacancies_presenter_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 RSpec.describe SchoolVacanciesPresenter do
   let(:school) { create(:school) }
-  let(:sort) { VacancySort.new }
   let(:type) { 'published' }
+  let(:sort) { VacancySort.new }
   let(:presenter) { described_class.new(school, sort, type) }
 
   let!(:draft_vacancies) { create_list(:vacancy, 5, :draft, school: school) }
@@ -22,6 +22,56 @@ RSpec.describe SchoolVacanciesPresenter do
     expect(presenter.school).to eq(school)
   end
 
+  describe 'sorting' do
+    let(:vacancy_ids) do
+      vacancies.sort_by { |vacancy| vacancy['job_title'].delete(' ') }.reverse.pluck(:id)
+    end
+
+    context 'when type is draft' do
+      let(:type) { 'draft' }
+      let(:vacancies) { draft_vacancies }
+
+      it 'returns sorted draft vacancies' do
+        sort.update(column: 'job_title', order: 'desc')
+
+        expect(presenter.vacancies.pluck(:id)).to eq(vacancy_ids)
+      end
+    end
+
+    context 'when type is pending' do
+      let(:type) { 'pending' }
+      let(:vacancies) { pending_vacancies }
+
+      it 'returns sorted pending vacancies' do
+        sort.update(column: 'job_title', order: 'desc')
+
+        expect(presenter.vacancies.pluck(:id)).to eq(vacancy_ids)
+      end
+    end
+
+    context 'when type is expired' do
+      let(:type) { 'expired' }
+      let(:vacancies) { expired_vacancies }
+
+      it 'returns sorted expired vacancies' do
+        sort.update(column: 'job_title', order: 'desc')
+
+        expect(presenter.vacancies.pluck(:id)).to eq(vacancy_ids)
+      end
+    end
+
+    context 'when type is published' do
+      let(:type) { 'published' }
+      let(:vacancies) { published_vacancies }
+
+      it 'returns sorted published vacancies' do
+        sort.update(column: 'job_title', order: 'desc')
+
+        expect(presenter.vacancies.pluck(:id)).to match_array(vacancy_ids)
+      end
+    end
+  end
+
   context 'when type is draft' do
     let(:type) { 'draft' }
 
@@ -31,12 +81,6 @@ RSpec.describe SchoolVacanciesPresenter do
 
     it 'returns draft vacancies' do
       expect(presenter.vacancies.count).to eq(draft_vacancies.count)
-    end
-
-    it 'returns sorted draft vacancies' do
-      sort.update(column: 'job_title', order: 'desc')
-      vacancy_ids = draft_vacancies.sort_by { |vacancy| vacancy['job_title'] }.reverse.pluck(:id)
-      expect(presenter.vacancies.pluck(:id)).to eq(vacancy_ids)
     end
   end
 
@@ -50,12 +94,6 @@ RSpec.describe SchoolVacanciesPresenter do
     it 'returns pending vacancies' do
       expect(presenter.vacancies.count).to eq(pending_vacancies.count)
     end
-
-    it 'returns sorted pending vacancies' do
-      sort.update(column: 'job_title', order: 'desc')
-      vacancy_ids = pending_vacancies.sort_by { |vacancy| vacancy['job_title'] }.reverse.pluck(:id)
-      expect(presenter.vacancies.pluck(:id)).to eq(vacancy_ids)
-    end
   end
 
   context 'when type is expired' do
@@ -68,12 +106,6 @@ RSpec.describe SchoolVacanciesPresenter do
     it 'returns expired vacancies' do
       expect(presenter.vacancies.count).to eq(expired_vacancies.count)
     end
-
-    it 'returns sorted expired vacancies' do
-      sort.update(column: 'job_title', order: 'desc')
-      vacancy_ids = expired_vacancies.sort_by { |vacancy| vacancy['job_title'] }.reverse.pluck(:id)
-      expect(presenter.vacancies.pluck(:id)).to eq(vacancy_ids)
-    end
   end
 
   context 'when type is published' do
@@ -85,12 +117,6 @@ RSpec.describe SchoolVacanciesPresenter do
 
     it 'returns published vacancies' do
       expect(presenter.vacancies.count).to eq(published_vacancies.count)
-    end
-
-    it 'returns sorted published vacancies' do
-      sort.update(column: 'job_title', order: 'desc')
-      vacancy_ids = published_vacancies.sort_by { |vacancy| vacancy['job_title'] }.reverse.pluck(:id)
-      expect(presenter.vacancies.pluck(:id)).to match_array(vacancy_ids)
     end
   end
 

--- a/spec/presenters/school_vacancies_presenter_spec.rb
+++ b/spec/presenters/school_vacancies_presenter_spec.rb
@@ -1,25 +1,27 @@
 require 'rails_helper'
 RSpec.describe SchoolVacanciesPresenter do
-  let(:school) { create(:school) }
+  before(:all) do
+    @school = create(:school)
+    @draft_vacancies = create_list(:vacancy, 5, :draft, school: @school)
+    @pending_vacancies = create_list(:vacancy, 4, :future_publish, school: @school)
+    @expired_vacancies = begin
+      expired_vacancies = []
+      3.times do
+        expired_vacancy = build(:vacancy, :expired, school: @school)
+        expired_vacancy.save(validate: false)
+        expired_vacancies << expired_vacancy
+      end
+      expired_vacancies
+    end
+    @published_vacancies = create_list(:vacancy, 7, :published, school: @school)
+  end
+
   let(:type) { 'published' }
   let(:sort) { VacancySort.new }
-  let(:presenter) { described_class.new(school, sort, type) }
-
-  let!(:draft_vacancies) { create_list(:vacancy, 5, :draft, school: school) }
-  let!(:pending_vacancies) { create_list(:vacancy, 4, :future_publish, school: school) }
-  let!(:expired_vacancies) do
-    expired_vacancies = []
-    3.times do
-      expired_vacancy = build(:vacancy, :expired, school: school)
-      expired_vacancy.save(validate: false)
-      expired_vacancies << expired_vacancy
-    end
-    expired_vacancies
-  end
-  let!(:published_vacancies) { create_list(:vacancy, 7, :published, school: school) }
+  let(:presenter) { described_class.new(@school, sort, type) }
 
   it 'returns the school' do
-    expect(presenter.school).to eq(school)
+    expect(presenter.school).to eq(@school)
   end
 
   describe 'sorting' do
@@ -29,7 +31,7 @@ RSpec.describe SchoolVacanciesPresenter do
 
     context 'when type is draft' do
       let(:type) { 'draft' }
-      let(:vacancies) { draft_vacancies }
+      let(:vacancies) { @draft_vacancies }
 
       it 'returns sorted draft vacancies' do
         sort.update(column: 'job_title', order: 'desc')
@@ -40,7 +42,7 @@ RSpec.describe SchoolVacanciesPresenter do
 
     context 'when type is pending' do
       let(:type) { 'pending' }
-      let(:vacancies) { pending_vacancies }
+      let(:vacancies) { @pending_vacancies }
 
       it 'returns sorted pending vacancies' do
         sort.update(column: 'job_title', order: 'desc')
@@ -51,7 +53,7 @@ RSpec.describe SchoolVacanciesPresenter do
 
     context 'when type is expired' do
       let(:type) { 'expired' }
-      let(:vacancies) { expired_vacancies }
+      let(:vacancies) { @expired_vacancies }
 
       it 'returns sorted expired vacancies' do
         sort.update(column: 'job_title', order: 'desc')
@@ -62,7 +64,7 @@ RSpec.describe SchoolVacanciesPresenter do
 
     context 'when type is published' do
       let(:type) { 'published' }
-      let(:vacancies) { published_vacancies }
+      let(:vacancies) { @published_vacancies }
 
       it 'returns sorted published vacancies' do
         sort.update(column: 'job_title', order: 'desc')
@@ -80,7 +82,7 @@ RSpec.describe SchoolVacanciesPresenter do
     end
 
     it 'returns draft vacancies' do
-      expect(presenter.vacancies.count).to eq(draft_vacancies.count)
+      expect(presenter.vacancies.count).to eq(@draft_vacancies.count)
     end
   end
 
@@ -92,7 +94,7 @@ RSpec.describe SchoolVacanciesPresenter do
     end
 
     it 'returns pending vacancies' do
-      expect(presenter.vacancies.count).to eq(pending_vacancies.count)
+      expect(presenter.vacancies.count).to eq(@pending_vacancies.count)
     end
   end
 
@@ -104,7 +106,7 @@ RSpec.describe SchoolVacanciesPresenter do
     end
 
     it 'returns expired vacancies' do
-      expect(presenter.vacancies.count).to eq(expired_vacancies.count)
+      expect(presenter.vacancies.count).to eq(@expired_vacancies.count)
     end
   end
 
@@ -116,7 +118,7 @@ RSpec.describe SchoolVacanciesPresenter do
     end
 
     it 'returns published vacancies' do
-      expect(presenter.vacancies.count).to eq(published_vacancies.count)
+      expect(presenter.vacancies.count).to eq(@published_vacancies.count)
     end
   end
 


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/8EMdqNfY/835-fix-flickering-failing-tests

## Changes in this PR:

Finally found the issue behind this. The fix is to remove all whitespace from the titles when using `sort_by`, which mimics the behaviour of Postgres's `ORDER BY`