### PR TITLE
Fix specific phase check

### DIFF
--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -120,7 +120,7 @@ class VacanciesController < ApplicationController
   def any_phase?
     return true if phases_to_a.blank?
 
-    phases_to_a.reject(&:blank?).any?
+    phases_to_a.reject(&:blank?).empty?
   end
 
   def set_headers

--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -13,7 +13,7 @@ class VacanciesController < ApplicationController
                 :minimum_salary,
                 :working_pattern,
                 :phases,
-                :any_phase?,
+                :specific_phases?,
                 :newly_qualified_teacher,
                 :radius,
                 :sort_column,
@@ -117,10 +117,10 @@ class VacanciesController < ApplicationController
     params[:sort_order]
   end
 
-  def any_phase?
-    return true if phases_to_a.blank?
+  def specific_phases?
+    return false if phases_to_a.blank?
 
-    phases_to_a.reject(&:blank?).empty?
+    phases_to_a.reject(&:blank?).any?
   end
 
   def set_headers

--- a/app/views/vacancies/_filters.html.haml
+++ b/app/views/vacancies/_filters.html.haml
@@ -24,11 +24,11 @@
     .govuk-form-group
       %fieldset.govuk-fieldset
         = label_tag 'phases', t('jobs.filters.education_phase'), class: 'govuk-label'
-        .govuk-checkboxes.checkbox-group{ class: ('checkbox-group--scrollable' if any_phase?) }
+        .govuk-checkboxes.checkbox-group{ class: ('checkbox-group--scrollable' unless specific_phases?) }
           .govuk-checkboxes__item
-            = check_box_tag 'phases[]', '', any_phase?, id: 'phases_any', class: 'govuk-checkboxes__input'
+            = check_box_tag 'phases[]', '', !specific_phases?, id: 'phases_any', class: 'govuk-checkboxes__input'
             = label_tag 'phases[]', 'Any', for: 'phases_any', class: 'govuk-label govuk-checkboxes__label'
-          .checkbox-group__divider 
+          .checkbox-group__divider
             = t('jobs.filters.education_phase_divider')
           - school_phase_options.each_with_index do |phase, i|
             .govuk-checkboxes__item


### PR DESCRIPTION
## Changes in this PR:

The search is for "Any" phase if "Any" box (mapped to "") is checked or
no box is checked. So we're checking to see if it's empty after removing
blank values.