### PR TITLE
Add Ordnance Survey API key to worker

### DIFF
--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,5 +1,5 @@
 redis = Redis.new(url: ENV['REDIS_CACHE_URL'])
-key = ENV.fetch('ORDNANCE_SURVEY_API_KEY', '')
+key = ENV.fetch('ORDNANCE_SURVEY_API_KEY', nil)
 
 Geocoder.configure(
   lookup: :os_names,

--- a/terraform/container-definitions/worker_container_definition.json
+++ b/terraform/container-definitions/worker_container_definition.json
@@ -141,6 +141,10 @@
         "value": "${google_drive_json_key}"
       },
       {
+        "name": "ORDNANCE_SURVEY_API_KEY",
+        "value": "${ordnance_survey_api_key}"
+      },
+      {
         "name": "SUBSCRIPTION_KEY_GENERATOR_SECRET",
         "value": "${subscription_key_generator_secret}"
       },

--- a/terraform/modules/ecs/ecs.tf
+++ b/terraform/modules/ecs/ecs.tf
@@ -525,6 +525,7 @@ data "template_file" "worker_container_definition" {
     subscription_key_generator_salt = "${var.subscription_key_generator_salt}"
     subscription_key_generator_secret = "${var.subscription_key_generator_secret}"
     feature_email_alerts              = "${var.feature_email_alerts}"
+    ordnance_survey_api_key             = "${var.ordnance_survey_api_key}"
     worker_command = "${jsonencode(var.worker_command)}"
   }
 }


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/YxYwCYBk/871-fix-rollbar-errors-in-development-when-running-senddailyalertemailjob

## Changes in this PR:

After deploying #868 - I noticed some strange errors were cropping up when the worker was running the `SendDailyAlertEmailJob`. This is because I only had the Ordnance Survey API key set up in the web container, and not the worker. To complicate matters further, the exact nature of the error was being masked, because `ENV.fetch` was defaulting to an empty string, so the Geocoder gem assumed there was a valid API key present, and so requests were getting passed through to the API, and the repsonse wasn't what we were expecting. I've fixed this by making sure the API key's default value is `nil` in the initializer now.

## Next steps:

- [x] Terraform deployment required?

- [ ] New development configuration to be shared?
