### PR TITLE
(chore) update the height of education phase checkboxes

### DIFF
--- a/app/assets/stylesheets/components/filter_vacancies.scss
+++ b/app/assets/stylesheets/components/filter_vacancies.scss
@@ -37,7 +37,7 @@
 
   .filters-form .checkbox-group {
     &--scrollable {
-      height: 170px;
+      height: 220px;
       overflow: auto;
     }
     padding: 10px 10px 0 10px;


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/deNkehnc/838-amend-educational-phase-as-a-search-option-so-that-it-is-multi-select

## Changes in this PR:
- Increase the height of education phase box

## Screenshots of UI changes:

### Before
<img width="327" alt="Screenshot 2019-05-08 at 17 11 06" src="https://user-images.githubusercontent.com/6421298/57390610-b074b000-71b4-11e9-82b6-67d7f793bad9.png">


### After
<img width="316" alt="Screenshot 2019-05-08 at 17 10 53" src="https://user-images.githubusercontent.com/6421298/57390616-b4083700-71b4-11e9-8855-fee7db1b84e5.png">
