### PR TITLE
(fix) Setting of db:environment:set for development

### DIFF
--- a/bin/drebuild
+++ b/bin/drebuild
@@ -26,7 +26,7 @@ pretty_print "Rebuilt and started the testing server for TVS."
 pretty_print "Rebuilding the web server…"
 run_with_pretty_print 'docker-compose build'
 run_with_pretty_print 'docker-compose run --rm web bin/dsetup'
-run_with_pretty_print 'docker-compose run --rm web rake db:seed'
+run_with_pretty_print 'bin/drake db:seed'
 run_with_pretty_print 'bin/drake elasticsearch:vacancies:index'
 pretty_print "Rebuilt and starting the web server for TVS…"
 run_with_pretty_print 'bin/dstart'

--- a/bin/dsetup
+++ b/bin/dsetup
@@ -1,4 +1,4 @@
-rake db:create
+rake db:create db:environment:set
 
 if rake db:migrate:status &> /dev/null; then
   rake db:migrate

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -19,7 +19,7 @@ setup_database()
     else
       echo "ENTRYPOINT: Environment is in non-production, attempting to automatically create the database…"
       echo "ENTRYPOINT: Running db:create db:schema:load…"
-      rake db:create db:schema:load
+      rake db:create db:environment:set db:schema:load
     fi
   fi
   echo "ENTRYPOINT: Finished database setup."


### PR DESCRIPTION
## Trello card URL:

https://trello.com/c/cgiojdXK/864-fix-ar-environment-mismatch-error

## Changes in this PR:

* Ensures that the correct environment is set in the AR internal metadata by calling `db:environment:set`. This was causing an error when doing initial setup.
* Refactored `bin/drebuild` to use `bin/drake` for `db:seed` task