### PR TITLE
Send correct data to AuditSearchEventJob

### DIFF
--- a/app/services/vacancies_finder.rb
+++ b/app/services/vacancies_finder.rb
@@ -35,8 +35,10 @@ class VacanciesFinder
   end
 
   def audit_search_event
-    AuditSearchEventJob.perform_later([Time.zone.now.iso8601.to_s,
-                                       vacancies.total_count,
-                                       *filters.to_hash.values])
+    AuditSearchEventJob.perform_later(audit_row)
+  end
+
+  def audit_row
+    { total_count: vacancies.total_count }.merge(filters.audit_hash)
   end
 end

--- a/app/services/vacancy_filters.rb
+++ b/app/services/vacancy_filters.rb
@@ -30,6 +30,21 @@ class VacancyFilters
     }
   end
 
+  def audit_hash
+    {
+      location: location,
+      radius: radius,
+      keyword: nil,
+      minimum_salary: minimum_salary,
+      maximum_salary: nil,
+      working_pattern: working_pattern,
+      phases: phases,
+      newly_qualified_teacher: newly_qualified_teacher,
+      subject: subject,
+      job_title: job_title
+    }
+  end
+
   def only_active_to_hash
     to_hash.delete_if { |_, v| v.blank? }
   end

--- a/spec/features/job_seekers_can_filter_vacancies_spec.rb
+++ b/spec/features/job_seekers_can_filter_vacancies_spec.rb
@@ -206,7 +206,19 @@ RSpec.feature 'Filtering vacancies' do
 
       Vacancy.__elasticsearch__.client.indices.flush
 
-      data = [timestamp.to_s, 3, '', '20', 'Physics', '', '', nil, nil, 'true']
+      data = {
+        total_count: 3,
+        location: '',
+        radius: '20',
+        keyword: nil,
+        minimum_salary: '',
+        maximum_salary: nil,
+        working_pattern: nil,
+        phases: nil,
+        newly_qualified_teacher: 'true',
+        subject: 'Physics',
+        job_title: ''
+      }
 
       expect(AuditSearchEventJob).to receive(:perform_later)
         .with(data)
@@ -228,7 +240,19 @@ RSpec.feature 'Filtering vacancies' do
 
       Vacancy.__elasticsearch__.client.indices.flush
 
-      data = [timestamp.to_s, 12, '', '20', 'Math', '', '', nil, nil, 'true']
+      data = {
+        total_count: 12,
+        location: '',
+        radius: '20',
+        keyword: nil,
+        minimum_salary: '',
+        maximum_salary: nil,
+        working_pattern: nil,
+        phases: nil,
+        newly_qualified_teacher: 'true',
+        subject: 'Math',
+        job_title: ''
+      }
 
       expect(AuditSearchEventJob).to receive(:perform_later)
         .with(data)


### PR DESCRIPTION
## Changes in this PR:

The data that goes to the job should be a hash now, rather than an array. I've also added an `audit_hash` method to the VacancyFilters class, as we've introduced some new search queries and deprecated some others, so this ensures we can record new rows in the spreadsheet without breaking the format of the spreadsheet (which has old data in it)